### PR TITLE
WIP: Unit test for recursivePruneName and for future CClaimTrieCache unit tests

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -61,6 +61,7 @@ BITCOIN_TESTS =\
   test/miner_tests.cpp \
   test/multisig_tests.cpp \
   test/claimtrie_tests.cpp \
+  test/claimtriecache_tests.cpp \
   test/claimtriebranching_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \

--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -1428,6 +1428,9 @@ bool CClaimTrieCache::removeClaimFromTrie(const std::string& name, const COutPoi
 
 bool CClaimTrieCache::recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, std::string sName, bool* pfNullified) const
 {
+    // Recursively prune leaf node(s) without any claims in it and store
+    // the modified nodes in the cache
+
     bool fNullified = false;
     std::string sCurrentSubstring = sName.substr(0, nPos);
     if (nPos < sName.size())

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -493,7 +493,7 @@ public:
     CClaimTrieProof getProofForName(const std::string& name) const;
 
     bool finalizeDecrement() const;
-private:
+protected:
     CClaimTrie* base;
 
     bool fRequireTakeoverHeights;

--- a/src/test/claimtriecache_tests.cpp
+++ b/src/test/claimtriecache_tests.cpp
@@ -1,0 +1,71 @@
+#include "claimtrie.h"
+#include "main.h"
+
+#include "test/test_bitcoin.h"
+#include <boost/test/unit_test.hpp>
+using namespace std;
+
+
+class CClaimTrieCacheTest : public CClaimTrieCache {
+public:
+    CClaimTrieCacheTest(CClaimTrie* base):
+        CClaimTrieCache(base, false){}
+
+    bool recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, std::string sName, bool* pfNullified) const
+    {
+        return CClaimTrieCache::recursivePruneName(tnCurrent,nPos,sName, pfNullified);
+    }
+    int cacheSize()
+    {
+        return cache.size();
+    }
+
+    nodeCacheType::iterator getCache(std::string key)
+    {
+        return cache.find(key);
+    }
+
+};
+
+BOOST_FIXTURE_TEST_SUITE(claimtriecache_tests, RegTestingSetup)
+
+BOOST_AUTO_TEST_CASE(recursiveprune_test)
+{
+    CClaimTrieCacheTest cc(pclaimTrie);
+    BOOST_CHECK_EQUAL(0, cc.cacheSize());
+
+    COutPoint outpoint;
+    uint160 claimId;
+    CAmount amount(20);
+    int height = 0;
+    int validAtHeight = 0;
+    CClaimValue test_claim(outpoint, claimId, amount, height, validAtHeight);
+
+    CClaimTrieNode base_node;
+    // base node has a claim, so it should not be pruned
+    base_node.insertClaim(test_claim);
+
+    // node 1 has a claim so it should not be pruned
+    CClaimTrieNode node_1;
+    const char c = 't';
+    base_node.children[c] = &node_1;
+    node_1.insertClaim(test_claim);
+    // set this just to make sure we get the right CClaimTrieNode back
+    node_1.nHeightOfLastTakeover = 10;
+
+    //node 2 does not have a claim so it should be pruned
+    // thus we should find pruned node 1 in cache
+    CClaimTrieNode node_2;
+    const char c_2 = 'e';
+    node_1.children[c_2] = &node_2;
+
+    cc.recursivePruneName(&base_node, 0, std::string("te"), NULL);
+    BOOST_CHECK_EQUAL(1, cc.cacheSize());
+    nodeCacheType::iterator it = cc.getCache(std::string("t"));
+    BOOST_CHECK_EQUAL(10, it->second->nHeightOfLastTakeover);
+    BOOST_CHECK_EQUAL(1, it->second->claims.size());
+    BOOST_CHECK_EQUAL(0, it->second->children.size());
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a unit test for function CClaimTrieCache::recursivePruneName()

The new test file claimtriecache_tests.cpp can also contain additional unit tests for CClaimTrieCache in the future which is very lacking as of now.

I had to change use of "private" in CClaimTrieCache to "protected" in order to unit test non-public functions. Not sure if this is the best way but I think its ok. Other classes like CClaimTrie could switch to using "protected" in the future as well for better unit tests. 

