### PR TITLE
rpc: add claimtrie field in getblocktemplate

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -659,6 +659,9 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
+    if (pclaimTrie)
+	result.push_back(Pair("claimtrie", pclaimTrie->getMerkleHash().GetHex()));
+
     return result;
 }
 


### PR DESCRIPTION
getblocktemplate is supposed to output all required mining infos