### PR TITLE
Add capability to extend expiration time of pre fork claims

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -131,6 +131,9 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 150; //retarget every block
         consensus.nPowTargetSpacing = 150;
+        consensus.nOriginalClaimExpirationTime = 262974;
+        consensus.nExtendedClaimExpirationTime = 2102400;
+        consensus.nExtendedClaimExpirationForkHeight = 400155;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
@@ -215,6 +218,9 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 150;
         consensus.nPowTargetSpacing = 150;
+        consensus.nOriginalClaimExpirationTime = 262974;
+        consensus.nExtendedClaimExpirationTime = 2102400;
+        consensus.nExtendedClaimExpirationForkHeight = 278160;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
@@ -292,6 +298,9 @@ public:
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 1;//14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 1;
+        consensus.nOriginalClaimExpirationTime = 500;
+        consensus.nExtendedClaimExpirationTime = 600;
+        consensus.nExtendedClaimExpirationForkHeight = 800;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains

--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -218,6 +218,7 @@ bool CClaimTrie::supportQueueEmpty() const
 void CClaimTrie::setExpirationTime(int t)
 {
     nExpirationTime = t;
+    LogPrintf("%s: Expiration time is now %d\n", __func__, nExpirationTime);
 }
 
 void CClaimTrie::clear()
@@ -1119,6 +1120,8 @@ bool CClaimTrie::ReadFromDisk(bool check)
         LogPrintf("%s: Couldn't read the best block's hash\n", __func__);
     if (!db.Read(CURRENT_HEIGHT, nCurrentHeight))
         LogPrintf("%s: Couldn't read the current height\n", __func__);
+    setExpirationTime(Params().GetConsensus().GetExpirationTime(nCurrentHeight-1));
+
     boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&db)->NewIterator());
 
     pcursor->SeekToFirst();
@@ -1699,8 +1702,17 @@ bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outP
 
 void CClaimTrieCache::addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry) const
 {
-    expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(nExpirationHeight, true);
-    itQueueRow->second.push_back(entry);
+    // NOTE: To disable expiration completely after fork, set this define to enable check
+    // #define CLAIM_EXPIRATION_DISABLED_AFTER_FORK
+    #ifdef CLAIM_EXPIRATION_DISABLED_AFTER_FORK
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+    if ((nExpirationHeight < consensusParams.nExtendedClaimExpirationForkHeight) ||
+        (base->nCurrentHeight < consensusParams.nExtendedClaimExpirationForkHeight))
+    #endif
+    {
+        expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(nExpirationHeight, true);
+        itQueueRow->second.push_back(entry);
+    }
 }
 
 void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight) const
@@ -1715,10 +1727,11 @@ void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const C
             if (name == itQueue->name && outPoint == itQueue->outPoint)
                 break;
         }
-    }
-    if (itQueue != itQueueRow->second.end())
-    {
-        itQueueRow->second.erase(itQueue);
+
+        if (itQueue != itQueueRow->second.end())
+        {
+            itQueueRow->second.erase(itQueue);
+        }
     }
 }
 
@@ -2140,6 +2153,7 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
             CClaimValue claim;
             assert(removeClaimFromTrie(itEntry->name, itEntry->outPoint, claim, true));
             expireUndo.push_back(std::make_pair(itEntry->name, claim));
+            LogPrintf("Expiring claim %s: %s, nHeight: %d, nValidAtHeight: %d\n", claim.claimId.GetHex(), itEntry->name, claim.nHeight, claim.nValidAtHeight);
         }
         itExpirationRow->second.clear();
     }
@@ -2191,6 +2205,7 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
             CSupportValue support;
             assert(removeSupportFromMap(itEntry->name, itEntry->outPoint, support, true));
             expireSupportUndo.push_back(std::make_pair(itEntry->name, support));
+            LogPrintf("Expiring support %s: %s, nHeight: %d, nValidAtHeight: %d\n", support.supportedClaimId.GetHex(), itEntry->name, support.nHeight, support.nValidAtHeight);
         }
         itSupportExpirationRow->second.clear();
     }

--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -1695,29 +1695,20 @@ bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outP
     if (removed == true)
     {
         nValidAtHeight = claim.nValidAtHeight;
-        removeFromExpirationQueue(name, outPoint, nHeight);
+        int expirationHeight = nHeight + base->nExpirationTime;
+        removeFromExpirationQueue(name, outPoint, expirationHeight);
     }
     return removed;
 }
 
 void CClaimTrieCache::addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry) const
 {
-    // NOTE: To disable expiration completely after fork, set this define to enable check
-    // #define CLAIM_EXPIRATION_DISABLED_AFTER_FORK
-    #ifdef CLAIM_EXPIRATION_DISABLED_AFTER_FORK
-    const Consensus::Params& consensusParams = Params().GetConsensus();
-    if ((nExpirationHeight < consensusParams.nExtendedClaimExpirationForkHeight) ||
-        (base->nCurrentHeight < consensusParams.nExtendedClaimExpirationForkHeight))
-    #endif
-    {
-        expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(nExpirationHeight, true);
-        itQueueRow->second.push_back(entry);
-    }
+    expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(nExpirationHeight, true);
+    itQueueRow->second.push_back(entry);
 }
 
-void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight) const
+void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int expirationHeight) const
 {
-    int expirationHeight = nHeight + base->nExpirationTime;
     expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(expirationHeight, false);
     expirationQueueRowType::iterator itQueue;
     if (itQueueRow != expirationQueueCache.end())
@@ -2036,7 +2027,8 @@ bool CClaimTrieCache::removeSupport(const std::string& name, const COutPoint& ou
         removed = true;
     if (removed)
     {
-        removeSupportFromExpirationQueue(name, outPoint, nHeight);
+        int expirationHeight = nHeight + base->nExpirationTime;
+        removeSupportFromExpirationQueue(name, outPoint, expirationHeight);
         nValidAtHeight = support.nValidAtHeight;
     }
     return removed;
@@ -2048,9 +2040,8 @@ void CClaimTrieCache::addSupportToExpirationQueue(int nExpirationHeight, nameOut
     itQueueRow->second.push_back(entry);
 }
 
-void CClaimTrieCache::removeSupportFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight) const
+void CClaimTrieCache::removeSupportFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int expirationHeight) const
 {
-    int expirationHeight = nHeight + base->nExpirationTime;
     expirationQueueType::iterator itQueueRow = getSupportExpirationQueueCacheRow(expirationHeight, false);
     expirationQueueRowType::iterator itQueue;
     if (itQueueRow != supportExpirationQueueCache.end())
@@ -2104,6 +2095,7 @@ bool CClaimTrieCache::spendSupport(const std::string& name, const COutPoint& out
 bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const
 {
     LogPrintf("%s: nCurrentHeight (before increment): %d\n", __func__, nCurrentHeight);
+
     claimQueueType::iterator itQueueRow = getQueueCacheRow(nCurrentHeight, false);
     if (itQueueRow != claimQueueCache.end())
     {
@@ -2421,6 +2413,7 @@ bool CClaimTrieCache::decrementBlock(insertUndoType& insertUndo, claimQueueRowTy
     {
         cacheTakeoverHeights[itTakeoverHeightUndo->first] = itTakeoverHeightUndo->second;
     }
+
     return true;
 }
 
@@ -2609,3 +2602,106 @@ CClaimTrieProof CClaimTrieCache::getProofForName(const std::string& name) const
     return CClaimTrieProof(nodes, fNameHasValue, outPoint,
                            nHeightOfLastTakeover);
 }
+
+
+void CClaimTrieCache::removeAndAddToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const
+{
+    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e)
+    {
+        // remove and insert with new expiration time
+        removeFromExpirationQueue(e->name, e->outPoint, height);
+        int extend_expiration = Params().GetConsensus().nExtendedClaimExpirationTime - Params().GetConsensus().nOriginalClaimExpirationTime;
+        int new_expiration_height = increment ? height + extend_expiration : height - extend_expiration;
+        nameOutPointType entry(e->name, e->outPoint);
+        addToExpirationQueue(new_expiration_height, entry);
+    }
+
+}
+
+void CClaimTrieCache::removeAndAddSupportToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const
+{
+    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e)
+    {
+        // remove and insert with new expiration time
+        removeSupportFromExpirationQueue(e->name, e->outPoint, height);
+        int extend_expiration = Params().GetConsensus().nExtendedClaimExpirationTime - Params().GetConsensus().nOriginalClaimExpirationTime;
+        int new_expiration_height = increment ? height + extend_expiration : height - extend_expiration;
+        nameOutPointType entry(e->name, e->outPoint);
+        addSupportToExpirationQueue(new_expiration_height, entry);
+    }
+
+}
+
+bool CClaimTrieCache::forkForExpirationChange(bool increment) const
+{
+    /*
+    If increment is True, we have forked to extend the expiration time, thus items in the expiration queue
+    will have their expiration extended by "new expiration time - original expiration time"
+
+    If increment is False, we are decremented a block to reverse the fork. Thus items in the expiration queue
+    will have their expiration extension removed.
+    */
+
+    // look through dirty expiration queues
+    std::set<int> dirtyHeights;
+    for (expirationQueueType::const_iterator i = base->dirtyExpirationQueueRows.begin(); i != base->dirtyExpirationQueueRows.end(); ++i)
+    {
+        int height = i->first;
+        dirtyHeights.insert(height);
+        expirationQueueRowType row = i->second;
+        removeAndAddToExpirationQueue(row, height, increment);
+    }
+
+    std::set<int> dirtySupportHeights;
+    for (expirationQueueType::const_iterator i = base->dirtySupportExpirationQueueRows.begin(); i != base->dirtySupportExpirationQueueRows.end(); ++i)
+    {
+        int height = i->first;
+        dirtySupportHeights.insert(height);
+        expirationQueueRowType row = i->second;
+        removeAndAddSupportToExpirationQueue(row, height, increment);
+    }
+
+
+    //look through db for expiration queues, if we haven't already found it in dirty expiration queue
+    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&base->db)->NewIterator());
+    pcursor->SeekToFirst();
+    while (pcursor->Valid())
+    {
+        std::pair<char, int> key;
+        if (pcursor->GetKey(key))
+        {
+            int height = key.second;
+            // if we've looked throught this in dirtyExprirationQueueRows, don't use it
+            // because its stale
+            if ((key.first == EXP_QUEUE_ROW) & (dirtyHeights.count(height) == 0))
+            {
+                expirationQueueRowType row;
+                if (pcursor->GetValue(row))
+                {
+                    removeAndAddToExpirationQueue(row, height, increment);
+                }
+                else
+                {
+                    return error("%s(): error reading expiration queue rows from disk", __func__);
+                }
+            }
+            else if ((key.first == SUPPORT_EXP_QUEUE_ROW) & (dirtySupportHeights.count(height) == 0))
+            {
+                expirationQueueRowType row;
+                if (pcursor->GetValue(row))
+                {
+                    removeAndAddSupportToExpirationQueue(row, height, increment);
+                }
+                else
+                {
+                    return error("%s(): error reading support expiration queue rows from disk", __func__);
+                }
+            }
+
+        }
+        pcursor->Next();
+    }
+
+    return true;
+}
+

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -517,6 +517,13 @@ public:
     CClaimTrieProof getProofForName(const std::string& name) const;
 
     bool finalizeDecrement() const;
+
+    void removeAndAddSupportToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const;
+    void removeAndAddToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const;
+
+    bool forkForExpirationChange(bool increment) const;
+
+
 protected:
     CClaimTrie* base;
 

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -6,6 +6,7 @@
 #include "uint256.h"
 #include "util.h"
 #include "dbwrapper.h"
+#include "chainparams.h"
 #include "primitives/transaction.h"
 
 #include <string>
@@ -299,7 +300,7 @@ class CClaimTrie
 public:
     CClaimTrie(bool fMemory = false, bool fWipe = false, int nProportionalDelayFactor = 32)
                : db(GetDataDir() / "claimtrie", 100, fMemory, fWipe, false)
-               , nCurrentHeight(0), nExpirationTime(262974)
+               , nCurrentHeight(0), nExpirationTime(Params().GetConsensus().nOriginalClaimExpirationTime)
                , nProportionalDelayFactor(nProportionalDelayFactor)
                , root(uint256S("0000000000000000000000000000000000000000000000000000000000000001"))
     {}

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -58,6 +58,14 @@ struct Params {
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
+    int64_t nOriginalClaimExpirationTime;
+    int64_t nExtendedClaimExpirationTime;
+    int64_t nExtendedClaimExpirationForkHeight;
+    int64_t GetExpirationTime(int64_t nHeight) const {
+        return nHeight < nExtendedClaimExpirationForkHeight ?
+            nOriginalClaimExpirationTime :
+            nExtendedClaimExpirationTime;
+    }
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
 };
 } // namespace Consensus

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1229,6 +1229,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheUsage * (1.0 / 1024 / 1024));
 
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+
     bool fLoaded = false;
     while (!fLoaded) {
         bool fReset = fReindex;
@@ -1266,7 +1268,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
-                if (!mapBlockIndex.empty() && mapBlockIndex.count(chainparams.GetConsensus().hashGenesisBlock) == 0)
+                if (!mapBlockIndex.empty() && mapBlockIndex.count(consensusParams.hashGenesisBlock) == 0)
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
 
                 // Initialize the block index (no-op if non-empty database was already loaded)
@@ -1422,6 +1424,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     RandAddSeedPerfmon();
 
+    pclaimTrie->setExpirationTime(consensusParams.GetExpirationTime(chainActive.Height()));
+
     //// debug print
     LogPrintf("mapBlockIndex.size() = %u\n",   mapBlockIndex.size());
     LogPrintf("nBestHeight = %d\n",                   chainActive.Height());
@@ -1437,7 +1441,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     StartNode(threadGroup, scheduler);
 
     // Monitor the chain, and alert if we get blocks much quicker or slower than expected
-    int64_t nPowTargetSpacing = Params().GetConsensus().nPowTargetSpacing;
+    int64_t nPowTargetSpacing = consensusParams.nPowTargetSpacing;
     CScheduler::Function f = boost::bind(&PartitionCheck, &IsInitialBlockDownload,
                                          boost::ref(cs_main), boost::cref(pindexBestHeader), nPowTargetSpacing);
     scheduler.scheduleEvery(f, nPowTargetSpacing);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2236,6 +2236,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     {
         LogPrintf("Decremented past the extended claim expiration hard fork height");
         pclaimTrie->setExpirationTime(Params().GetConsensus().GetExpirationTime(pindex->nHeight-1));
+        trieCache.forkForExpirationChange(false);
     }
 
 
@@ -2504,6 +2505,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     {
         LogPrintf("Incremented past the extended claim expiration hard fork height");
         pclaimTrie->setExpirationTime(chainparams.GetConsensus().GetExpirationTime(pindex->nHeight));
+        trieCache.forkForExpirationChange(true);
     }
 
 

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -23,7 +23,6 @@ using namespace std;
 
 BOOST_FIXTURE_TEST_SUITE(claimtriebranching_tests, RegTestingSetup)
 
-
 //is a claim in queue 
 boost::test_tools::predicate_result
 is_claim_in_queue(std::string name, const CTransaction &tx)
@@ -164,7 +163,16 @@ struct ClaimTrieChainFixture{
     unsigned int num_txs; 
     unsigned int num_txs_for_next_block; 
 
-    ClaimTrieChainFixture()
+    // these will take on regtest parameters
+    const int expirationForkHeight;
+    const int originalExpiration;
+    const int extendedExpiration;
+
+
+    ClaimTrieChainFixture():
+        expirationForkHeight(Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationForkHeight),
+        originalExpiration(Params(CBaseChainParams::REGTEST).GetConsensus().nOriginalClaimExpirationTime),
+        extendedExpiration(Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationTime)
     {
         fRequireStandard = false;
         BOOST_CHECK(pclaimTrie->nCurrentHeight == chainActive.Height() + 1);
@@ -298,6 +306,17 @@ struct ClaimTrieChainFixture{
         }
         mempool.clear();
         num_txs_for_next_block = 0; 
+    }
+
+
+    void WriteClearReadClaimTrie()
+    {
+        // this will simulate restart of lbrycrdd by writing the claimtrie to disk,
+        // clearing the-in memory claimtrie, and then reading the saved claimtrie
+        // from disk
+        pclaimTrie->WriteToDisk();
+        pclaimTrie->clear();
+        pclaimTrie->ReadFromDisk(true);
     }
 
 };
@@ -846,76 +865,68 @@ BOOST_AUTO_TEST_CASE(claimtriebranching_get_claim_by_id)
 }
 
 /*
-    expiration
+    claim expiration for hard fork
         check claims do not expire post ExpirationForkHeight
         check supports work post ExpirationForkHeight
 */
-BOOST_AUTO_TEST_CASE(claimtriebranching_no_expire)
+BOOST_AUTO_TEST_CASE(claimtriebranching_hardfork_claim)
 {
     ClaimTrieChainFixture fixture;
 
-    // To activate the expiration hard fork, the expiration time must
-    // be set to 10 years of blocks (not used as 10 years, but rather
-    // a sentinel value for hard fork activation) and we must advance
-    // past nExtendedClaimExpirationForkHeight.  This is purposely set
-    // low enough for testing in the Regtest chain parameters.
-    const int expirationForkHeight =
-        Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationForkHeight;
-    const int originalExpiration =
-        Params(CBaseChainParams::REGTEST).GetConsensus().nOriginalClaimExpirationTime;
-    const int extendedExpiration =
-        Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationTime;
-
-    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, originalExpiration);
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.originalExpiration);
     // First create a claim and make sure it expires pre-fork
     CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",3);
-    fixture.IncrementBlocks(originalExpiration+1);
+    fixture.IncrementBlocks(fixture.originalExpiration+1);
     BOOST_CHECK(!is_best_claim("test",tx1));
-    fixture.DecrementBlocks(originalExpiration);
+    fixture.DecrementBlocks(fixture.originalExpiration);
     BOOST_CHECK(is_best_claim("test",tx1));
-    fixture.IncrementBlocks(originalExpiration);
+    fixture.IncrementBlocks(fixture.originalExpiration);
     BOOST_CHECK(!is_best_claim("test",tx1));
 
     // Create a claim 1 block before the fork height that will expire after the fork height
-    fixture.IncrementBlocks(expirationForkHeight - chainActive.Height() -2);
+    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height() -2);
     CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test2","one",3);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK_EQUAL(chainActive.Height(), expirationForkHeight -1);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight -1);
 
     // Disable future expirations and fast-forward past the fork height
     fixture.IncrementBlocks(1);
-    BOOST_CHECK_EQUAL(chainActive.Height(), expirationForkHeight);
-    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, extendedExpiration);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight);
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.extendedExpiration);
     // make sure decrementing to before the fork height will apppropriately set back the
     // expiration time to the original expiraiton time
     fixture.DecrementBlocks(1);
-    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, originalExpiration);
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.originalExpiration);
     fixture.IncrementBlocks(1);
 
     // make sure that claim created 1 block before the fork expires as expected
-    // at the original expiration times
+    // at the extended expiration times
     BOOST_CHECK(is_best_claim("test2", tx2));
-    fixture.IncrementBlocks(originalExpiration-1);
+    fixture.IncrementBlocks(fixture.extendedExpiration-1);
     BOOST_CHECK(!is_best_claim("test2", tx2));
-    fixture.DecrementBlocks(originalExpiration-1);
+    fixture.DecrementBlocks(fixture.extendedExpiration-1);
 
     // This first claim is still expired since it's pre-fork, even
     // after fork activation
     BOOST_CHECK(!is_best_claim("test",tx1));
 
     // This new claim created at the fork height cannot expire at original expiration
-    BOOST_CHECK_EQUAL(chainActive.Height(), expirationForkHeight);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight);
     CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
     fixture.IncrementBlocks(1);
-    fixture.IncrementBlocks(originalExpiration);
+    fixture.IncrementBlocks(fixture.originalExpiration);
     BOOST_CHECK(is_best_claim("test",tx3));
     BOOST_CHECK(!is_best_claim("test",tx1));
-    fixture.DecrementBlocks(originalExpiration);
+    fixture.DecrementBlocks(fixture.originalExpiration);
 
-    // but it expires at the extended expiration
-    fixture.IncrementBlocks(extendedExpiration);
+    // but it expires at the extended expiration, and not a single block below
+    fixture.IncrementBlocks(fixture.extendedExpiration);
     BOOST_CHECK(!is_best_claim("test",tx3));
-    fixture.DecrementBlocks(extendedExpiration);
+    fixture.DecrementBlocks(fixture.extendedExpiration);
+    fixture.IncrementBlocks(fixture.extendedExpiration-1);
+    BOOST_CHECK(is_best_claim("test",tx3));
+    fixture.DecrementBlocks(fixture.extendedExpiration-1);
+
 
     // Ensure that we cannot update the original pre-fork expired claim
     CMutableTransaction u1 = fixture.MakeUpdate(tx1,"test","two",ClaimIdHash(tx1.GetHash(),0), 3);
@@ -936,5 +947,121 @@ BOOST_AUTO_TEST_CASE(claimtriebranching_no_expire)
     BOOST_CHECK(is_best_claim("test",u2));
 }
 
+/*
+    support expiration for hard fork
+*/
+BOOST_AUTO_TEST_CASE(claimtriebranching_hardfork_support)
+{
+    ClaimTrieChainFixture fixture;
+
+    int blocks_before_fork = 10;
+    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height() - blocks_before_fork-1); 
+    // Create claim and support it before the fork height
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",2);
+    // this claim will win without the support
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    fixture.IncrementBlocks(1);
+    fixture.IncrementBlocks(blocks_before_fork);
+
+    // check that the claim expires as expected at the extended time, as does the support
+    fixture.IncrementBlocks(fixture.originalExpiration - blocks_before_fork);
+    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
+    fixture.DecrementBlocks(fixture.originalExpiration - blocks_before_fork);
+    fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork);
+    BOOST_CHECK(!is_best_claim("test",tx1));
+    fixture.DecrementBlocks(fixture.extendedExpiration - blocks_before_fork);
+    fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork - 1);
+    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
+    fixture.DecrementBlocks(fixture.extendedExpiration - blocks_before_fork - 1);
+
+    // update the claims at fork
+    fixture.DecrementBlocks(1);
+    CMutableTransaction u1 = fixture.MakeUpdate(tx1,"test","two",ClaimIdHash(tx1.GetHash(),0),1);
+    CMutableTransaction u2 = fixture.MakeUpdate(tx2,"test","two",ClaimIdHash(tx2.GetHash(),0),2);
+    fixture.IncrementBlocks(1);
+    BOOST_CHECK_EQUAL(fixture.expirationForkHeight, chainActive.Height());
+
+    BOOST_CHECK(is_best_claim("test", u1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
+    BOOST_CHECK(!is_claim_in_queue("test",tx1));
+    BOOST_CHECK(!is_claim_in_queue("test",tx2));
+
+    // check that the support expires as expected
+    fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork);
+    BOOST_CHECK(is_best_claim("test",u2));
+    fixture.DecrementBlocks(fixture.extendedExpiration - blocks_before_fork);
+    fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork - 1);
+    BOOST_CHECK(is_best_claim("test",u1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
+
+}
+
+/*
+    claim/support expiration for hard fork, but with checks for disk procedures
+*/
+BOOST_AUTO_TEST_CASE(claimtriebranching_hardfork_disktest)
+{
+    ClaimTrieChainFixture fixture;
+
+    // Check that incrementing to fork height, reseting to disk will get proper expiration time
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.originalExpiration);
+    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height());
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight);
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.extendedExpiration);
+    fixture.WriteClearReadClaimTrie();
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.extendedExpiration);
+
+    // Create a claim and support 1 block before the fork height that will expire after the fork height.
+    // Reset to disk, increment past the fork height and make sure we get
+    // proper behavior
+    fixture.DecrementBlocks(2);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",1);
+    fixture.IncrementBlocks(1);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight -1);
+
+    fixture.WriteClearReadClaimTrie();
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight-1);
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.originalExpiration);
+    fixture.IncrementBlocks(1);
+    BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.extendedExpiration);
+    BOOST_CHECK(is_best_claim("test", tx1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    fixture.IncrementBlocks(fixture.originalExpiration-1);
+    BOOST_CHECK(is_best_claim("test", tx1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    fixture.DecrementBlocks(fixture.originalExpiration-1);
+    fixture.IncrementBlocks(fixture.extendedExpiration-1);
+    BOOST_CHECK(!is_best_claim("test", tx1));
+
+    // Create a claim and support before the fork height, reset to disk, update the claim
+    // increment past the fork height and make sure we get proper behavior
+    int  height_of_update_before_expiration = 50;
+    fixture.DecrementBlocks(chainActive.Height() - fixture.expirationForkHeight + height_of_update_before_expiration+2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test2","one",1);
+    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(),tx2,"test2",1);
+    fixture.IncrementBlocks(1);
+    fixture.WriteClearReadClaimTrie();
+    CMutableTransaction u2 = fixture.MakeUpdate(tx2,"test2","two",ClaimIdHash(tx2.GetHash(),0),1);
+    // increment to fork
+    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height());
+    BOOST_CHECK(is_best_claim("test2", u2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test2",2));
+    // increment to original expiration, should not be expired
+    fixture.IncrementBlocks(fixture.originalExpiration - height_of_update_before_expiration);
+    BOOST_CHECK(is_best_claim("test2", u2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test2",2));
+    fixture.DecrementBlocks(fixture.originalExpiration - height_of_update_before_expiration);
+    // increment to extended expiration, should be expired and not one block before
+    fixture.IncrementBlocks(fixture.extendedExpiration - height_of_update_before_expiration);
+    BOOST_CHECK(!is_best_claim("test2", u2));
+    fixture.DecrementBlocks(fixture.extendedExpiration - height_of_update_before_expiration);
+    fixture.IncrementBlocks(fixture.extendedExpiration - height_of_update_before_expiration-1);
+    BOOST_CHECK(is_best_claim("test2", u2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test2",1)); // the support expires one block before
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Details of hard fork for all:**

The fork of the mainnet will be on block 400155 (will be around noon EST 7/9/18) 

The fork of the testnet will be on block 280831 (will be around noon EST 5/21/18)

Claims made on and after the target hardfork blocks will expire after 2102400 blocks (approximately 10 years assuming block time 2.5 minutes).

Claims that were made before the hardfork and have not expired will have their expiration extended by the difference between the new expiration time and the previous expiration time (456 days). 

Claims that already expired will remain expired. 

**Details for reviewers**

This is further work off of : https://github.com/lbryio/lbrycrd/pull/110 in order to add the extension of claim expiration to already existing claims ( in #110 claims made before the hard fork would still expire at the old expiration time)

While working on this, I made two adjustments to #110. A) the first was that the new expiration time took effect 1 block after the target hard fork block, and not on the target hard fork block. It would be more intuitive if the new expiration time took effect on the target hard fork block. B) I fixed the logic of calling setExpirationTime() to only be called when we are at the target hard fork block, instead of on every block. This is more intuitive and in line with the soft-fork logic that is already present for Bitcoin. This means we need to also called setExpirationTime when we load the claimtrie from disk so I did that.  The combination of A) and B) fixes a bug in #110 where if you loaded the claimtrie from disk (restarted lbrycrdd) than you expiration time for the first block after restart would be the old expiration time instead of the new one even after the hard fork. 

The above work is on https://github.com/lbryio/lbrycrd/pull/137/commits/2df3bb104b29f5f1cd0615efbe33ab46bc1aca53

While working on extending the expiration of existing claims, I realized that #110 had the problem where it would not properly be able to remove expirations from the expiration queue properly.  This is because the function removeFromExpirationQueue() : https://github.com/lbryio/lbrycrd/blob/master/src/claimtrie.cpp#L1675 was not adjusted to consider the hard fork change in expiration time hence this line: https://github.com/lbryio/lbrycrd/blob/master/src/claimtrie.cpp#L1677 could calculate the wrong expiration time for a claim that was created before the hard fork an expires after the hard fork. 

The way we extend the claim is fairly straight forward. When we encounter the hard fork block, we set the new expiration time, and we look at all the entries in the expiration queue either in the dirty queue (where entries that are not saved to disk resides) or the disk database. The entries are adjusted to have their expiration time extended by the difference between the new expiration time and the old expiration time. Effectively, this makes it look like all the claims share the same new expiration time so the issue I described is solved. 

The above work on extending the expiraiton of existing claims is on 
b3aa62c 

For the unit tests, I added a series of tests to see if supports behaved properly, and also added tests to see if the claimtrie behaved properly on the hard fork if I simulated a restart (write claimtrie to disk, clear it in memory, and than read it from disk). https://github.com/lbryio/lbrycrd/pull/137/commits/6621f50b985d49a5b5c4c09b32d871c58fa54121

The other commits should be straight forward. 