### PR TITLE
Limits name length of claimtrie transactions to 255 bytes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -961,8 +961,14 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
         nValueOut += txout.nValue;
         if (!MoneyRange(nValueOut))
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-txouttotal-toolarge");
+
+        // check claimtrie transactions 
+
         if (ClaimScriptSize(txout.scriptPubKey) > MAX_CLAIM_SCRIPT_SIZE)
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-claimscriptsize-toolarge");
+        if (ClaimNameSize(txout.scriptPubKey) > MAX_CLAIM_NAME_SIZE)                 
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-claimscriptname-toolarge");
+            
     }
 
     // Check for duplicate inputs

--- a/src/nameclaim.cpp
+++ b/src/nameclaim.cpp
@@ -136,3 +136,17 @@ size_t ClaimScriptSize(const CScript& scriptIn)
     return scriptIn.size() - strippedScript.size();
 }
 
+size_t ClaimNameSize(const CScript& scriptIn)
+{
+    std::vector<std::vector<unsigned char> > vvchParams;
+    CScript::const_iterator pc = scriptIn.begin();
+    int op;
+    if (!DecodeClaimScript(scriptIn, op, vvchParams, pc))
+    {
+        return 0;
+    }
+    else
+    {
+        return vvchParams[0].size();
+    }
+}

--- a/src/nameclaim.h
+++ b/src/nameclaim.h
@@ -6,7 +6,13 @@
 
 #include <vector>
 
+// This is the max claim script size in bytes, not including the script pubkey part of the script.
+// Scripts exceeding this size are rejected in CheckTransaction in main.cpp
 #define MAX_CLAIM_SCRIPT_SIZE 8192
+
+// This is the max claim name size in bytes, for all claim trie transactions. 
+// Scripts exceeding this size are rejected in CheckTransaction in main.cpp
+#define MAX_CLAIM_NAME_SIZE 255
 
 bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams);
 bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams, CScript::const_iterator& pc);
@@ -15,6 +21,9 @@ CScript StripClaimScriptPrefix(const CScript& scriptIn, int& op);
 uint160 ClaimIdHash(const uint256& txhash, uint32_t nOut);
 std::vector<unsigned char> uint32_t_to_vch(uint32_t n);
 uint32_t vch_to_uint32_t(std::vector<unsigned char>& vchN);
+// get size of the claim script, minus the script pubkey part 
 size_t ClaimScriptSize(const CScript& scriptIn);
+// get size of the name in a claim script, returns 0 if scriptin is not a claimetrie transaction 
+size_t ClaimNameSize(const CScript& scriptIn); 
 
 #endif // BITCOIN_NAMECLAIM_H

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -12,6 +12,7 @@
 #include "key.h"
 #include "keystore.h"
 #include "main.h" // For CheckTransaction
+#include "nameclaim.h"
 #include "policy/policy.h"
 #include "script/script.h"
 #include "script/script_error.h"
@@ -445,6 +446,7 @@ BOOST_AUTO_TEST_CASE(test_claimsValid)
     BOOST_CHECK(CheckTransaction(t, state));
     BOOST_CHECK(state.IsValid());
 
+    // exceeds max script size 
     vchName = std::vector<unsigned char>(2<<12, '0');
     vchValue = std::vector<unsigned char>(2<<12, '0');    
 
@@ -454,5 +456,30 @@ BOOST_AUTO_TEST_CASE(test_claimsValid)
     
     BOOST_CHECK(!CheckTransaction(t, state));
     BOOST_CHECK(!state.IsValid());
+
+    // does not exceed max name size 
+    vchName = std::vector<unsigned char>(MAX_CLAIM_NAME_SIZE, '0');
+    vchValue = std::vector<unsigned char>(1, '0');    
+
+    t.vout[0].scriptPubKey = CScript() << OP_CLAIM_NAME << vchName << vchValue << OP_2DROP << OP_DROP << OP_TRUE;
+    
+    state = CValidationState();
+    
+    BOOST_CHECK(CheckTransaction(t, state));
+    BOOST_CHECK(state.IsValid());
+
+    // exceeds max name size 
+    vchName = std::vector<unsigned char>(MAX_CLAIM_NAME_SIZE+1, '0');
+    vchValue = std::vector<unsigned char>(1, '0');    
+
+    t.vout[0].scriptPubKey = CScript() << OP_CLAIM_NAME << vchName << vchValue << OP_2DROP << OP_DROP << OP_TRUE;
+    
+    state = CValidationState();
+    
+    BOOST_CHECK(!CheckTransaction(t, state));
+    BOOST_CHECK(!state.IsValid());
+
+
+
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This patch limits name length of claimtrie transactions to 255 bytes at most. 
This is a soft fork, and nodes should upgrade immediately. 