### PR TITLE
Change max block decrement amount to 50

### DIFF
--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -4,6 +4,8 @@
 #include "univalue.h"
 #include "txmempool.h"
 
+// Maximum block decrement that is allowed from rpc calls
+const int MAX_RPC_BLOCK_DECREMENTS = 50;
 
 UniValue getclaimsintrie(const UniValue& params, bool fHelp)
 {
@@ -682,7 +684,7 @@ UniValue getnameproof(const UniValue& params, bool fHelp)
     if (!chainActive.Contains(pblockIndex))
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Block not in main chain");
 
-    if (chainActive.Tip()->nHeight > (pblockIndex->nHeight + 20))
+    if (chainActive.Tip()->nHeight > (pblockIndex->nHeight + MAX_RPC_BLOCK_DECREMENTS))
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Block too deep to generate proof");
 
     CClaimTrieProof proof;


### PR DESCRIPTION
Increase the maximum amount that a rpc call is allowed to decrement blocks from 20 to 50. This affects how far RPC command getprooforname, used by lbryum, can go back in blocks. 

Calling getproofforname and going back 50 blocks takes about 0.009 seconds (going back 20 blocks takes about 0.007) which should not be too much of a load increase.   

This should decrease cases where we get the error "Block too deep to generate proof" from lbryum when calling its getvalueforname command.  
