### PR TITLE
Switching to digishield difficulty retargeting algorithm

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,6 +127,7 @@ BITCOIN_CORE_H = \
   miner.h \
   nameclaim.h \
   claimtrie.h \
+  lbry.h \
   net.h \
   netbase.h \
   noui.h \
@@ -193,6 +194,7 @@ libbitcoin_server_a_SOURCES = \
   httpserver.cpp \
   init.cpp \
   dbwrapper.cpp \
+  lbry.cpp \
   main.cpp \
   merkleblock.cpp \
   miner.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -52,6 +52,7 @@ BITCOIN_TESTS =\
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/key_tests.cpp \
+  test/lbry_tests.cpp \
   test/limitedmap_tests.cpp \
   test/dbwrapper_tests.cpp \
   test/main_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -122,7 +122,7 @@ public:
         consensus.BIP34Height = 227931;
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 150 * 24 * 2; // 2 hours
+        consensus.nPowTargetTimespan = 150; //retarget every block
         consensus.nPowTargetSpacing = 150;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;

--- a/src/lbry.cpp
+++ b/src/lbry.cpp
@@ -1,0 +1,40 @@
+#include "lbry.h" 
+#include "uint256.h" 
+#include <cstdio>
+unsigned int CalculateLbryNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
+{
+    if (params.fPowNoRetargeting)
+        return pindexLast->nBits;
+
+    const int64_t retargetTimespan = params.nPowTargetTimespan;
+    const int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
+    int64_t nModulatedTimespan = nActualTimespan;
+    int64_t nMaxTimespan;
+    int64_t nMinTimespan;
+
+    nModulatedTimespan = retargetTimespan + (nModulatedTimespan - retargetTimespan) / 8;
+
+    nMinTimespan = retargetTimespan - (retargetTimespan / 8); //(150 - 18 = 132)
+    nMaxTimespan = retargetTimespan + (retargetTimespan / 2); //(150 + 75 = 225) 
+
+    // Limit adjustment step
+    if (nModulatedTimespan < nMinTimespan)
+        nModulatedTimespan = nMinTimespan;
+    else if (nModulatedTimespan > nMaxTimespan)
+        nModulatedTimespan = nMaxTimespan;
+
+    // Retarget
+    const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+    arith_uint256 bnNew;
+    arith_uint256 bnOld;
+    bnNew.SetCompact(pindexLast->nBits);
+    bnOld = bnNew;
+    bnNew *= nModulatedTimespan;
+    bnNew /= retargetTimespan;
+    if (bnNew > bnPowLimit)
+        bnNew = bnPowLimit;
+
+    return bnNew.GetCompact();
+}
+
+

--- a/src/lbry.h
+++ b/src/lbry.h
@@ -1,0 +1,9 @@
+#ifndef LBRY_H
+#define LBRY_H
+
+#include "chain.h"
+#include "chainparams.h"
+
+unsigned int CalculateLbryNextWorkRequired(const CBlockIndex* pindexLast, int64_t nLastRetargetTime, const Consensus::Params& params);
+
+#endif

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -9,6 +9,7 @@
 #include "chain.h"
 #include "primitives/block.h"
 #include "uint256.h"
+#include "lbry.h"
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
@@ -40,13 +41,17 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return pindexLast->nBits;
     }
 
-    // Go back by what we want to be 14 days worth of blocks
-    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
+    // Go back the full period unless it's the first retarget after genesis.
+    int blockstogoback = params.DifficultyAdjustmentInterval()-1;
+    if ((pindexLast->nHeight+1) != params.DifficultyAdjustmentInterval())
+        blockstogoback = params.DifficultyAdjustmentInterval();
+
+    int nHeightFirst = pindexLast->nHeight - blockstogoback;
     assert(nHeightFirst >= 0);
     const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
     assert(pindexFirst);
 
-    return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    return CalculateLbryNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
 }
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)

--- a/src/pow.h
+++ b/src/pow.h
@@ -17,6 +17,7 @@ class uint256;
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
+
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);
 

--- a/src/test/lbry_tests.cpp
+++ b/src/test/lbry_tests.cpp
@@ -1,0 +1,102 @@
+#include "arith_uint256.h"
+#include "chainparams.h"
+#include "lbry.h"
+#include "main.h"
+#include "test/test_bitcoin.h"
+#include <cstdio> 
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(lbry_tests, TestingSetup)
+
+//1 test block 1 difficulty, should be a max retarget
+BOOST_AUTO_TEST_CASE(get_block_1_difficulty)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    CBlockIndex pindexLast;
+    int64_t nFirstBlockTime = 1386475638; 
+    
+    pindexLast.nHeight = 0;
+    pindexLast.nTime = 1386475638; 
+    pindexLast.nBits = 0x1f00ffff ;//starting difficulty, also limit 
+    unsigned int out = CalculateLbryNextWorkRequired(&pindexLast, nFirstBlockTime, params);
+    arith_uint256 a; 
+    a.SetCompact(out);
+    unsigned int expected = 0x1f00e146;
+    BOOST_CHECK_EQUAL(out,expected);
+
+}
+
+// test max retarget (difficulty increase) 
+BOOST_AUTO_TEST_CASE(max_retarget)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    CBlockIndex pindexLast;
+    int64_t nFirstBlockTime = 1386475638;
+    
+    pindexLast.nHeight = 100;
+    pindexLast.nTime = nFirstBlockTime; 
+    pindexLast.nBits = 0x1f00a000 ;
+
+    unsigned int out = CalculateLbryNextWorkRequired(&pindexLast, nFirstBlockTime, params);
+    arith_uint256 a; 
+    a.SetCompact(out); 
+    unsigned int expected = 0x1f008ccc;
+    BOOST_CHECK_EQUAL(out,expected);
+
+
+}
+
+// test min retarget (difficulty decrease) 
+BOOST_AUTO_TEST_CASE(min_retarget)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    CBlockIndex pindexLast;
+    int64_t nFirstBlockTime = 1386475638;
+    
+    pindexLast.nHeight = 101;
+    pindexLast.nTime = nFirstBlockTime + 60*20 ; 
+    pindexLast.nBits = 0x1f00a000;
+
+    unsigned int out = CalculateLbryNextWorkRequired(&pindexLast, nFirstBlockTime, params);
+    arith_uint256 a; 
+    a.SetCompact(out);
+    unsigned int expected = 0x1f00f000;
+    BOOST_CHECK_EQUAL(out,expected);
+
+      
+}
+
+// test to see if pow limit is not exceeded
+BOOST_AUTO_TEST_CASE(pow_limit_check)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    CBlockIndex pindexLast;
+    int64_t nFirstBlockTime = 1386475638;
+    
+    pindexLast.nHeight = 102;
+    pindexLast.nTime = nFirstBlockTime + 600 ; //took a long time to generate book, will try to reduce difficulty but it would hit limit  
+    pindexLast.nBits = 0x1f00ffff ;
+
+    unsigned int out = CalculateLbryNextWorkRequired(&pindexLast, nFirstBlockTime, params);
+    arith_uint256 a; 
+    a.SetCompact(out);
+    unsigned int expected = 0x1f00ffff;
+    BOOST_CHECK_EQUAL(out,expected);
+
+     
+}
+
+
+
+
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -17,7 +17,7 @@
 #include "utilstrencodings.h"
 
 #include "test/test_bitcoin.h"
-
+#include <cstdio>
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(miner_tests, TestingSetup)
@@ -93,17 +93,17 @@ struct {
 };*/
 
 const unsigned int nonces[] = {
-    25847, 24375, 15084, 43119, 32778, 18489, 72464, 3066, 21699, 148524,
-    11755, 75956, 20849, 21954, 35157, 145272, 248297, 4826, 33638, 23323,
-    67779, 132944, 18863, 56090, 198531, 12291, 139396, 58208, 45077, 5032,
-    60910, 160315, 28228, 52228, 56715, 185713, 41299, 9809, 12440, 44195,
-    174243, 74222, 2824, 31928, 57317, 2301, 56474, 38742, 206678, 241219,
-    230802, 700108, 340728, 94773, 190539, 422314, 165285, 241662, 126464, 655554,
-    105922, 220360, 92001, 465473, 283326, 337895, 130951, 143184, 32737, 20130,
-    396207, 962689, 568567, 111795, 494699, 82970, 7992, 715083, 46184, 118701,
-    406960, 201220, 672245, 111503, 20150, 269794, 218458, 443980, 67694, 253945,
-    75069, 183171, 629799, 126886, 23608, 633958, 419889, 30723, 206984, 2290215,
-    104632, 2612510, 274546, 394861, 230744, 353025, 1291707, 1953717, 1471195, 94639,
+9715, 56480, 403383, 161192, 58621, 73382, 85226, 98311, 206519, 15440,
+176081, 28022, 3824, 23276, 22704, 69819, 79283, 4656, 30511, 6411,
+201628, 4501, 23558, 74540, 168, 12681, 16511, 7266, 10486, 83995,
+66238, 66, 26787, 14984, 73652, 6838, 22145, 103579, 65324, 283683,
+102001, 49586, 130264, 33672, 6912, 13815, 51036, 24127, 72967, 27871,
+5051, 193056, 77536, 20886, 34333, 53415, 11799, 64284, 37214, 23710,
+104020, 102819, 64378, 54221, 53838, 11188, 18847, 58036, 18297, 122279,
+7004, 53797, 11485, 91262, 61017, 71342, 48033, 18755, 42992, 26418,
+1410, 113720, 23320, 25180, 62603, 32101, 122149, 8533, 44719, 45796,
+92600, 4908, 13175, 8836, 20067, 165509, 94213, 22031, 3834, 14936,
+84587, 912, 1308, 66266, 11429, 28065, 23100, 9701, 10143, 23224,
 };
 
 CBlockIndex CreateBlockIndex(int nHeight)
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         CBlock *pblock = &pblocktemplate->block; // pointer for convenience
         pblock->hashPrevBlock = chainActive.Tip()->GetBlockHash();
         pblock->nVersion = 1;
-        pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+        pblock->nTime = chainActive.Tip()->GetBlockTime()+150*(i+1);
         CMutableTransaction txCoinbase(pblock->vtx[0]);
         txCoinbase.nVersion = 1;
         txCoinbase.vin[0].scriptSig = CScript();
@@ -166,7 +166,11 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             txFirst.push_back(new CTransaction(pblock->vtx[0]));
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
         pblock->nNonce = nonces[i];
-        /*bool fFound = false;
+
+
+        //Use below code to find nonces, in case we change hashing or difficulty retargeting algo
+        /*
+        bool fFound = false;
         for (int j = 0; !fFound; j++)
         {
             pblock->nNonce = j;
@@ -179,7 +183,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
                 else
                     std::cout << " ";
             }
-        }*/
+        }
+        */
+
         CValidationState state;
         BOOST_CHECK(ProcessNewBlock(state, chainparams, NULL, pblock, true, NULL));
         BOOST_CHECK(state.IsValid());


### PR DESCRIPTION
Switching to digishield difficulty retargeting algorithm. Algorithm is based off of dogecoin implementation, only difference is minimum timespan factor was changed from 4 to 8. In summary the algorithm will retarget every block (2.5 min) , and difficulty will either increase by maximum of 13% or decrease by 33%

This breaks the unit test miner_tests.cpp which contains pre generated nonces to meet the bitcoin difficulty retargeting algorithm. Need to generate new nonces so the test will pass. 