### PR TITLE
Fix memory leak

### DIFF
--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -1220,14 +1220,24 @@ bool CClaimTrieCache::empty() const
 
 CClaimTrieNode* CClaimTrieCache::addNodeToCache(const std::string& position, CClaimTrieNode* original) const
 {
-    if (!original)
-        original = new CClaimTrieNode();
-    CClaimTrieNode* cacheCopy = new CClaimTrieNode(*original);
+    // create a copy of the node in the cache, if new node, create empty node
+    CClaimTrieNode* cacheCopy;
+    if(!original)
+        cacheCopy = new CClaimTrieNode();
+    else
+        cacheCopy = new CClaimTrieNode(*original);
     cache[position] = cacheCopy;
+
+    // check to see if there is the original node in block_originals,
+    // if not, add it to block_originals cache
     nodeCacheType::const_iterator itOriginals = block_originals.find(position);
     if (block_originals.end() == itOriginals)
     {
-        CClaimTrieNode* originalCopy = new CClaimTrieNode(*original);
+        CClaimTrieNode* originalCopy;
+        if(!original)
+            originalCopy = new CClaimTrieNode();
+        else
+            originalCopy = new CClaimTrieNode(*original);
         block_originals[position] = originalCopy;
     }
     return cacheCopy;

--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -2467,6 +2467,7 @@ bool CClaimTrieCache::clear() const
     supportCache.clear();
     supportQueueCache.clear();
     supportQueueNameCache.clear();
+    supportExpirationQueueCache.clear();
     namesToCheckForTakeover.clear();
     cacheTakeoverHeights.clear();
     return true;


### PR DESCRIPTION
b2ba3f5
There was a memory leak which would cause a extra ClaimTrie node to be allocated but never deleted. 
This would happen when a new node would be created in the ClaimTrie and CClaimTrieCache.addNodeToCache() was called. 

The only reason the extra ClaimTrie node was created was to serve as a empty node template which would be copied by value over to the actual Node (I guess it looks like a DRY shortcut that was not implemented correctly). This is not necessary, and the fix just creates an empty node when necessary.

a2fa2c0
the was a missing clear() on a cache object in CClaimTrieCache. This should not cause any problem since we don't need to call clear() on map objects that are going to get destroyed anyways but nonetheless should be consistent. 

Was able to reindex with this patch, and passes tests. Uses half the memory it used to according to my tests.