### PR TITLE
Change rpc amounts to decimal, add getEffectiveAmountForClaim command [WIP]

### DIFF
--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -273,6 +273,30 @@ struct claimsForNameType
 
     claimsForNameType(std::vector<CClaimValue> claims, std::vector<CSupportValue> supports, int nLastTakeoverHeight)
     : claims(claims), supports(supports), nLastTakeoverHeight(nLastTakeoverHeight) {}
+    
+    //return effective amount form claim, retuns 0 if claim is not found
+    CAmount getEffectiveAmountForClaim(uint160 claimId, int currentHeight)
+    {
+        CAmount effectiveAmount = 0;
+        bool claim_found = false; 
+        for (std::vector<CClaimValue>::iterator it=claims.begin(); it!=claims.end(); ++it)
+        {
+            if (it->claimId == claimId && it->nValidAtHeight < currentHeight)
+                effectiveAmount += it->nAmount;       
+                claim_found = true;  
+                break;
+        }
+        if (!claim_found)
+            return effectiveAmount; 
+        
+        for (std::vector<CSupportValue>::iterator it=supports.begin(); it!=supports.end(); ++it)
+        {
+            if (it->supportedClaimId == claimId && it->nValidAtHeight < currentHeight)
+                effectiveAmount += it->nAmount; 
+        }
+        return effectiveAmount; 
+
+    }
 };
 
 class CClaimTrieCache;
@@ -330,7 +354,7 @@ public:
     unsigned int getTotalNamesInTrie() const;
     unsigned int getTotalClaimsInTrie() const;
     CAmount getTotalValueOfClaimsInTrie(bool fControllingOnly) const;
-    
+
     friend class CClaimTrieCache;
     
     CDBWrapper db;

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -183,11 +183,12 @@ UniValue getvalueforname(const UniValue& params, bool fHelp)
     std::string sValue;
     if (!getValueForClaim(claim.outPoint, sValue))
         return ret;
+
     ret.push_back(Pair("value", sValue));
     ret.push_back(Pair("txid", claim.outPoint.hash.GetHex()));
     ret.push_back(Pair("n", (int)claim.outPoint.n));
-    ret.push_back(Pair("amount", claim.nAmount));
-    ret.push_back(Pair("effective amount", claim.nEffectiveAmount)); 
+    ret.push_back(Pair("amount", ValueFromAmount(claim.nAmount)));
+    ret.push_back(Pair("effective amount", ValueFromAmount(claim.nEffectiveAmount))); 
     ret.push_back(Pair("height", claim.nHeight));
     return ret;
 }
@@ -214,7 +215,7 @@ UniValue claimsAndSupportsToJSON(claimSupportMapType::const_iterator itClaimsAnd
         {
             nEffectiveAmount += itSupports->nAmount;
         }
-        supportObj.push_back(Pair("nAmount", itSupports->nAmount));
+        supportObj.push_back(Pair("nAmount", ValueFromAmount(itSupports->nAmount)));
         supportObjs.push_back(supportObj);
     }
     ret.push_back(Pair("claimId", itClaimsAndSupports->first.GetHex()));
@@ -226,13 +227,13 @@ UniValue claimsAndSupportsToJSON(claimSupportMapType::const_iterator itClaimsAnd
     {
         nEffectiveAmount += claim.nAmount;
     }
-    ret.push_back(Pair("nAmount", claim.nAmount));
+    ret.push_back(Pair("nAmount", ValueFromAmount(claim.nAmount)));
     std::string sValue;
     if (getValueForClaim(claim.outPoint, sValue))
     {
         ret.push_back(Pair("value", sValue));
     }
-    ret.push_back(Pair("nEffectiveAmount", nEffectiveAmount));
+    ret.push_back(Pair("nEffectiveAmount", ValueFromAmount(nEffectiveAmount)));
     ret.push_back(Pair("supports", supportObjs));
 
     return ret;
@@ -251,7 +252,7 @@ UniValue supportsWithoutClaimsToJSON(supportsWithoutClaimsMapType::const_iterato
         supportObj.push_back(Pair("n", (int)itSupports->outPoint.n));
         supportObj.push_back(Pair("nHeight", itSupports->nHeight));
         supportObj.push_back(Pair("nValidAtHeight", itSupports->nValidAtHeight));
-        supportObj.push_back(Pair("nAmount", itSupports->nAmount));
+        supportObj.push_back(Pair("nAmount", ValueFromAmount(itSupports->nAmount)));
         supportObjs.push_back(supportObj);
     }
     ret.push_back(Pair("supports", supportObjs));

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -188,7 +188,9 @@ UniValue getvalueforname(const UniValue& params, bool fHelp)
     ret.push_back(Pair("txid", claim.outPoint.hash.GetHex()));
     ret.push_back(Pair("n", (int)claim.outPoint.n));
     ret.push_back(Pair("amount", ValueFromAmount(claim.nAmount)));
-    ret.push_back(Pair("effective amount", ValueFromAmount(claim.nEffectiveAmount))); 
+    claimsForNameType claimsForName = pclaimTrie->getClaimsForName(name);
+    CAmount effectiveAmount = claimsForName.getEffectiveAmountForClaim(claim.claimId,chainActive.Height()); 
+    ret.push_back(Pair("effective amount", ValueFromAmount(effectiveAmount))); 
     ret.push_back(Pair("height", claim.nHeight));
     return ret;
 }
@@ -197,12 +199,11 @@ typedef std::pair<CClaimValue, std::vector<CSupportValue> > claimAndSupportsType
 typedef std::map<uint160, claimAndSupportsType> claimSupportMapType;
 typedef std::map<uint160, std::vector<CSupportValue> > supportsWithoutClaimsMapType;
 
-UniValue claimsAndSupportsToJSON(claimSupportMapType::const_iterator itClaimsAndSupports, int nCurrentHeight)
+UniValue claimsAndSupportsToJSON(claimSupportMapType::const_iterator itClaimsAndSupports, CAmount nEffectiveAmount)
 {
     UniValue ret(UniValue::VOBJ);
     const CClaimValue claim = itClaimsAndSupports->second.first;
     const std::vector<CSupportValue> supports = itClaimsAndSupports->second.second;
-    CAmount nEffectiveAmount = 0;
     UniValue supportObjs(UniValue::VARR);
     for (std::vector<CSupportValue>::const_iterator itSupports = supports.begin(); itSupports != supports.end(); ++itSupports)
     {
@@ -211,10 +212,6 @@ UniValue claimsAndSupportsToJSON(claimSupportMapType::const_iterator itClaimsAnd
         supportObj.push_back(Pair("n", (int)itSupports->outPoint.n));
         supportObj.push_back(Pair("nHeight", itSupports->nHeight));
         supportObj.push_back(Pair("nValidAtHeight", itSupports->nValidAtHeight));
-        if (itSupports->nValidAtHeight < nCurrentHeight)
-        {
-            nEffectiveAmount += itSupports->nAmount;
-        }
         supportObj.push_back(Pair("nAmount", ValueFromAmount(itSupports->nAmount)));
         supportObjs.push_back(supportObj);
     }
@@ -223,10 +220,6 @@ UniValue claimsAndSupportsToJSON(claimSupportMapType::const_iterator itClaimsAnd
     ret.push_back(Pair("n", (int)claim.outPoint.n));
     ret.push_back(Pair("nHeight", claim.nHeight));
     ret.push_back(Pair("nValidAtHeight", claim.nValidAtHeight));
-    if (claim.nValidAtHeight < nCurrentHeight)
-    {
-        nEffectiveAmount += claim.nAmount;
-    }
     ret.push_back(Pair("nAmount", ValueFromAmount(claim.nAmount)));
     std::string sValue;
     if (getValueForClaim(claim.outPoint, sValue))
@@ -330,7 +323,8 @@ UniValue getclaimsforname(const UniValue& params, bool fHelp)
     ret.push_back(Pair("nLastTakeoverHeight", claimsForName.nLastTakeoverHeight));
     for (claimSupportMapType::const_iterator itClaimsAndSupports = claimSupportMap.begin(); itClaimsAndSupports != claimSupportMap.end(); ++itClaimsAndSupports)
     {
-        UniValue claimAndSupportsObj = claimsAndSupportsToJSON(itClaimsAndSupports, nCurrentHeight);
+        CAmount nEffectiveAmount = claimsForName.getEffectiveAmountForClaim(itClaimsAndSupports->second.first.claimId,nCurrentHeight); 
+        UniValue claimAndSupportsObj = claimsAndSupportsToJSON(itClaimsAndSupports, nEffectiveAmount);
         claimObjs.push_back(claimAndSupportsObj);
     }
     ret.push_back(Pair("claims", claimObjs));


### PR DESCRIPTION
Return decimal values for amounts instead of dewey's in rpc commands getclaimsforname and getvalueforname

Add getEffectiveAmountForClaim command to use in rpc command getclaimsforname and to fix getvalueforname https://github.com/lbryio/lbrycrd/issues/33

Rework of https://github.com/lbryio/lbrycrd/pull/35 as per Jimmy's suggestions to keep view related functionality separated from claimtrie.h/.cpp 
