### PR TITLE
Fix a crash bug on node restart when blocks are disconnected

### DIFF
--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -1679,10 +1679,11 @@ void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const C
             if (name == itQueue->name && outPoint == itQueue->outPoint)
                 break;
         }
-    }
-    if (itQueue != itQueueRow->second.end())
-    {
-        itQueueRow->second.erase(itQueue);
+
+        if (itQueue != itQueueRow->second.end())
+        {
+            itQueueRow->second.erase(itQueue);
+        }
     }
 }
 


### PR DESCRIPTION
While looking at related parts, I ran into this uninitialized iterator bug. The expiration queue is empty on restart, so disconnecting a block forces a crash since we're using an uninitialized iterator in that case.