### PR TITLE
use specific version of libevent in reproducible builds

### DIFF
--- a/reproducible_build.sh
+++ b/reproducible_build.sh
@@ -297,7 +297,7 @@ function build_boost() {
 function build_libevent() {
     LIBEVENT_LOG="$1"
     if [ ! -d libevent ]; then
-	git clone https://github.com/libevent/libevent.git
+	git clone --branch release-2.0.22-stable https://github.com/libevent/libevent.git
     fi
     cd libevent
     echo "Building libevent.  tail -f ${LIBEVENT_LOG} to see the details and monitor progress"


### PR DESCRIPTION
In reproducible_build.sh, to build libevent, it would just download from the master branch of libveven'ts github repo without checking out any specific version. 

Download 2.0.22 release instead as specified here: https://github.com/lbryio/lbrycrd/blob/master/depends/packages/libevent.mk 