### PR TITLE
Small fix for best_claim_effective_amount_equals 

### DIFF
--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -74,7 +74,7 @@ best_claim_effective_amount_equals(std::string name, CAmount amount)
     else
     {
         CAmount effective_amount = pclaimTrie->getEffectiveAmountForClaim(name, val.claimId);
-        if (val.nEffectiveAmount != amount)
+        if (effective_amount != amount)
         {
             boost::test_tools::predicate_result res(false);
             res.message()<<amount<<" != "<<effective_amount;


### PR DESCRIPTION
Noticed that in test fixture best_claim_effective_amount_equals, we called getEffectiveAmountForClaim() but never used its result. This is likely why the error in this PR https://github.com/lbryio/lbrycrd/pull/123 was never caught. 

There is not really any functional difference between the original code and this change. 

Noting that a small minor difference is that the effective amount returned in getInfoForName claim value is calculated on demand and may not necessarily be the correct value. For example upon lbrycrdd restart, the effective amount returned by getInfoForName will be garbage because it hasn't been calculated yet.  This has no impact on these unit tests because we do not test restarts. 

