### PR TITLE
Replace `Satoshi` subversion with `LBRY`

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -13,7 +13,7 @@
  * for both bitcoind and bitcoin-core, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string CLIENT_NAME("Satoshi");
+const std::string CLIENT_NAME("LBRY");
 
 /**
  * Client version number


### PR DESCRIPTION
Distinguishes lbry nodes from bitcoin nodes