### PR TITLE
Change regtest address related prefixes to be same as main net

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -336,11 +336,12 @@ public:
             0,
             0
         };
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
-        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
-        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
-        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
+
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0x55);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,0x7a);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,0x1c);
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x01)(0x9C)(0x35)(0x4f).convert_to_container<std::vector<unsigned char> >();
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x01)(0x9C)(0x31)(0x18).convert_to_container<std::vector<unsigned char> >();
     }
 };
 static CRegTestParams regTestParams;


### PR DESCRIPTION
Make regtest address prefixes the same as main net. This will make coding easier to setup lbryum to work in regtest mode, which is needed in lbry-in-a-box. 