### PR TITLE
normalize difficulty so that 1 == minimum difficulty

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -48,12 +48,12 @@ double GetDifficulty(const CBlockIndex* blockindex)
     double dDiff =
         (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
 
-    while (nShift < 29)
+    while (nShift < 31)
     {
         dDiff *= 256.0;
         nShift++;
     }
-    while (nShift > 29)
+    while (nShift > 31)
     {
         dDiff /= 256.0;
         nShift--;


### PR DESCRIPTION
Lbrycrd's maximum target is 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff or in nBits 0x1f00ffff, compared to Bitcoin's maximum nBits 0x1d00ffff

We never adjusted the GetDifficulty() function to reflect this change (29 == 0x1d , 32==0x1f). This change makes it so that the lowest difficulty we can have is 1 , instead of some decimal number. 

I'm not aware of any applications that uses this difficulty readings from RPC commands so its probably ok to change this.   

See https://en.bitcoin.it/wiki/Difficulty for more info.