### PR TITLE
fix reproducable_build.sh on os x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,8 +311,6 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
-         openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
-         bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
          qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
          if test x$openssl_prefix != x; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
fixes build issue where the compiled openssl and berkeley-db aren't used in favor of non-existent brew versions