### PR TITLE
fix fPowAllowMinDifficultyBlocks to work on the testnet

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -14,31 +14,20 @@
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
-
     // Genesis block
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
 
-    // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
+    if (params.fPowAllowMinDifficultyBlocks)
     {
-        if (params.fPowAllowMinDifficultyBlocks)
-        {
-            // Special difficulty rule for testnet:
-            // If the new block's timestamp is more than 2* 10 minutes
-            // then allow mining of a min-difficulty block.
-            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
-                return nProofOfWorkLimit;
-            else
-            {
-                // Return the last non-special-min-difficulty-rules-block
-                const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
-                    pindex = pindex->pprev;
-                return pindex->nBits;
-            }
+        // Special difficulty rule for testnet:
+        // If the new block's timestamp is twice the target block time
+        // then allow mining of a min-difficulty block.
+        // This is to prevent the testnet from gettig stuck when a large amount
+        // of hashrate drops off the network.
+        if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2){
+            return nProofOfWorkLimit;
         }
-        return pindexLast->nBits;
     }
 
     // Go back the full period unless it's the first retarget after genesis.


### PR DESCRIPTION
chainparams parameter : fPowAllowMinDifficultyBlocks , which is set to true only on testnet, was designed to allow the difficulty to adjust to the minimum difficulty if a block was not found within 2x target block time. 

This parameter was not working due to the fact that we'd never enter the if statement in line https://github.com/lbryio/lbrycrd/blob/master/src/pow.cpp#L23  since our params.DifficultyAdjustmentInterval() is 1 

This has been fixed and should allow testnet to proceed when a large amount of hashrate drops off the network.



