### PR TITLE
Updating chainparams, adding checkpoint at block 4000 to mainnet, fix…

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -25,6 +25,9 @@
 #define MAINNET_GENESIS_HASH "9c89283ba0f3227f6c03b70216b9f665f0118d5e0fa729cedf4fb34d6a34f463"
 #define MAINNET_GENESIS_NONCE 1287
 
+#define TESTNET_GENESIS_HASH "9c89283ba0f3227f6c03b70216b9f665f0118d5e0fa729cedf4fb34d6a34f463"
+#define TESTNET_GENESIS_NONCE 1287
+
 #define REGTEST_GENESIS_HASH "6e3fcf1299d4ec5d79c3a4c91d624a4acf9e2e173d95a1a0504f677669687556"
 #define REGTEST_GENESIS_NONCE 1
 
@@ -123,8 +126,8 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
-        consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+        consensus.BIP34Height = 1; 
+        consensus.BIP34Hash = uint256S("0xdecb9e2cca03a419fd9cca0cb2b1d5ad11b088f22f8f38556d93ac4358b86c24"); 
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 150; //retarget every block
         consensus.nPowTargetSpacing = 150;
@@ -186,11 +189,11 @@ public:
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
-            (     0, uint256S("0x0000343f59c49eb433ba3a37ee4b3493ff014ee9b266f610bb3cd1b36927787a")),
-            1417453734, // * UNIX timestamp of last checkpoint block
-            1,   // * total number of transactions between genesis and last checkpoint
+            (     4000, uint256S("0xa6bbb48f5343eb9b0287c22f3ea8b29f36cf10794a37f8a925a894d6f4519913")),
+            1467272478, // * UNIX timestamp of last checkpoint block
+            4146,   // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            0.0     // * estimated number of transactions per day after checkpoint
+            600.0     // * estimated number of transactions per day after checkpoint
         };
     }
 };
@@ -202,7 +205,7 @@ static CMainParams mainParams;
 class CTestNetParams : public CChainParams {
 public:
     CTestNetParams() {
-        strNetworkID = "test";
+        strNetworkID = "lbrycrdtest";
         consensus.nSubsidyLevelInterval = 1 << 5;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
@@ -210,8 +213,8 @@ public:
         consensus.BIP34Height = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 30 * 60 * 12;//14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 30;
+        consensus.nPowTargetTimespan = 150;
+        consensus.nPowTargetSpacing = 150;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
@@ -225,20 +228,20 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
-        pchMessageStart[0] = 0x1d;
-        pchMessageStart[1] = 0x0c;
+        pchMessageStart[0] = 0xfa;
+        pchMessageStart[1] = 0xe4;
         pchMessageStart[2] = 0xaa;
-        pchMessageStart[3] = 0xd1;
+        pchMessageStart[3] = 0xe1;
         nDefaultPort = 19246;
         nPruneAfterHeight = 1000;
 
-        genesis = CreateGenesisBlock(1446058291, MAINNET_GENESIS_NONCE, 0x1f00ffff, 1, 400000000 * COIN, consensus);
+        genesis = CreateGenesisBlock(1446058291, TESTNET_GENESIS_NONCE, 0x1f00ffff, 1, 400000000 * COIN, consensus);
         consensus.hashGenesisBlock = genesis.GetHash();
 #ifdef FIND_GENESIS
         std::cout << "testnet genesis hash: " << genesis.GetHash().GetHex() << std::endl;
         std::cout << "testnet merkle hash: " << genesis.hashMerkleRoot.GetHex() << std::endl;
 #else
-        assert(consensus.hashGenesisBlock == uint256S(MAINNET_GENESIS_HASH));
+        assert(consensus.hashGenesisBlock == uint256S(TESTNET_GENESIS_HASH));
         assert(genesis.hashMerkleRoot == uint256S(GENESIS_MERKLE_ROOT));
 #endif
 
@@ -264,10 +267,10 @@ public:
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
-            ( 546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")),
-            1337966069,
-            1488,
-            300
+            ( 0, uint256S(TESTNET_GENESIS_HASH)),
+            0,
+            0,
+            0
         };
 
     }
@@ -280,16 +283,16 @@ static CTestNetParams testNetParams;
 class CRegTestParams : public CChainParams {
 public:
     CRegTestParams() {
-        strNetworkID = "regtest";
-        consensus.nSubsidyLevelInterval = 1 << 4;
+        strNetworkID = "lbrycrdreg";
+        consensus.nSubsidyLevelInterval = 1 << 5;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
         consensus.BIP34Height = -1; // BIP34 has not necessarily activated on regtest
         consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 30 * 60 * 12;//14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 30;
+        consensus.nPowTargetTimespan = 150;//14 * 24 * 60 * 60; // two weeks
+        consensus.nPowTargetSpacing = 150;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
@@ -301,10 +304,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 999999999999ULL;
 
-        pchMessageStart[0] = 0xfb;
-        pchMessageStart[1] = 0xbe;
-        pchMessageStart[2] = 0xbf;
-        pchMessageStart[3] = 0xd9;
+        pchMessageStart[0] = 0xfa;
+        pchMessageStart[1] = 0xe4;
+        pchMessageStart[2] = 0xaa;
+        pchMessageStart[3] = 0xd1;
         nDefaultPort = 29246;
         nPruneAfterHeight = 1000;
 
@@ -329,7 +332,7 @@ public:
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of
-            ( 0, uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")),
+            ( 0, uint256S(REGTEST_GENESIS_HASH)),
             0,
             0,
             0

--- a/src/test/claimtrie_tests.cpp
+++ b/src/test/claimtrie_tests.cpp
@@ -99,7 +99,7 @@ bool CreateBlock(CBlockTemplate* pblocktemplate)
     static int unique_block_counter = 0;
     CBlock* pblock = &pblocktemplate->block;
     pblock->nVersion = 1;
-    pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+    pblock->nTime = chainActive.Tip()->GetBlockTime()+Params().GetConsensus().nPowTargetSpacing;
     CMutableTransaction txCoinbase(pblock->vtx[0]);
     txCoinbase.vin[0].scriptSig = CScript() << CScriptNum(unique_block_counter++) << CScriptNum(chainActive.Height());
     txCoinbase.vout[0].nValue = GetBlockSubsidy(chainActive.Height() + 1, Params().GetConsensus());
@@ -289,9 +289,9 @@ BOOST_AUTO_TEST_CASE(claimtrie_merkle_hash)
 
 BOOST_AUTO_TEST_CASE(claimtrie_insert_update_claim)
 {
+    
     fRequireStandard = false;
     BOOST_CHECK(pclaimTrie->nCurrentHeight == chainActive.Height() + 1);
-    
     LOCK(cs_main);
 
     std::string sName1("atest");

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -93,17 +93,17 @@ struct {
 };*/
 
 const unsigned int nonces[] = {
-    336984, 142281, 190844, 28794, 60108, 38620, 50265, 1467, 51047, 5744,
-    3125, 3088, 1463, 38012, 136014, 82442, 108217, 67261, 164429, 295896,
-    5625, 33163, 18912, 17233, 33394, 31250, 90162, 83127, 31836, 245670,
-    49024, 5885, 121125, 13475, 27802, 92250, 94286, 15970, 11536, 225728,
-    139479, 120543, 125802, 2277, 29409, 188078, 44811, 777656, 739940, 463139,
-    98442, 199176, 257878, 1071941, 201178, 3749, 103041, 184443, 32931, 95584,
-    170413, 218370, 215087, 795280, 232087, 74312, 551792, 105084, 93228, 202816,
-    142542, 309855, 83512, 136555, 514030, 246349, 687104, 210446, 58494, 164980,
-    20188, 615074, 73461, 755562, 268257, 119909, 146341, 201954, 169429, 138541,
-    56238, 211463, 94796, 264180, 46875, 20947, 2127286, 1343640, 481679, 565494,
-    309051, 191932, 570553, 968624, 3807762, 281065, 1186138, 1168816, 231340, 715540,
+9875, 95807, 31359, 234335, 145717, 80791, 112145, 24413, 180722, 9910,
+43622, 8531, 6247, 21164, 31399, 115014, 6240, 11855, 15380, 16059,
+151773, 42247, 258112, 33467, 66678, 118631, 31485, 53636, 74882, 4123,
+86392, 11386, 58121, 27870, 76602, 17616, 80966, 37064, 84547, 58182,
+169550, 11965, 63424, 245620, 4710, 6134, 77310, 100050, 134882, 44029,
+3970, 175316, 56994, 23523, 12055, 15866, 25422, 71227, 105999, 107878,
+75188, 17820, 54863, 74022, 81834, 121376, 67397, 10857, 22081, 33061,
+65027, 46272, 56681, 1209, 151028, 82788, 7817, 92273, 55392, 15714,
+94174, 21541, 33833, 30596, 93204, 53265, 51495, 59980, 91955, 57202,
+40559, 23761, 75982, 4582, 3207, 109694, 12944, 93689, 47593, 20997,
+194095, 112324, 146676, 66180, 33360, 140817, 731, 19918, 31681, 19541,
 };
 
 CBlockIndex CreateBlockIndex(int nHeight)
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         CBlock *pblock = &pblocktemplate->block; // pointer for convenience
         pblock->hashPrevBlock = chainActive.Tip()->GetBlockHash();
         pblock->nVersion = 1;
-        pblock->nTime = chainActive.Tip()->GetBlockTime()+150*(i+1);
+        pblock->nTime = chainActive.Tip()->GetBlockTime()+chainparams.GetConsensus().nPowTargetSpacing;
         CMutableTransaction txCoinbase(pblock->vtx[0]);
         txCoinbase.nVersion = 1;
         txCoinbase.vin[0].scriptSig = CScript();
@@ -167,9 +167,10 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
         pblock->nNonce = nonces[i];
 
-
+        //#define NEED_NEW_NONCES_MINER_TEST
         //Use below code to find nonces, in case we change hashing or difficulty retargeting algo
-        /*
+        #ifdef NEED_NEW_NONCES_MINER_TEST
+                
         bool fFound = false;
 
         for (int j = 0; !fFound; j++)
@@ -184,8 +185,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
                 else
                     std::cout << " ";
             }
-        }
-        */
+        } 
+        #endif
 
         CValidationState state;
         BOOST_CHECK(ProcessNewBlock(state, chainparams, NULL, pblock, true, NULL));


### PR DESCRIPTION
This fixes the regtest and testnet parameters which are are necessary to create a testing environment for lbrycrd. 

This also adds in a checkpoint on the mainnet at block 4000. Although checkpoints in bitcoin is used as a DOS prevention method, for our purpose it will effectively prevent malicious forks before that block since that is fairly easy to do with the current hash rate.  

Parameters for BIP34 soft fork activation was changed from what it was in Bitcoin.

Some unit tests were also broken , and this has been fixed as well.  
