### PR TITLE
Bogus claimid tests

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -291,8 +291,8 @@ public:
         consensus.BIP34Height = -1; // BIP34 has not necessarily activated on regtest
         consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 150;//14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 150;
+        consensus.nPowTargetTimespan = 1;//14 * 24 * 60 * 60; // two weeks
+        consensus.nPowTargetSpacing = 1;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains


### PR DESCRIPTION
This adds a test which checks that someone can't just set claimId to whatever they want when creating a claim update (for example, the claimId of the current winner) and get their claim inserted immediately (or ever).