### PR TITLE
make regtest generate blocks faster so that tests run in a reasonable amount of time

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -291,8 +291,8 @@ public:
         consensus.BIP34Height = -1; // BIP34 has not necessarily activated on regtest
         consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 150;//14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 150;
+        consensus.nPowTargetTimespan = 1;//14 * 24 * 60 * 60; // two weeks
+        consensus.nPowTargetSpacing = 1;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains


### PR DESCRIPTION
The introduction of the new retargeting function caused blocks in regtest mode to take a very long time to generate, which results in the tests taking a very very long time to run. This makes blocks in regtest generate faster.