### PR TITLE
docker: Lbrynet as a container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+image: ubuntu:18.04
+
+before_script:
+  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+
+build:
+  stage: build
+  script:
+  ## Add a prep.sh file eventually when we add a configuration function to this container.
+  # - ./docker/prep.sh
+  - docker build -t registry.gitlab.com/chamunks/lbry/$CI_COMMIT_REF_NAME:latest .
+  - docker-compose stop
+  - docker-compose rm -f
+  - docker-compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+## Base Image
+FROM ubuntu:18.04
+MAINTAINER chamunks [at] gmail [dot] com
+
+RUN apt-get update && apt-get -y install unzip
+# RUN mkdir -pv /app && chown 1000:1000 /app
+RUN adduser lbrynet --gecos GECOS --shell /bin/bash/ --disabled-password --home /app/
+
+## Add lbrynet
+ADD https://lbry.io/get/lbrynet.linux.zip /app/lbrynet.linux.zip
+RUN unzip /app/lbrynet.linux.zip -d /app/ && \
+    rm /app/lbrynet.linux.zip && \
+    chown -Rv lbrynet:lbrynet /app
+
+## Install into PATH
+RUN mv /app/lbrynet-* /bin/ && \
+    ls -lAh /bin/
+
+## Daemon port
+EXPOSE 4444
+# ## Peer port
+# EXPOSE 3333
+## Wallet port
+EXPOSE 50001
+
+## Undocumented ports that exist in conf.py
+## API port
+# EXPOSE 5279
+# ## Reflector port
+# EXPOSE 5566
+
+# VOLUME /app/.local/share/lbry/lbryum/wallets
+# VOLUME /app/.local/
+## Not sure where this is going to be.
+# VOLUME /app/.config/conf.py
+# VOLUME /app/Downloads/
+
+## Never run container processes as root
+USER lbrynet
+## Run on container launch
+CMD ["lbrynet-daemon"]
+
+## Setting this entrypoint should mean that you can `docker exec lbrynet commands`
+## and you should be able to control the daemon's CLI this way.  There is an
+## alternative method we could use here where we have an entrypoint shell script which could be a bit smarter.
+# ENTRYPOINT ["lbrynet-cli"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+## To-Do:
+## * [] setup webhooks in gitlab on projects that build containers for this.
+## * [] Get the thing tested & perfected.
+## * [] Healthchecks on all containers ideally without needing a custom container.
+version: '3.4'
+services:
+
+#############
+## Lbrynet ##
+#############
+  lbrynet:
+    build: .
+    restart: always
+    ports:
+      - 4444:4444
+      - 50001:50001
+    ## host volumes for persistent data such as wallet private keys.
+    volumes:
+      - ./data/:/app

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+## Speech-As-A-Container
+
+I'll document a bit of this later but for now you may look over ```docker-compose.yml``` and then modify any environment variables you feel the need to.
+
+#### Invocation
+
+```docker-compose up -d```
+
+#### Executing commands
+
+To list containers on the host execute `docker ps -a` then run `docker exec CONTAINERNAME lbrynet-cli commands`
+
+#### Docker Directory
+
+This directory is in case we need to expand the functionality of this container at some point in the future.


### PR DESCRIPTION
## Documentation 

Added some basic documentation to docker/README.md it can be used elsewhere but at some point if we add other things which end up justifying that the end user run a `git clone` and then `docker-compose up -d` from inside of the git repo of lbrycrd we can let them store data in docker/data/ with some fancy git ignoring.

## Docker Compose
For the sake of getting people launched asap I've included a basic docker-compose.yml file which can launch the app with `docker-compose up -d` then commands can be run using `docker exec CONTAINERNAME lbrynet-cli commands`

## .gitlab-ci.yml
This is for CI/CD prebuild and deploy if we want to use GitLab for building these containers rather than the hub.docker.com route.  Currently, this is just configured to show what it would look like with my repositories.

## Dockerfile

Currently, the dockerfile is very basic and just installs the daemon into the containers $PATH for easy execution then it stores the daemons content in /app/ as that is defined as the unprivileged daemon processes home directory. 

## Commit size
https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention the version I was working from in my topic branch was hugely out of date so rather than carrying over all of the commits I just added everything fresh I know that it's lazy but this code doesn't meddle with anyone's stuff so it seemed like it should be okay to do it this way.

## Maintainance

This container should be reasonably future proof for now as I've defined all non-ephemeral blobs to reside in the /app/ directory inside of the container which can be updated at a later time just fine.

The configuration will be added using a shell script in the future which can be optionally included.  The goal is to allow configuration using environment variables in the docker-compose.yml file which will be the officially supported launch method as it's the least maintenance method. 