### PR TITLE
Add fees to claim trie transactions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -62,6 +62,7 @@ BITCOIN_TESTS =\
   test/multisig_tests.cpp \
   test/claimtrie_tests.cpp \
   test/claimtriebranching_tests.cpp \
+  test/nameclaim_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/main.h
+++ b/src/main.h
@@ -50,7 +50,7 @@ static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 //! -maxtxfee default
-static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
+static const CAmount DEFAULT_TRANSACTION_MAXFEE = 1 * COIN;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
 static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
@@ -163,6 +163,9 @@ extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction) */
 extern CAmount maxTxFee;
+/** Used to calculate minimum fee for claim trie transactions **/
+extern CAmount minFeePerNameClaimChar;
+
 /** If the tip is older than this (in seconds), the node is considered to be in initial block download. */
 extern int64_t nMaxTipAge;
 extern bool fEnableReplacement;

--- a/src/nameclaim.h
+++ b/src/nameclaim.h
@@ -1,22 +1,33 @@
 #ifndef BITCOIN_NAMECLAIM_H
 #define BITCOIN_NAMECLAIM_H
 
+#include "amount.h"
 #include "script/script.h"
+#include "primitives/transaction.h"
 #include "uint256.h"
 
 #include <vector>
+
+// This is the minimum claim fee per character in the name of an OP_CLAIM_NAME command that must
+// be attached to transactions for it to be accepted into the memory pool.
+// Rationale: current implementation of the claim trie uses more memory for longer name claims
+// due to the fact that each chracater is assigned a trie node regardless of whether it contains
+// any claims or not. In the future, we can switch to a radix tree implementation where
+// empty nodes do not take up any memory and the minimum fee can be priced on a per claim
+// basis.
+#define MIN_FEE_PER_NAMECLAIM_CHAR 200000
 
 // This is the max claim script size in bytes, not including the script pubkey part of the script.
 // Scripts exceeding this size are rejected in CheckTransaction in main.cpp
 #define MAX_CLAIM_SCRIPT_SIZE 8192
 
-// This is the max claim name size in bytes, for all claim trie transactions. 
+// This is the max claim name size in bytes, for all claim trie transactions.
 // Scripts exceeding this size are rejected in CheckTransaction in main.cpp
 #define MAX_CLAIM_NAME_SIZE 255
 
 CScript ClaimNameScript(std::string name, std::string value);
 CScript SupportClaimScript(std::string name, uint160 claimId);
-CScript UpdateClaimScript(std::string name, uint160 claimId, std::string value); 
+CScript UpdateClaimScript(std::string name, uint160 claimId, std::string value);
 bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams);
 bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams, CScript::const_iterator& pc);
 CScript StripClaimScriptPrefix(const CScript& scriptIn);
@@ -24,10 +35,11 @@ CScript StripClaimScriptPrefix(const CScript& scriptIn, int& op);
 uint160 ClaimIdHash(const uint256& txhash, uint32_t nOut);
 std::vector<unsigned char> uint32_t_to_vch(uint32_t n);
 uint32_t vch_to_uint32_t(std::vector<unsigned char>& vchN);
-// get size of the claim script, minus the script pubkey part 
+// get size of the claim script, minus the script pubkey part
 size_t ClaimScriptSize(const CScript& scriptIn);
-// get size of the name in a claim script, returns 0 if scriptin is not a claimetrie transaction 
-size_t ClaimNameSize(const CScript& scriptIn); 
-
+// get size of the name in a claim script, returns 0 if scriptin is not a claimetrie transaction
+size_t ClaimNameSize(const CScript& scriptIn);
+// calculate the minimum fee (mempool rule) required for transaction
+CAmount CalcMinClaimTrieFee(const CTransaction& tx, const CAmount &minFeePerNameClaimChar);
 
 #endif // BITCOIN_NAMECLAIM_H

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -751,6 +751,4 @@ BOOST_AUTO_TEST_CASE(claimtriebranching_expire)
 
 }
 
-
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/nameclaim_tests.cpp
+++ b/src/test/nameclaim_tests.cpp
@@ -1,0 +1,38 @@
+#include "nameclaim.h"
+#include "primitives/transaction.h"
+#include <boost/test/unit_test.hpp>
+#include "test/test_bitcoin.h"
+
+//BOOST_FIXTURE_TEST_SUITE(nameclaim_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(calc_min_claimtrie_fee)
+{
+
+    CMutableTransaction tx;
+    tx.vout.resize(1);
+    tx.vout[0].scriptPubKey = ClaimNameScript("A","test");
+    BOOST_CHECK_EQUAL(CalcMinClaimTrieFee(tx, MIN_FEE_PER_NAMECLAIM_CHAR), MIN_FEE_PER_NAMECLAIM_CHAR);
+
+    // check that fee is adjusted based on name length
+    CMutableTransaction tx2;
+    tx2.vout.resize(1);
+    tx2.vout[0].scriptPubKey = ClaimNameScript("ABCDE","test");
+    BOOST_CHECK_EQUAL(CalcMinClaimTrieFee(tx2,MIN_FEE_PER_NAMECLAIM_CHAR), MIN_FEE_PER_NAMECLAIM_CHAR*5);
+
+    // check that multiple OP_CLAIM_NAME outputs are counted
+    CMutableTransaction tx3;
+    tx3.vout.resize(2);
+    tx3.vout[0].scriptPubKey = ClaimNameScript("A","test");
+    tx3.vout[1].scriptPubKey = ClaimNameScript("AB","test");
+    BOOST_CHECK_EQUAL(CalcMinClaimTrieFee(tx3,MIN_FEE_PER_NAMECLAIM_CHAR), MIN_FEE_PER_NAMECLAIM_CHAR*3);
+
+    // if tx has no claim minimum fee is 0
+    CMutableTransaction tx4;
+    tx4.vout.resize(1);
+    BOOST_CHECK_EQUAL(CalcMinClaimTrieFee(tx4,MIN_FEE_PER_NAMECLAIM_CHAR), 0);
+
+}
+
+
+
+//BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -153,6 +153,7 @@ TestChain100Setup::~TestChain100Setup()
 RegTestingSetup::RegTestingSetup() : TestingSetup(CBaseChainParams::REGTEST)
 {
     minRelayTxFee = CFeeRate(0);
+    minFeePerNameClaimChar = 0;
 }
 
 RegTestingSetup::~RegTestingSetup()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2279,6 +2279,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 if (coinControl && nFeeNeeded > 0 && coinControl->nMinimumTotalFee > nFeeNeeded) {
                     nFeeNeeded = coinControl->nMinimumTotalFee;
                 }
+                // Make sure we meet the minimum claimtrie fee, pick which ever one is largest
+                CAmount minClaimTrieFee = CalcMinClaimTrieFee(wtxNew, minFeePerNameClaimChar);
+                nFeeNeeded = std::max(nFeeNeeded, minClaimTrieFee);
 
                 // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
                 // because we must be at the maximum allowed fee.


### PR DESCRIPTION
7f2f918 / reworked to: 1f137fc 
Add new function CalcMinClaimTrieFee to calculate the minimum fee required for claim trie transactions. Works based on MIN_FEE_PER_NAMECLAIM_CHAR , which defines the fee attached per each character of the name in the name claim. Set to 200000 base units or (0.002 LBC) for max fee 0.51 LBC (0.002*255 max length name claim). 

Added test for it in nameclaim_tests.cpp (that we should expand with other tests for nameclaim.cpp) 

8384c04 / reworked to: 12784d4
increase DEFAULT_TRANSACTION_MAXFEE from 0.1 to 1 since we can now get fees over 0.1 LBC

7f2f918 / reworked to: 5c4d8b9
implement CalcMinClaimTrieFee into AcceptToMemoryPool to allow CalcMinClaimTrieFee to take effect when rejecting transactions from the memory pool. Implement CalcMinClaimTrieFee into src/wallet/wallet.cpp so that generated transactions take into consideration the claim trie fee. 

Not sure this is the best way to do it though, ideally the function signature for AcceptToMemoryPool is not affected, but we still need a way to turn off the cacluation of minimum claim trie fee for the tests in claimtrie_tests.cpp and claimtriebranching_tests.cpp, otherwise they break. Will rethink this commit. 

EDIT2: This has been reworked : CalcMinClaimTrieFee now takes as argument minFeePerNameClaimChar . This variable is set as a global in main.cpp along with other globals. This allows it to be set freely to whatever is needed for testing purposes.

