### PR TITLE
Adding effective amount function to CClaimTrie

### DIFF
--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -525,6 +525,31 @@ claimsForNameType CClaimTrie::getClaimsForName(const std::string& name) const
     return allClaims;
 }
 
+//return effective amount form claim, retuns 0 if claim is not found
+CAmount CClaimTrie::getEffectiveAmountForClaim(const std::string& name, uint160 claimId) const
+{
+	claimsForNameType claims = getClaimsForName(name);
+	CAmount effectiveAmount = 0;
+	bool claim_found = false;
+	for (std::vector<CClaimValue>::iterator it=claims.claims.begin(); it!=claims.claims.end(); ++it)
+	{
+		if (it->claimId == claimId && it->nValidAtHeight < nCurrentHeight)
+			effectiveAmount += it->nAmount;
+			claim_found = true;
+			break;
+	}
+	if (!claim_found)
+		return effectiveAmount;
+
+	for (std::vector<CSupportValue>::iterator it=claims.supports.begin(); it!=claims.supports.end(); ++it)
+	{
+		if (it->supportedClaimId == claimId && it->nValidAtHeight < nCurrentHeight)
+			effectiveAmount += it->nAmount;
+	}
+	return effectiveAmount;
+
+}
+
 bool CClaimTrie::checkConsistency() const
 {
     if (empty())

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -302,7 +302,8 @@ public:
     bool getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const;
 
     claimsForNameType getClaimsForName(const std::string& name) const;
-    
+    CAmount getEffectiveAmountForClaim(const std::string& name, uint160 claimId) const;   
+ 
     bool queueEmpty() const;
     bool supportEmpty() const;
     bool supportQueueEmpty() const;

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -187,7 +187,7 @@ UniValue getvalueforname(const UniValue& params, bool fHelp)
     ret.push_back(Pair("txid", claim.outPoint.hash.GetHex()));
     ret.push_back(Pair("n", (int)claim.outPoint.n));
     ret.push_back(Pair("amount", claim.nAmount));
-    ret.push_back(Pair("effective amount", claim.nEffectiveAmount)); 
+    ret.push_back(Pair("effective amount", pclaimTrie->getEffectiveAmountForClaim(name, claim.claimId))); 
     ret.push_back(Pair("height", claim.nHeight));
     return ret;
 }


### PR DESCRIPTION
Redo of https://github.com/lbryio/lbrycrd/pull/36 (without changes for decimal amounts) 

Add getEffectiveAmountForClaim command to CClaimTrie as per Jimmy's comment for use in rpc command getvalueforname 

Fixes issue https://github.com/lbryio/lbrycrd/issues/33

Add some tests for the new function in claimtriebranching_tests.