### PR TITLE
Fix remove support bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2588,10 +2588,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         std::string name(vvchParams[0].begin(), vvchParams[0].end());
                         uint160 supportedClaimId(vvchParams[1]);
                         int nValidAtHeight;
-                        LogPrintf("%s: Removing support for %s in %s. Tx: %s, nOut: %d\n", __func__, supportedClaimId.ToString(), name, txin.prevout.hash.ToString(), txin.prevout.n);
+                        LogPrintf("%s: Removing support for %s in %s. Tx: %s, nOut: %d, removed txid: %s\n", __func__, supportedClaimId.ToString(), name, txin.prevout.hash.ToString(), txin.prevout.n,tx.GetHash().ToString());
                         if (trieCache.spendSupport(name, COutPoint(txin.prevout.hash, txin.prevout.n), coins->nHeight, nValidAtHeight))
                         {
-                            mClaimUndoHeights[0] = nValidAtHeight;
+                            mClaimUndoHeights[i] = nValidAtHeight;
                         }
                     }
                 }


### PR DESCRIPTION
This is a redo of https://github.com/lbryio/lbrycrd/pull/45, containing only the fix and not the test which is contained in https://github.com/lbryio/lbrycrd/pull/52

Fixing below exception that would occurs, when decrementing block and calling function "removeSupportFromMap" to undo a support which has been spent on a txin that is NOT txin[0]

lbrycrdd: claimtrie.cpp:2294: bool CClaimTrieCache::decrementBlock(insertUndoType&, claimQueueRowType&, insertUndoType&, supportQueueRowType&, std::vectorstd::pair<std::basic_string<char, int> >&) const: Assertion `removeSupportFromMap(itSupportUndo->name, itSupportUndo->outPoint, support, false)' failed.

Essentially, the bug caused spent supports to not be undoable. Thus when decrementing a block where a support is spent, the support would still be spent when it should be unspent. When decrementing the block where that support was created, the removeSupportFromMap function would fail because the support its looking to remove is not there.

With this change, clients must run -reindex once to fix the claimtrie.

To verify the patch is working, running ./lbrycrd-cli verifychain 4 0 , should not cause an exception and return true. If not patched, running the command, will cause lbrycrdd to throw the above exception.
