### PR TITLE
Fix getblocktemplate command not returning the correct claimtrie hash

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -658,9 +658,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
-
-    if (pclaimTrie)
-	result.push_back(Pair("claimtrie", pclaimTrie->getMerkleHash().GetHex()));
+    result.push_back(Pair("claimtrie", pblock->hashClaimTrie.GetHex()));
 
     return result;
 }


### PR DESCRIPTION
getblocktemplate command was not returning the correct claimtrie hash updated with the transactions in the block 