### PR TITLE
Sanitize claimtrie RPC commands.

### DIFF
--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -380,6 +380,10 @@ UniValue getclaimbyid(const UniValue& params, bool fHelp)
         );
 
     LOCK(cs_main);
+
+    // Used for validation.
+    ParseHashV(params[0], "Claim-id (parameter 1)");
+
     uint160 claimId;
     claimId.SetHex(params[0].get_str());
     UniValue claim(UniValue::VOBJ);
@@ -512,10 +516,7 @@ UniValue getclaimsfortx(const UniValue& params, bool fHelp)
         );
 
     LOCK(cs_main);
-
-    uint256 hash;
-    hash.SetHex(params[0].get_str());
-
+    uint256 hash = ParseHashV(params[0], "txid (parameter 1)");
     UniValue ret(UniValue::VARR);
 
     int op;
@@ -741,8 +742,7 @@ UniValue getnameproof(const UniValue& params, bool fHelp)
     uint256 blockHash;
     if (params.size() == 2)
     {
-        std::string strBlockHash = params[1].get_str();
-        blockHash = uint256S(strBlockHash);
+        uint256 hash = ParseHashV(params[1], "blockhash (optional parameter 2)");
     }
     else
     {

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -382,7 +382,7 @@ UniValue getclaimbyid(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     // Used for validation.
-    ParseHashV(params[0], "Claim-id (parameter 1)");
+    ParseHexV(params[0], "Claim-id (parameter 1)");
 
     uint160 claimId;
     claimId.SetHex(params[0].get_str());
@@ -742,7 +742,7 @@ UniValue getnameproof(const UniValue& params, bool fHelp)
     uint256 blockHash;
     if (params.size() == 2)
     {
-        uint256 hash = ParseHashV(params[1], "blockhash (optional parameter 2)");
+        blockHash = ParseHashV(params[1], "blockhash (optional parameter 2)");
     }
     else
     {

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -7,6 +7,22 @@
 // Maximum block decrement that is allowed from rpc calls
 const int MAX_RPC_BLOCK_DECREMENTS = 50;
 
+uint160 ParseClaimtrieId(const UniValue& v, std::string strName)
+{
+    std::string strHex;
+    if (v.isStr())
+        strHex = v.get_str();
+    if (!IsHex(strHex)) // Note: IsHex("") is false
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be a 20-character hexadecimal string (not '"+strHex+"')");
+    if (40 != strHex.length())
+      throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s must be of length %d (not %d)", strName, 40, strHex.length()));
+
+    uint160 result;
+    result.SetHex(strHex);
+    return result;
+}
+
+
 UniValue getclaimsintrie(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 0)
@@ -380,12 +396,7 @@ UniValue getclaimbyid(const UniValue& params, bool fHelp)
         );
 
     LOCK(cs_main);
-
-    // Used for validation.
-    ParseHexV(params[0], "Claim-id (parameter 1)");
-
-    uint160 claimId;
-    claimId.SetHex(params[0].get_str());
+    uint160 claimId = ParseClaimtrieId(params[0], "Claim-id (parameter 1)");
     UniValue claim(UniValue::VOBJ);
     std::string name;
     CClaimValue claimValue;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -336,13 +336,16 @@ BOOST_AUTO_TEST_CASE(rpc_claimtrie_validation) {
     // std::runtime_error: parameter 2 must be hexadecimal string (not 'not_hex')
     BOOST_CHECK_THROW(CallRPC("getnameproof test not_hex"), runtime_error);
     // std::runtime_error: Block not found
-    BOOST_CHECK_THROW(CallRPC("getnameproof test a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("getnameproof test abcd"), runtime_error);
+    // Generate a block to validate the NO_THROW case.
+    UniValue result = CallRPC("generate 1");
+    BOOST_CHECK_NO_THROW(CallRPC(string("getnameproof test ") + result[0].get_str()));
 
     BOOST_CHECK_THROW(CallRPC("getclaimsfortx not_hex"), runtime_error);
-    BOOST_CHECK_NO_THROW(CallRPC("getclaimsfortx a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed"));
+    BOOST_CHECK_NO_THROW(CallRPC("getclaimsfortx abcd"));
 
     BOOST_CHECK_THROW(CallRPC("getclaimbyid not_hex"), runtime_error);
-    BOOST_CHECK_NO_THROW(CallRPC("getclaimbyid a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed"));
+    BOOST_CHECK_NO_THROW(CallRPC("getclaimbyid abcd"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -332,4 +332,17 @@ BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
     BOOST_CHECK_EQUAL(result[2].get_int(), 9);
 }
 
+BOOST_AUTO_TEST_CASE(rpc_claimtrie_validation) {
+    // std::runtime_error: parameter 2 must be hexadecimal string (not 'not_hex')
+    BOOST_CHECK_THROW(CallRPC("getnameproof test not_hex"), runtime_error);
+    // std::runtime_error: Block not found
+    BOOST_CHECK_THROW(CallRPC("getnameproof test a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed"), runtime_error);
+
+    BOOST_CHECK_THROW(CallRPC("getclaimsfortx not_hex"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("getclaimsfortx a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed"));
+
+    BOOST_CHECK_THROW(CallRPC("getclaimbyid not_hex"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("getclaimbyid a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -336,16 +336,18 @@ BOOST_AUTO_TEST_CASE(rpc_claimtrie_validation) {
     // std::runtime_error: parameter 2 must be hexadecimal string (not 'not_hex')
     BOOST_CHECK_THROW(CallRPC("getnameproof test not_hex"), runtime_error);
     // std::runtime_error: Block not found
-    BOOST_CHECK_THROW(CallRPC("getnameproof test abcd"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("getnameproof test aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), runtime_error);
     // Generate a block to validate the NO_THROW case.
     UniValue result = CallRPC("generate 1");
     BOOST_CHECK_NO_THROW(CallRPC(string("getnameproof test ") + result[0].get_str()));
 
     BOOST_CHECK_THROW(CallRPC("getclaimsfortx not_hex"), runtime_error);
-    BOOST_CHECK_NO_THROW(CallRPC("getclaimsfortx abcd"));
+    BOOST_CHECK_NO_THROW(CallRPC("getclaimsfortx aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
     BOOST_CHECK_THROW(CallRPC("getclaimbyid not_hex"), runtime_error);
-    BOOST_CHECK_NO_THROW(CallRPC("getclaimbyid abcd"));
+    // Wrong length.
+    BOOST_CHECK_THROW(CallRPC("getclaimbyid a"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("getclaimbyid aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Change for issue #125

I wasn't exactly sure how you deal with upstream test changes, but I'm pretty sure this isn't it. For now, I went ahead and updated the existing `rpc_tests` suite instead of copying over the CallRPC utility. Is there a better spot, or approach?