### PR TITLE
Separate disk related functions in CClaimTrieDb

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,7 @@ BITCOIN_CORE_H = \
   miner.h \
   nameclaim.h \
   claimtrie.h \
+  claimtriedb.h \
   lbry.h \
   net.h \
   netbase.h \
@@ -191,6 +192,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   claimtrie.cpp \
+  claimtriedb.cpp \
   net.cpp \
   noui.cpp \
   policy/fees.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -62,6 +62,7 @@ BITCOIN_TESTS =\
   test/multisig_tests.cpp \
   test/claimtriecache_tests.cpp \
   test/claimtriebranching_tests.cpp \
+  test/claimtriedb_tests.cpp \
   test/nameclaim_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \

--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -2,9 +2,13 @@
 #include "coins.h"
 #include "hash.h"
 
-#include <boost/scoped_ptr.hpp>
-#include <iostream>
 #include <algorithm>
+#include <iostream>
+
+#define HASH_BLOCK 'h'
+#define CURRENT_HEIGHT 't'
+
+const uint256 one = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
 
 std::vector<unsigned char> heightToVch(int n)
 {
@@ -21,7 +25,7 @@ std::vector<unsigned char> heightToVch(int n)
     return vchHeight;
 }
 
-uint256 getValueHash(COutPoint outPoint, int nHeightOfLastTakeover)
+uint256 getValueHash(const COutPoint& outPoint, int nHeightOfLastTakeover)
 {
     CHash256 txHasher;
     txHasher.Write(outPoint.hash.begin(), outPoint.hash.size());
@@ -32,7 +36,7 @@ uint256 getValueHash(COutPoint outPoint, int nHeightOfLastTakeover)
     std::stringstream ss;
     ss << outPoint.n;
     std::string snOut = ss.str();
-    nOutHasher.Write((unsigned char*) snOut.data(), snOut.size());
+    nOutHasher.Write((unsigned char*)snOut.data(), snOut.size());
     std::vector<unsigned char> vchnOutHash(nOutHasher.OUTPUT_SIZE);
     nOutHasher.Finalize(&(vchnOutHash[0]));
 
@@ -53,7 +57,7 @@ uint256 getValueHash(COutPoint outPoint, int nHeightOfLastTakeover)
     return valueHash;
 }
 
-bool CClaimTrieNode::insertClaim(CClaimValue claim)
+bool CClaimTrieNode::insertClaim(const CClaimValue& claim)
 {
     LogPrintf("%s: Inserting %s:%d (amount: %d)  into the claim trie\n", __func__, claim.outPoint.hash.ToString(), claim.outPoint.n, claim.nAmount);
     claims.push_back(claim);
@@ -65,24 +69,18 @@ bool CClaimTrieNode::removeClaim(const COutPoint& outPoint, CClaimValue& claim)
     LogPrintf("%s: Removing txid: %s, nOut: %d from the claim trie\n", __func__, outPoint.hash.ToString(), outPoint.n);
 
     std::vector<CClaimValue>::iterator itClaims;
-    for (itClaims = claims.begin(); itClaims != claims.end(); ++itClaims)
-    {
-        if (itClaims->outPoint == outPoint)
-        {
+    for (itClaims = claims.begin(); itClaims != claims.end(); ++itClaims) {
+        if (itClaims->outPoint == outPoint) {
             std::swap(claim, *itClaims);
             break;
         }
     }
-    if (itClaims != claims.end())
-    {
+    if (itClaims != claims.end()) {
         claims.erase(itClaims);
-    }
-    else
-    {
+    } else {
         LogPrintf("CClaimTrieNode::%s() : asked to remove a claim that doesn't exist\n", __func__);
         LogPrintf("CClaimTrieNode::%s() : claims that do exist:\n", __func__);
-        for (unsigned int i = 0; i < claims.size(); i++)
-        {
+        for (unsigned int i = 0; i < claims.size(); i++) {
             LogPrintf("\ttxhash: %s, nOut: %d:\n", claims[i].outPoint.hash.ToString(), claims[i].outPoint.n);
         }
         return false;
@@ -92,12 +90,9 @@ bool CClaimTrieNode::removeClaim(const COutPoint& outPoint, CClaimValue& claim)
 
 bool CClaimTrieNode::getBestClaim(CClaimValue& claim) const
 {
-    if (claims.empty())
-    {
+    if (claims.empty()) {
         return false;
-    }
-    else
-    {
+    } else {
         claim = claims.front();
         return true;
     }
@@ -105,10 +100,8 @@ bool CClaimTrieNode::getBestClaim(CClaimValue& claim) const
 
 bool CClaimTrieNode::haveClaim(const COutPoint& outPoint) const
 {
-    for (std::vector<CClaimValue>::const_iterator itclaim = claims.begin(); itclaim != claims.end(); ++itclaim)
-    {
-        if (itclaim->outPoint == outPoint)
-            return true;
+    for (std::vector<CClaimValue>::const_iterator itclaim = claims.begin(); itclaim != claims.end(); ++itclaim) {
+        if (itclaim->outPoint == outPoint) return true;
     }
     return false;
 }
@@ -117,17 +110,13 @@ void CClaimTrieNode::reorderClaims(supportMapEntryType& supports)
 {
     std::vector<CClaimValue>::iterator itclaim;
 
-    for (itclaim = claims.begin(); itclaim != claims.end(); ++itclaim)
-    {
+    for (itclaim = claims.begin(); itclaim != claims.end(); ++itclaim) {
         itclaim->nEffectiveAmount = itclaim->nAmount;
     }
 
-    for (supportMapEntryType::iterator itsupport = supports.begin(); itsupport != supports.end(); ++itsupport)
-    {
-        for (itclaim = claims.begin(); itclaim != claims.end(); ++itclaim)
-        {
-            if (itsupport->supportedClaimId == itclaim->claimId)
-            {
+    for (supportMapEntryType::iterator itsupport = supports.begin(); itsupport != supports.end(); ++itsupport) {
+        for (itclaim = claims.begin(); itclaim != claims.end(); ++itclaim) {
+            if (itsupport->supportedClaimId == itclaim->claimId) {
                 itclaim->nEffectiveAmount += itsupport->nAmount;
                 break;
             }
@@ -135,6 +124,20 @@ void CClaimTrieNode::reorderClaims(supportMapEntryType& supports)
     }
 
     std::make_heap(claims.begin(), claims.end());
+}
+
+bool CClaimTrieNode::empty() const
+{
+    return children.empty() && claims.empty();
+}
+
+CClaimTrie::CClaimTrie(bool fMemory, bool fWipe, int nProportionalDelayFactor)
+    : nCurrentHeight(0), nExpirationTime(Params().GetConsensus().nOriginalClaimExpirationTime), nProportionalDelayFactor(nProportionalDelayFactor), db(fMemory, fWipe), root(one)
+{
+}
+
+CClaimTrie::~CClaimTrie()
+{
 }
 
 uint256 CClaimTrie::getMerkleHash()
@@ -147,72 +150,24 @@ bool CClaimTrie::empty() const
     return root.empty();
 }
 
-template<typename K> bool CClaimTrie::keyTypeEmpty(char keyType, K& dummy) const
-{
-    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&db)->NewIterator());
-    pcursor->SeekToFirst();
-    
-    while (pcursor->Valid())
-    {
-        std::pair<char, K> key;
-        if (pcursor->GetKey(key))
-        {
-            if (key.first == keyType)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            break;
-        }
-        pcursor->Next();
-    }
-    return true;
-}
-
 bool CClaimTrie::queueEmpty() const
 {
-    for (claimQueueType::const_iterator itRow = dirtyQueueRows.begin(); itRow != dirtyQueueRows.end(); ++itRow)
-    {
-        if (!itRow->second.empty())
-            return false;
-    }
-    int dummy;
-    return keyTypeEmpty(CLAIM_QUEUE_ROW, dummy);
+    return db.keyTypeEmpty<int, claimQueueRowType>();
 }
 
 bool CClaimTrie::expirationQueueEmpty() const
 {
-    for (expirationQueueType::const_iterator itRow = dirtyExpirationQueueRows.begin(); itRow != dirtyExpirationQueueRows.end(); ++itRow)
-    {
-        if (!itRow->second.empty())
-            return false;
-    }
-    int dummy;
-    return keyTypeEmpty(EXP_QUEUE_ROW, dummy);
+    return db.keyTypeEmpty<int, expirationQueueRowType>();
 }
 
 bool CClaimTrie::supportEmpty() const
 {
-    for (supportMapType::const_iterator itNode = dirtySupportNodes.begin(); itNode != dirtySupportNodes.end(); ++itNode)
-    {
-        if (!itNode->second.empty())
-            return false;
-    }
-    std::string dummy;
-    return keyTypeEmpty(SUPPORT, dummy);
+    return db.keyTypeEmpty<std::string, supportMapEntryType>();
 }
 
 bool CClaimTrie::supportQueueEmpty() const
 {
-    for (supportQueueType::const_iterator itRow = dirtySupportQueueRows.begin(); itRow != dirtySupportQueueRows.end(); ++itRow)
-    {
-        if (!itRow->second.empty())
-            return false;
-    }
-    int dummy;
-    return keyTypeEmpty(SUPPORT_QUEUE_ROW, dummy);
+    return db.keyTypeEmpty<int, supportQueueRowType>();
 }
 
 void CClaimTrie::setExpirationTime(int t)
@@ -228,37 +183,25 @@ void CClaimTrie::clear()
 
 void CClaimTrie::clear(CClaimTrieNode* current)
 {
-    for (nodeMapType::const_iterator itchildren = current->children.begin(); itchildren != current->children.end(); ++itchildren)
-    {
+    for (nodeMapType::const_iterator itchildren = current->children.begin(); itchildren != current->children.end(); ++itchildren) {
         clear(itchildren->second);
         delete itchildren->second;
     }
+    current->children.clear();
 }
 
 bool CClaimTrie::haveClaim(const std::string& name, const COutPoint& outPoint) const
 {
-    const CClaimTrieNode* current = &root;
-    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname)
-    {
-        nodeMapType::const_iterator itchildren = current->children.find(*itname);
-        if (itchildren == current->children.end())
-            return false;
-        current = itchildren->second;
-    }
-    return current->haveClaim(outPoint);
+    const CClaimTrieNode* current = getNodeForName(name);
+    return current && current->haveClaim(outPoint);
 }
 
 bool CClaimTrie::haveSupport(const std::string& name, const COutPoint& outPoint) const
 {
     supportMapEntryType node;
-    if (!getSupportNode(name, node))
-    {
-        return false;
-    }
-    for (supportMapEntryType::const_iterator itnode = node.begin(); itnode != node.end(); ++itnode)
-    {
-        if (itnode->outPoint == outPoint)
-            return true;
+    if (!db.getQueueRow(name, node)) return false;
+    for (supportMapEntryType::const_iterator itnode = node.begin(); itnode != node.end(); ++itnode) {
+        if (itnode->outPoint == outPoint) return true;
     }
     return false;
 }
@@ -266,32 +209,20 @@ bool CClaimTrie::haveSupport(const std::string& name, const COutPoint& outPoint)
 bool CClaimTrie::haveClaimInQueue(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight) const
 {
     queueNameRowType nameRow;
-    if (!getQueueNameRow(name, nameRow))
-    {
-        return false;
-    }
+    if (!db.getQueueRow(name, nameRow)) return false;
     queueNameRowType::const_iterator itNameRow;
-    for (itNameRow = nameRow.begin(); itNameRow != nameRow.end(); ++itNameRow)
-    {
-        if (itNameRow->outPoint == outPoint)
-        {
+    for (itNameRow = nameRow.begin(); itNameRow != nameRow.end(); ++itNameRow) {
+        if (itNameRow->outPoint == outPoint) {
             nValidAtHeight = itNameRow->nHeight;
             break;
         }
     }
-    if (itNameRow == nameRow.end())
-    {
-        return false;
-    }
+    if (itNameRow == nameRow.end()) return false;
     claimQueueRowType row;
-    if (getQueueRow(nValidAtHeight, row))
-    {
-        for (claimQueueRowType::const_iterator itRow = row.begin(); itRow != row.end(); ++itRow)
-        {
-            if (itRow->first == name && itRow->second.outPoint == outPoint)
-            {
-                if (itRow->second.nValidAtHeight != nValidAtHeight)
-                {
+    if (db.getQueueRow(nValidAtHeight, row)) {
+        for (claimQueueRowType::const_iterator itRow = row.begin(); itRow != row.end(); ++itRow) {
+            if (itRow->first == name && itRow->second.outPoint == outPoint) {
+                if (itRow->second.nValidAtHeight != nValidAtHeight) {
                     LogPrintf("%s: An inconsistency was found in the claim queue. Please report this to the developers:\nDifferent nValidAtHeight between named queue and height queue\n: name: %s, txid: %s, nOut: %d, nValidAtHeight in named queue: %d, nValidAtHeight in height queue: %d current height: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nValidAtHeight, itRow->second.nValidAtHeight, nCurrentHeight);
                 }
                 return true;
@@ -304,33 +235,21 @@ bool CClaimTrie::haveClaimInQueue(const std::string& name, const COutPoint& outP
 
 bool CClaimTrie::haveSupportInQueue(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight) const
 {
-    queueNameRowType nameRow;
-    if (!getSupportQueueNameRow(name, nameRow))
-    {
-        return false;
-    }
-    queueNameRowType::const_iterator itNameRow;
-    for (itNameRow = nameRow.begin(); itNameRow != nameRow.end(); ++itNameRow)
-    {
-        if (itNameRow->outPoint == outPoint)
-        {
+    supportQueueNameRowType nameRow;
+    if (!db.getQueueRow(name, nameRow)) return false;
+    supportQueueNameRowType::const_iterator itNameRow;
+    for (itNameRow = nameRow.begin(); itNameRow != nameRow.end(); ++itNameRow) {
+        if (itNameRow->outPoint == outPoint) {
             nValidAtHeight = itNameRow->nHeight;
             break;
         }
     }
-    if (itNameRow == nameRow.end())
-    {
-        return false;
-    }
+    if (itNameRow == nameRow.end()) return false;
     supportQueueRowType row;
-    if (getSupportQueueRow(nValidAtHeight, row))
-    {
-        for (supportQueueRowType::const_iterator itRow = row.begin(); itRow != row.end(); ++itRow)
-        {
-            if (itRow->first == name && itRow->second.outPoint == outPoint)
-            {
-                if (itRow->second.nValidAtHeight != nValidAtHeight)
-                {
+    if (db.getQueueRow(nValidAtHeight, row)) {
+        for (supportQueueRowType::const_iterator itRow = row.begin(); itRow != row.end(); ++itRow) {
+            if (itRow->first == name && itRow->second.outPoint == outPoint) {
+                if (itRow->second.nValidAtHeight != nValidAtHeight) {
                     LogPrintf("%s: An inconsistency was found in the support queue. Please report this to the developers:\nDifferent nValidAtHeight between named queue and height queue\n: name: %s, txid: %s, nOut: %d, nValidAtHeight in named queue: %d, nValidAtHeight in height queue: %d current height: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nValidAtHeight, itRow->second.nValidAtHeight, nCurrentHeight);
                 }
                 return true;
@@ -343,8 +262,7 @@ bool CClaimTrie::haveSupportInQueue(const std::string& name, const COutPoint& ou
 
 unsigned int CClaimTrie::getTotalNamesInTrie() const
 {
-    if (empty())
-        return 0;
+    if (empty()) return 0;
     const CClaimTrieNode* current = &root;
     return getTotalNamesRecursive(current);
 }
@@ -352,10 +270,10 @@ unsigned int CClaimTrie::getTotalNamesInTrie() const
 unsigned int CClaimTrie::getTotalNamesRecursive(const CClaimTrieNode* current) const
 {
     unsigned int names_in_subtrie = 0;
-    if (!(current->claims.empty()))
+    if (!(current->claims.empty())) {
         names_in_subtrie += 1;
-    for (nodeMapType::const_iterator it = current->children.begin(); it != current->children.end(); ++it)
-    {
+    }
+    for (nodeMapType::const_iterator it = current->children.begin(); it != current->children.end(); ++it) {
         names_in_subtrie += getTotalNamesRecursive(it->second);
     }
     return names_in_subtrie;
@@ -363,8 +281,7 @@ unsigned int CClaimTrie::getTotalNamesRecursive(const CClaimTrieNode* current) c
 
 unsigned int CClaimTrie::getTotalClaimsInTrie() const
 {
-    if (empty())
-        return 0;
+    if (empty()) return 0;
     const CClaimTrieNode* current = &root;
     return getTotalClaimsRecursive(current);
 }
@@ -372,8 +289,7 @@ unsigned int CClaimTrie::getTotalClaimsInTrie() const
 unsigned int CClaimTrie::getTotalClaimsRecursive(const CClaimTrieNode* current) const
 {
     unsigned int claims_in_subtrie = current->claims.size();
-    for (nodeMapType::const_iterator it = current->children.begin(); it != current->children.end(); ++it)
-    {
+    for (nodeMapType::const_iterator it = current->children.begin(); it != current->children.end(); ++it) {
         claims_in_subtrie += getTotalClaimsRecursive(it->second);
     }
     return claims_in_subtrie;
@@ -381,8 +297,7 @@ unsigned int CClaimTrie::getTotalClaimsRecursive(const CClaimTrieNode* current) 
 
 CAmount CClaimTrie::getTotalValueOfClaimsInTrie(bool fControllingOnly) const
 {
-    if (empty())
-        return 0;
+    if (empty()) return 0;
     const CClaimTrieNode* current = &root;
     return getTotalValueOfClaimsRecursive(current, fControllingOnly);
 }
@@ -390,29 +305,23 @@ CAmount CClaimTrie::getTotalValueOfClaimsInTrie(bool fControllingOnly) const
 CAmount CClaimTrie::getTotalValueOfClaimsRecursive(const CClaimTrieNode* current, bool fControllingOnly) const
 {
     CAmount value_in_subtrie = 0;
-    for (std::vector<CClaimValue>::const_iterator itclaim = current->claims.begin(); itclaim != current->claims.end(); ++itclaim)
-    {
+    for (std::vector<CClaimValue>::const_iterator itclaim = current->claims.begin(); itclaim != current->claims.end(); ++itclaim) {
         value_in_subtrie += itclaim->nAmount;
-        if (fControllingOnly)
-            break;
+        if (fControllingOnly) break;
     }
-    for (nodeMapType::const_iterator itchild = current->children.begin(); itchild != current->children.end(); ++itchild)
-     {
-         value_in_subtrie += getTotalValueOfClaimsRecursive(itchild->second, fControllingOnly);
-     }
-     return value_in_subtrie;
+    for (nodeMapType::const_iterator itchild = current->children.begin(); itchild != current->children.end(); ++itchild) {
+        value_in_subtrie += getTotalValueOfClaimsRecursive(itchild->second, fControllingOnly);
+    }
+    return value_in_subtrie;
 }
 
 bool CClaimTrie::recursiveFlattenTrie(const std::string& name, const CClaimTrieNode* current, std::vector<namedNodeType>& nodes) const
 {
-    namedNodeType node(name, *current);
-    nodes.push_back(node);
-    for (nodeMapType::const_iterator it = current->children.begin(); it != current->children.end(); ++it)
-    {
+    nodes.push_back(namedNodeType(name, *current));
+    for (nodeMapType::const_iterator it = current->children.begin(); it != current->children.end(); ++it) {
         std::stringstream ss;
         ss << name << it->first;
-        if (!recursiveFlattenTrie(ss.str(), it->second, nodes))
-            return false;
+        if (!recursiveFlattenTrie(ss.str(), it->second, nodes)) return false;
     }
     return true;
 }
@@ -420,19 +329,18 @@ bool CClaimTrie::recursiveFlattenTrie(const std::string& name, const CClaimTrieN
 std::vector<namedNodeType> CClaimTrie::flattenTrie() const
 {
     std::vector<namedNodeType> nodes;
-    if (!recursiveFlattenTrie("", &root, nodes))
+    if (!recursiveFlattenTrie("", &root, nodes)) {
         LogPrintf("%s: Something went wrong flattening the trie", __func__);
+    }
     return nodes;
 }
 
 const CClaimTrieNode* CClaimTrie::getNodeForName(const std::string& name) const
 {
     const CClaimTrieNode* current = &root;
-    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname)
-    {
+    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname) {
         nodeMapType::const_iterator itchildren = current->children.find(*itname);
-        if (itchildren == current->children.end())
-            return NULL;
+        if (itchildren == current->children.end()) return NULL;
         current = itchildren->second;
     }
     return current;
@@ -441,22 +349,18 @@ const CClaimTrieNode* CClaimTrie::getNodeForName(const std::string& name) const
 bool CClaimTrie::getInfoForName(const std::string& name, CClaimValue& claim) const
 {
     const CClaimTrieNode* current = getNodeForName(name);
-    if (current)
-    {
-        return current->getBestClaim(claim);
-    }
-    return false;
+    return current && current->getBestClaim(claim);
 }
 
 bool CClaimTrie::getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const
 {
     const CClaimTrieNode* current = getNodeForName(name);
-    if (current && !current->claims.empty())
-    {
+    if (current && !current->claims.empty()) {
         lastTakeoverHeight = current->nHeightOfLastTakeover;
         return true;
+    } else {
+        return false;
     }
-    return false;
 }
 
 claimsForNameType CClaimTrie::getClaimsForName(const std::string& name) const
@@ -465,56 +369,41 @@ claimsForNameType CClaimTrie::getClaimsForName(const std::string& name) const
     std::vector<CSupportValue> supports;
     int nLastTakeoverHeight = 0;
     const CClaimTrieNode* current = getNodeForName(name);
-    if (current)
-    {
-        if (!current->claims.empty())
-        {
+    if (current) {
+        if (!current->claims.empty()) {
             nLastTakeoverHeight = current->nHeightOfLastTakeover;
         }
-        for (std::vector<CClaimValue>::const_iterator itClaims = current->claims.begin(); itClaims != current->claims.end(); ++itClaims)
-        {
+        for (std::vector<CClaimValue>::const_iterator itClaims = current->claims.begin(); itClaims != current->claims.end(); ++itClaims) {
             claims.push_back(*itClaims);
         }
     }
     supportMapEntryType supportNode;
-    if (getSupportNode(name, supportNode))
-    {
-        for (std::vector<CSupportValue>::const_iterator itSupports = supportNode.begin(); itSupports != supportNode.end(); ++itSupports)
-        {
+    if (db.getQueueRow(name, supportNode)) {
+        for (std::vector<CSupportValue>::const_iterator itSupports = supportNode.begin(); itSupports != supportNode.end(); ++itSupports) {
             supports.push_back(*itSupports);
         }
     }
     queueNameRowType namedClaimRow;
-    if (getQueueNameRow(name, namedClaimRow))
-    {
-        for (queueNameRowType::const_iterator itClaimsForName = namedClaimRow.begin(); itClaimsForName != namedClaimRow.end(); ++itClaimsForName)
-        {
+    if (db.getQueueRow(name, namedClaimRow)) {
+        for (queueNameRowType::const_iterator itClaimsForName = namedClaimRow.begin(); itClaimsForName != namedClaimRow.end(); ++itClaimsForName) {
             claimQueueRowType claimRow;
-            if (getQueueRow(itClaimsForName->nHeight, claimRow))
-            {
-                for (claimQueueRowType::const_iterator itClaimRow = claimRow.begin(); itClaimRow != claimRow.end(); ++itClaimRow)
-                 {
-                     if (itClaimRow->first == name && itClaimRow->second.outPoint == itClaimsForName->outPoint)
-                     {
-                         claims.push_back(itClaimRow->second);
-                         break;
-                     }
-                 }
+            if (db.getQueueRow(itClaimsForName->nHeight, claimRow)) {
+                for (claimQueueRowType::const_iterator itClaimRow = claimRow.begin(); itClaimRow != claimRow.end(); ++itClaimRow) {
+                    if (itClaimRow->first == name && itClaimRow->second.outPoint == itClaimsForName->outPoint) {
+                        claims.push_back(itClaimRow->second);
+                        break;
+                    }
+                }
             }
         }
     }
-    queueNameRowType namedSupportRow;
-    if (getSupportQueueNameRow(name, namedSupportRow))
-    {
-        for (queueNameRowType::const_iterator itSupportsForName = namedSupportRow.begin(); itSupportsForName != namedSupportRow.end(); ++itSupportsForName)
-        {
+    supportQueueNameRowType namedSupportRow;
+    if (db.getQueueRow(name, namedSupportRow)) {
+        for (supportQueueNameRowType::const_iterator itSupportsForName = namedSupportRow.begin(); itSupportsForName != namedSupportRow.end(); ++itSupportsForName) {
             supportQueueRowType supportRow;
-            if (getSupportQueueRow(itSupportsForName->nHeight, supportRow))
-            {
-                for (supportQueueRowType::const_iterator itSupportRow = supportRow.begin(); itSupportRow != supportRow.end(); ++itSupportRow)
-                {
-                    if (itSupportRow->first == name && itSupportRow->second.outPoint == itSupportsForName->outPoint)
-                    {
+            if (db.getQueueRow(itSupportsForName->nHeight, supportRow)) {
+                for (supportQueueRowType::const_iterator itSupportRow = supportRow.begin(); itSupportRow != supportRow.end(); ++itSupportRow) {
+                    if (itSupportRow->first == name && itSupportRow->second.outPoint == itSupportsForName->outPoint) {
                         supports.push_back(itSupportRow->second);
                         break;
                     }
@@ -527,35 +416,28 @@ claimsForNameType CClaimTrie::getClaimsForName(const std::string& name) const
 }
 
 //return effective amount from claim, retuns 0 if claim is not found
-CAmount CClaimTrie::getEffectiveAmountForClaim(const std::string& name, uint160 claimId) const
+CAmount CClaimTrie::getEffectiveAmountForClaim(const std::string& name, const uint160& claimId) const
 {
     std::vector<CSupportValue> supports;
     return getEffectiveAmountForClaimWithSupports(name, claimId, supports);
 }
 
 //return effective amount from claim and the supports used as inputs, retuns 0 if claim is not found
-CAmount CClaimTrie::getEffectiveAmountForClaimWithSupports(const std::string& name, uint160 claimId,
-                                                           std::vector<CSupportValue>& supports) const
+CAmount CClaimTrie::getEffectiveAmountForClaimWithSupports(const std::string& name, const uint160& claimId, std::vector<CSupportValue>& supports) const
 {
     claimsForNameType claims = getClaimsForName(name);
     CAmount effectiveAmount = 0;
     bool claim_found = false;
-    for (std::vector<CClaimValue>::iterator it=claims.claims.begin(); it!=claims.claims.end(); ++it)
-    {
-        if (it->claimId == claimId && it->nValidAtHeight < nCurrentHeight)
-        {
+    for (std::vector<CClaimValue>::iterator it = claims.claims.begin(); it != claims.claims.end(); ++it) {
+        if (it->claimId == claimId && it->nValidAtHeight < nCurrentHeight) {
             effectiveAmount += it->nAmount;
             claim_found = true;
             break;
         }
     }
-    if (!claim_found)
-        return effectiveAmount;
-
-    for (std::vector<CSupportValue>::iterator it=claims.supports.begin(); it!=claims.supports.end(); ++it)
-    {
-        if (it->supportedClaimId == claimId && it->nValidAtHeight < nCurrentHeight)
-        {
+    if (!claim_found) return effectiveAmount;
+    for (std::vector<CSupportValue>::iterator it = claims.supports.begin(); it != claims.supports.end(); ++it) {
+        if (it->supportedClaimId == claimId && it->nValidAtHeight < nCurrentHeight) {
             effectiveAmount += it->nAmount;
             supports.push_back(*it);
         }
@@ -565,8 +447,7 @@ CAmount CClaimTrie::getEffectiveAmountForClaimWithSupports(const std::string& na
 
 bool CClaimTrie::checkConsistency() const
 {
-    if (empty())
-        return true;
+    if (empty()) return true;
     return recursiveCheckConsistency(&root);
 }
 
@@ -574,22 +455,19 @@ bool CClaimTrie::recursiveCheckConsistency(const CClaimTrieNode* node) const
 {
     std::vector<unsigned char> vchToHash;
 
-    for (nodeMapType::const_iterator it = node->children.begin(); it != node->children.end(); ++it)
-    {
-        if (recursiveCheckConsistency(it->second))
-        {
+    for (nodeMapType::const_iterator it = node->children.begin(); it != node->children.end(); ++it) {
+        if (recursiveCheckConsistency(it->second)) {
             vchToHash.push_back(it->first);
             vchToHash.insert(vchToHash.end(), it->second->hash.begin(), it->second->hash.end());
-        }
-        else
+        } else {
             return false;
+        }
     }
 
     CClaimValue claim;
     bool hasClaim = node->getBestClaim(claim);
 
-    if (hasClaim)
-    {
+    if (hasClaim) {
         uint256 valueHash = getValueHash(claim.outPoint, node->nHeightOfLastTakeover);
         vchToHash.insert(vchToHash.end(), valueHash.begin(), valueHash.end());
     }
@@ -604,317 +482,76 @@ bool CClaimTrie::recursiveCheckConsistency(const CClaimTrieNode* node) const
 
 void CClaimTrie::addToClaimIndex(const std::string& name, const CClaimValue& claim)
 {
-    CClaimIndexElement element = { name, claim };
     LogPrintf("%s: ClaimIndex[%s] updated %s\n", __func__, claim.claimId.GetHex(), name);
-    db.Write(std::make_pair(CLAIM_BY_ID, claim.claimId), element);
+
+    CClaimIndexElement element = {name, claim};
+    db.updateQueueRow(claim.claimId, element);
 }
 
 void CClaimTrie::removeFromClaimIndex(const CClaimValue& claim)
 {
     LogPrintf("%s: ClaimIndex[%s] removed\n", __func__, claim.claimId.GetHex());
-    db.Erase(std::make_pair(CLAIM_BY_ID, claim.claimId));
+
+    CClaimIndexElement element;
+    db.updateQueueRow(claim.claimId, element);
 }
 
-bool CClaimTrie::getClaimById(const uint160 claimId, std::string& name, CClaimValue& claim) const
+bool CClaimTrie::getClaimById(const uint160& claimId, std::string& name, CClaimValue& claim) const
 {
     CClaimIndexElement element;
-    if (db.Read(std::make_pair(CLAIM_BY_ID, claimId), element))
-    {
-        if (element.claim.claimId == claimId) {
-            name = element.name;
-            claim = element.claim;
-            return true;
-        } else {
-            LogPrintf("%s: ClaimIndex[%s] returned unmatched claimId %s when looking for %s\n",
-                __func__, claimId.GetHex(), element.claim.claimId.GetHex(), name);
-        }
-    }
-    return false;
-}
-
-bool CClaimTrie::getQueueRow(int nHeight, claimQueueRowType& row) const
-{
-    claimQueueType::const_iterator itQueueRow = dirtyQueueRows.find(nHeight);
-    if (itQueueRow != dirtyQueueRows.end())
-    {
-        row = itQueueRow->second;
+    if (db.getQueueRow(claimId, element) && !element.empty()) {
+        name = element.name;
+        claim = element.claim;
         return true;
+    } else {
+        LogPrintf("%s: ClaimIndex[%s] returned unmatched claimId %s when looking for %s\n",
+            __func__, claimId.GetHex(), element.claim.claimId.GetHex(), name);
+        return false;
     }
-    return db.Read(std::make_pair(CLAIM_QUEUE_ROW, nHeight), row);
 }
 
-bool CClaimTrie::getQueueNameRow(const std::string& name, queueNameRowType& row) const
-{
-    queueNameType::const_iterator itQueueNameRow = dirtyQueueNameRows.find(name);
-    if (itQueueNameRow != dirtyQueueNameRows.end())
-    {
-        row = itQueueNameRow->second;
-        return true;
-    }
-    return db.Read(std::make_pair(CLAIM_QUEUE_NAME_ROW, name), row);
-}
-
-bool CClaimTrie::getExpirationQueueRow(int nHeight, expirationQueueRowType& row) const
-{
-    expirationQueueType::const_iterator itQueueRow = dirtyExpirationQueueRows.find(nHeight);
-    if (itQueueRow != dirtyExpirationQueueRows.end())
-    {
-        row = itQueueRow->second;
-        return true;
-    }
-    return db.Read(std::make_pair(EXP_QUEUE_ROW, nHeight), row);
-}
-
-void CClaimTrie::updateQueueRow(int nHeight, claimQueueRowType& row)
-{
-    claimQueueType::iterator itQueueRow = dirtyQueueRows.find(nHeight);
-    if (itQueueRow == dirtyQueueRows.end())
-    {
-        claimQueueRowType newRow;
-        std::pair<claimQueueType::iterator, bool> ret;
-        ret = dirtyQueueRows.insert(std::pair<int, claimQueueRowType >(nHeight, newRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    itQueueRow->second.swap(row);
-}
-
-void CClaimTrie::updateQueueNameRow(const std::string& name, queueNameRowType& row)
-{
-    queueNameType::iterator itQueueRow = dirtyQueueNameRows.find(name);
-    if (itQueueRow == dirtyQueueNameRows.end())
-    {
-        queueNameRowType newRow;
-        std::pair<queueNameType::iterator, bool> ret;
-        ret = dirtyQueueNameRows.insert(std::pair<std::string, queueNameRowType>(name, newRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    itQueueRow->second.swap(row);
-}
-
-void CClaimTrie::updateExpirationRow(int nHeight, expirationQueueRowType& row)
-{
-    expirationQueueType::iterator itQueueRow = dirtyExpirationQueueRows.find(nHeight);
-    if (itQueueRow == dirtyExpirationQueueRows.end())
-    {
-        expirationQueueRowType newRow;
-        std::pair<expirationQueueType::iterator, bool> ret;
-        ret = dirtyExpirationQueueRows.insert(std::pair<int, expirationQueueRowType >(nHeight, newRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    itQueueRow->second.swap(row);
-}
-
-void CClaimTrie::updateSupportMap(const std::string& name, supportMapEntryType& node)
-{
-    supportMapType::iterator itNode = dirtySupportNodes.find(name);
-    if (itNode == dirtySupportNodes.end())
-    {
-        supportMapEntryType newNode;
-        std::pair<supportMapType::iterator, bool> ret;
-        ret = dirtySupportNodes.insert(std::pair<std::string, supportMapEntryType>(name, newNode));
-        assert(ret.second);
-        itNode = ret.first;
-    }
-    itNode->second.swap(node);
-}
-
-void CClaimTrie::updateSupportQueue(int nHeight, supportQueueRowType& row)
-{
-    supportQueueType::iterator itQueueRow = dirtySupportQueueRows.find(nHeight);
-    if (itQueueRow == dirtySupportQueueRows.end())
-    {
-        supportQueueRowType newRow;
-        std::pair<supportQueueType::iterator, bool> ret;
-        ret = dirtySupportQueueRows.insert(std::pair<int, supportQueueRowType >(nHeight, newRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    itQueueRow->second.swap(row);
-}
-
-void CClaimTrie::updateSupportNameQueue(const std::string& name, queueNameRowType& row)
-{
-    queueNameType::iterator itQueueRow = dirtySupportQueueNameRows.find(name);
-    if (itQueueRow == dirtySupportQueueNameRows.end())
-    {
-        queueNameRowType newRow;
-        std::pair<queueNameType::iterator, bool> ret;
-        ret = dirtySupportQueueNameRows.insert(std::pair<std::string, queueNameRowType>(name, newRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    itQueueRow->second.swap(row);
-}
-
-void CClaimTrie::updateSupportExpirationQueue(int nHeight, expirationQueueRowType& row)
-{
-    expirationQueueType::iterator itQueueRow = dirtySupportExpirationQueueRows.find(nHeight);
-    if (itQueueRow == dirtySupportExpirationQueueRows.end())
-    {
-        expirationQueueRowType newRow;
-        std::pair<expirationQueueType::iterator, bool> ret;
-        ret = dirtySupportExpirationQueueRows.insert(std::pair<int, expirationQueueRowType >(nHeight, newRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    itQueueRow->second.swap(row);
-}
-
-bool CClaimTrie::getSupportNode(std::string name, supportMapEntryType& node) const
-{
-    supportMapType::const_iterator itNode = dirtySupportNodes.find(name);
-    if (itNode != dirtySupportNodes.end())
-    {
-        node = itNode->second;
-        return true;
-    }
-    return db.Read(std::make_pair(SUPPORT, name), node);
-}
-
-bool CClaimTrie::getSupportQueueRow(int nHeight, supportQueueRowType& row) const
-{
-    supportQueueType::const_iterator itQueueRow = dirtySupportQueueRows.find(nHeight);
-    if (itQueueRow != dirtySupportQueueRows.end())
-    {
-        row = itQueueRow->second;
-        return true;
-    }
-    return db.Read(std::make_pair(SUPPORT_QUEUE_ROW, nHeight), row);
-}
-
-bool CClaimTrie::getSupportQueueNameRow(const std::string& name, queueNameRowType& row) const
-{
-    queueNameType::const_iterator itQueueNameRow = dirtySupportQueueNameRows.find(name);
-    if (itQueueNameRow != dirtySupportQueueNameRows.end())
-    {
-        row = itQueueNameRow->second;
-        return true;
-    }
-    return db.Read(std::make_pair(SUPPORT_QUEUE_NAME_ROW, name), row);
-}
-
-bool CClaimTrie::getSupportExpirationQueueRow(int nHeight, expirationQueueRowType& row) const
-{
-    expirationQueueType::const_iterator itQueueRow = dirtySupportExpirationQueueRows.find(nHeight);
-    if (itQueueRow != dirtySupportExpirationQueueRows.end())
-    {
-        row = itQueueRow->second;
-        return true;
-    }
-    return db.Read(std::make_pair(SUPPORT_EXP_QUEUE_ROW, nHeight), row);
-}
-
-bool CClaimTrie::update(nodeCacheType& cache, hashMapType& hashes, std::map<std::string, int>& takeoverHeights, const uint256& hashBlockIn, claimQueueType& queueCache, queueNameType& queueNameCache, expirationQueueType& expirationQueueCache, int nNewHeight, supportMapType& supportCache, supportQueueType& supportQueueCache, queueNameType& supportQueueNameCache, expirationQueueType& supportExpirationQueueCache)
-{
-    for (nodeCacheType::iterator itcache = cache.begin(); itcache != cache.end(); ++itcache)
-    {
-        if (!updateName(itcache->first, itcache->second))
-        {
-            LogPrintf("%s: Failed to update name for:%s\n", __func__, itcache->first);
-            return false;
-        }
-    }
-    for (hashMapType::iterator ithash = hashes.begin(); ithash != hashes.end(); ++ithash)
-    {
-        if (!updateHash(ithash->first, ithash->second))
-        {
-            LogPrintf("%s: Failed to update hash for:%s\n", __func__, ithash->first);
-            return false;
-        }
-    }
-    for (std::map<std::string, int>::iterator itheight = takeoverHeights.begin(); itheight != takeoverHeights.end(); ++itheight)
-    {
-        if (!updateTakeoverHeight(itheight->first, itheight->second))
-        {
-            LogPrintf("%s: Failed to update takeover height for:%s\n", __func__, itheight->first);
-            return false;
-        }
-    }
-    for (claimQueueType::iterator itQueueCacheRow = queueCache.begin(); itQueueCacheRow != queueCache.end(); ++itQueueCacheRow)
-    {
-        updateQueueRow(itQueueCacheRow->first, itQueueCacheRow->second);
-    }
-    for (queueNameType::iterator itQueueNameCacheRow = queueNameCache.begin(); itQueueNameCacheRow != queueNameCache.end(); ++itQueueNameCacheRow)
-    {
-        updateQueueNameRow(itQueueNameCacheRow->first, itQueueNameCacheRow->second);
-    }
-    for (expirationQueueType::iterator itExpirationRow = expirationQueueCache.begin(); itExpirationRow != expirationQueueCache.end(); ++itExpirationRow)
-    {
-        updateExpirationRow(itExpirationRow->first, itExpirationRow->second);
-    }
-    for (supportMapType::iterator itSupportCache = supportCache.begin(); itSupportCache != supportCache.end(); ++itSupportCache)
-    {
-        updateSupportMap(itSupportCache->first, itSupportCache->second);
-    }
-    for (supportQueueType::iterator itSupportQueue = supportQueueCache.begin(); itSupportQueue != supportQueueCache.end(); ++itSupportQueue)
-    {
-        updateSupportQueue(itSupportQueue->first, itSupportQueue->second);
-    }
-    for (queueNameType::iterator itSupportNameQueue = supportQueueNameCache.begin(); itSupportNameQueue != supportQueueNameCache.end(); ++itSupportNameQueue)
-    {
-        updateSupportNameQueue(itSupportNameQueue->first, itSupportNameQueue->second);
-    }
-    for (expirationQueueType::iterator itSupportExpirationQueue = supportExpirationQueueCache.begin(); itSupportExpirationQueue != supportExpirationQueueCache.end(); ++itSupportExpirationQueue)
-    {
-        updateSupportExpirationQueue(itSupportExpirationQueue->first, itSupportExpirationQueue->second);
-    }
-    hashBlock = hashBlockIn;
-    nCurrentHeight = nNewHeight;
-    return true;
-}
-
-void CClaimTrie::markNodeDirty(const std::string &name, CClaimTrieNode* node)
+void CClaimTrie::markNodeDirty(const std::string& name, CClaimTrieNode* node)
 {
     std::pair<nodeCacheType::iterator, bool> ret;
     ret = dirtyNodes.insert(std::pair<std::string, CClaimTrieNode*>(name, node));
-    if (ret.second == false)
+    if (ret.second == false) {
         ret.first->second = node;
+    }
 }
 
-bool CClaimTrie::updateName(const std::string &name, CClaimTrieNode* updatedNode)
+bool CClaimTrie::updateName(const std::string& name, CClaimTrieNode* updatedNode)
 {
     CClaimTrieNode* current = &root;
-    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname)
-    {
+    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname) {
         nodeMapType::iterator itchild = current->children.find(*itname);
-        if (itchild == current->children.end())
-        {
-            if (itname + 1 == name.end())
-            {
+        if (itchild == current->children.end()) {
+            if (itname + 1 == name.end()) {
                 CClaimTrieNode* newNode = new CClaimTrieNode();
                 current->children[*itname] = newNode;
                 current = newNode;
-            }
-            else
+            } else {
                 return false;
-        }
-        else
-        {
+            }
+        } else {
             current = itchild->second;
         }
     }
     assert(current != NULL);
     current->claims.swap(updatedNode->claims);
     markNodeDirty(name, current);
-    for (nodeMapType::iterator itchild = current->children.begin(); itchild != current->children.end();)
-    {
+    for (nodeMapType::iterator itchild = current->children.begin(); itchild != current->children.end();) {
         nodeMapType::iterator itupdatechild = updatedNode->children.find(itchild->first);
-        if (itupdatechild == updatedNode->children.end())
-        {
+        if (itupdatechild == updatedNode->children.end()) {
             // This character has apparently been deleted, so delete
             // all descendents from this child.
             std::stringstream ss;
             ss << name << itchild->first;
             std::string newName = ss.str();
-            if (!recursiveNullify(itchild->second, newName))
-                return false;
+            if (!recursiveNullify(itchild->second, newName)) return false;
             current->children.erase(itchild++);
-        }
-        else
+        } else {
             ++itchild;
+        }
     }
     return true;
 }
@@ -922,13 +559,11 @@ bool CClaimTrie::updateName(const std::string &name, CClaimTrieNode* updatedNode
 bool CClaimTrie::recursiveNullify(CClaimTrieNode* node, std::string& name)
 {
     assert(node != NULL);
-    for (nodeMapType::iterator itchild = node->children.begin(); itchild != node->children.end(); ++itchild)
-    {
+    for (nodeMapType::iterator itchild = node->children.begin(); itchild != node->children.end(); ++itchild) {
         std::stringstream ss;
         ss << name << itchild->first;
         std::string newName = ss.str();
-        if (!recursiveNullify(itchild->second, newName))
-            return false;
+        if (!recursiveNullify(itchild->second, newName)) return false;
     }
     node->children.clear();
     markNodeDirty(name, NULL);
@@ -936,14 +571,12 @@ bool CClaimTrie::recursiveNullify(CClaimTrieNode* node, std::string& name)
     return true;
 }
 
-bool CClaimTrie::updateHash(const std::string& name, uint256& hash)
+bool CClaimTrie::updateHash(const std::string& name, const uint256& hash)
 {
     CClaimTrieNode* current = &root;
-    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname)
-    {
+    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname) {
         nodeMapType::iterator itchild = current->children.find(*itname);
-        if (itchild == current->children.end())
-            return false;
+        if (itchild == current->children.end()) return false;
         current = itchild->second;
     }
     assert(current != NULL);
@@ -955,11 +588,9 @@ bool CClaimTrie::updateHash(const std::string& name, uint256& hash)
 bool CClaimTrie::updateTakeoverHeight(const std::string& name, int nTakeoverHeight)
 {
     CClaimTrieNode* current = &root;
-    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname)
-    {
+    for (std::string::const_iterator itname = name.begin(); itname != name.end(); ++itname) {
         nodeMapType::iterator itchild = current->children.find(*itname);
-        if (itchild == current->children.end())
-            return false;
+        if (itchild == current->children.end()) return false;
         current = itchild->second;
     }
     assert(current != NULL);
@@ -968,164 +599,41 @@ bool CClaimTrie::updateTakeoverHeight(const std::string& name, int nTakeoverHeig
     return true;
 }
 
-void CClaimTrie::BatchWriteNode(CDBBatch& batch, const std::string& name, const CClaimTrieNode* pNode) const
-{
-    uint32_t num_claims = 0;
-    if (pNode)
-        num_claims = pNode->claims.size();
-    LogPrintf("%s: Writing %s to disk with %d claims\n", __func__, name, num_claims);
-    if (pNode)
-        batch.Write(std::make_pair(TRIE_NODE, name), *pNode);
-    else
-        batch.Erase(std::make_pair(TRIE_NODE, name));
-}
-
-void CClaimTrie::BatchWriteQueueRows(CDBBatch& batch)
-{
-    for (claimQueueType::iterator itQueue = dirtyQueueRows.begin(); itQueue != dirtyQueueRows.end(); ++itQueue)
-    {
-        if (itQueue->second.empty())
-        {
-            batch.Erase(std::make_pair(CLAIM_QUEUE_ROW, itQueue->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(CLAIM_QUEUE_ROW, itQueue->first), itQueue->second);
-        }
-    }
-}
-
-void CClaimTrie::BatchWriteQueueNameRows(CDBBatch& batch)
-{
-    for (queueNameType::iterator itQueue = dirtyQueueNameRows.begin(); itQueue != dirtyQueueNameRows.end(); ++itQueue)
-    {
-        if (itQueue->second.empty())
-        {
-            batch.Erase(std::make_pair(CLAIM_QUEUE_NAME_ROW, itQueue->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(CLAIM_QUEUE_NAME_ROW, itQueue->first), itQueue->second);
-        }
-    }
-}
-
-void CClaimTrie::BatchWriteExpirationQueueRows(CDBBatch& batch)
-{
-    for (expirationQueueType::iterator itQueue = dirtyExpirationQueueRows.begin(); itQueue != dirtyExpirationQueueRows.end(); ++itQueue)
-    {
-        if (itQueue->second.empty())
-        {
-            batch.Erase(std::make_pair(EXP_QUEUE_ROW, itQueue->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(EXP_QUEUE_ROW, itQueue->first), itQueue->second);
-        }
-    }
-}
-
-void CClaimTrie::BatchWriteSupportNodes(CDBBatch& batch)
-{
-    for (supportMapType::iterator itSupport = dirtySupportNodes.begin(); itSupport != dirtySupportNodes.end(); ++itSupport)
-    {
-        if (itSupport->second.empty())
-        {
-            batch.Erase(std::make_pair(SUPPORT, itSupport->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(SUPPORT, itSupport->first), itSupport->second);
-        }
-    }
-}
-
-void CClaimTrie::BatchWriteSupportQueueRows(CDBBatch& batch)
-{
-    for (supportQueueType::iterator itQueue = dirtySupportQueueRows.begin(); itQueue != dirtySupportQueueRows.end(); ++itQueue)
-    {
-        if (itQueue->second.empty())
-        {
-            batch.Erase(std::make_pair(SUPPORT_QUEUE_ROW, itQueue->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(SUPPORT_QUEUE_ROW, itQueue->first), itQueue->second);
-        }
-    }
-}
-
-void CClaimTrie::BatchWriteSupportQueueNameRows(CDBBatch& batch)
-{
-    for (queueNameType::iterator itQueue = dirtySupportQueueNameRows.begin(); itQueue != dirtySupportQueueNameRows.end(); ++itQueue)
-    {
-        if (itQueue->second.empty())
-        {
-            batch.Erase(std::make_pair(SUPPORT_QUEUE_NAME_ROW, itQueue->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(SUPPORT_QUEUE_NAME_ROW, itQueue->first), itQueue->second);
-        }
-    }
-}
-
-void CClaimTrie::BatchWriteSupportExpirationQueueRows(CDBBatch& batch)
-{
-    for (expirationQueueType::iterator itQueue = dirtySupportExpirationQueueRows.begin(); itQueue != dirtySupportExpirationQueueRows.end(); ++itQueue)
-    {
-        if (itQueue->second.empty())
-        {
-            batch.Erase(std::make_pair(SUPPORT_EXP_QUEUE_ROW, itQueue->first));
-        }
-        else
-        {
-            batch.Write(std::make_pair(SUPPORT_EXP_QUEUE_ROW, itQueue->first), itQueue->second);
-        }
-    }
-}
-
 bool CClaimTrie::WriteToDisk()
 {
-    CDBBatch batch(&db.GetObfuscateKey());
-    for (nodeCacheType::iterator itcache = dirtyNodes.begin(); itcache != dirtyNodes.end(); ++itcache)
-        BatchWriteNode(batch, itcache->first, itcache->second);
+    for (nodeCacheType::iterator itcache = dirtyNodes.begin(); itcache != dirtyNodes.end(); ++itcache) {
+        CClaimTrieNode* pNode = itcache->second;
+        uint32_t num_claims = pNode ? pNode->claims.size() : 0;
+        LogPrintf("%s: Writing %s to disk with %d claims\n", __func__, itcache->first, num_claims);
+        if (pNode) {
+            CClaimTrieNode copy(*pNode);
+            db.updateQueueRow(itcache->first, copy);
+        } else {
+            CClaimTrieNode emptyNode;
+            db.updateQueueRow(itcache->first, emptyNode);
+        }
+    }
+
     dirtyNodes.clear();
-    BatchWriteQueueRows(batch);
-    dirtyQueueRows.clear();
-    BatchWriteQueueNameRows(batch);
-    dirtyQueueNameRows.clear();
-    BatchWriteExpirationQueueRows(batch);
-    dirtyExpirationQueueRows.clear();
-    BatchWriteSupportNodes(batch);
-    dirtySupportNodes.clear();
-    BatchWriteSupportQueueRows(batch);
-    dirtySupportQueueRows.clear();
-    BatchWriteSupportQueueNameRows(batch);
-    dirtySupportQueueNameRows.clear();
-    BatchWriteSupportExpirationQueueRows(batch);
-    dirtySupportExpirationQueueRows.clear();
-    batch.Write(HASH_BLOCK, hashBlock);
-    batch.Write(CURRENT_HEIGHT, nCurrentHeight);
-    return db.WriteBatch(batch);
+    db.writeQueues();
+    db.Write(HASH_BLOCK, hashBlock);
+    db.Write(CURRENT_HEIGHT, nCurrentHeight);
+    return db.Sync();
 }
 
 bool CClaimTrie::InsertFromDisk(const std::string& name, CClaimTrieNode* node)
 {
-    if (name.size() == 0)
-    {
+    if (name.empty()) {
         root = *node;
         return true;
     }
     CClaimTrieNode* current = &root;
-    for (std::string::const_iterator itname = name.begin(); itname + 1 != name.end(); ++itname)
-    {
+    for (std::string::const_iterator itname = name.begin(); itname + 1 != name.end(); ++itname) {
         nodeMapType::iterator itchild = current->children.find(*itname);
-        if (itchild == current->children.end())
-            return false;
+        if (itchild == current->children.end()) return false;
         current = itchild->second;
     }
-    current->children[name[name.size()-1]] = node;
+    current->children[name[name.size() - 1]] = new CClaimTrieNode(*node);
     return true;
 }
 
@@ -1135,91 +643,84 @@ bool CClaimTrie::ReadFromDisk(bool check)
         LogPrintf("%s: Couldn't read the best block's hash\n", __func__);
     if (!db.Read(CURRENT_HEIGHT, nCurrentHeight))
         LogPrintf("%s: Couldn't read the current height\n", __func__);
-    setExpirationTime(Params().GetConsensus().GetExpirationTime(nCurrentHeight-1));
 
-    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&db)->NewIterator());
+    setExpirationTime(Params().GetConsensus().GetExpirationTime(nCurrentHeight - 1));
 
-    pcursor->SeekToFirst();
-    while (pcursor->Valid())
-    {
-        std::pair<char, std::string> key;
-        if (pcursor->GetKey(key))
-        {
-            if (key.first == TRIE_NODE)
-            {
-                CClaimTrieNode* node = new CClaimTrieNode();
-                if (pcursor->GetValue(*node))
-                {
-                    if (!InsertFromDisk(key.second, node))
-                    {
-                        return error("%s(): error restoring claim trie from disk", __func__);
-                    }
-                }
-                else
-                {
-                    return error("%s(): error reading claim trie from disk", __func__);
-                }
-            }
-        }
-        pcursor->Next();
+    typedef std::map<std::string, CClaimTrieNode, nodeNameCompare> trieNodeMapType;
+
+    trieNodeMapType nodes;
+    if (!db.seekByKey(nodes)) {
+        return error("%s(): error reading claim trie from disk", __func__);
     }
 
-    if (check)
-    {
+    for (trieNodeMapType::iterator it = nodes.begin(); it != nodes.end(); ++it) {
+        if (!InsertFromDisk(it->first, &(it->second))) {
+            return error("%s(): error restoring claim trie from disk", __func__);
+        }
+    }
+
+    if (check) {
         LogPrintf("Checking Claim trie consistency...");
-        if (checkConsistency())
-        {
+        if (checkConsistency()) {
             LogPrintf("consistent\n");
             return true;
+        } else {
+            LogPrintf("inconsistent!\n");
+            return false;
         }
-        LogPrintf("inconsistent!\n");
-        return false;
     }
     return true;
 }
 
-bool CClaimTrieCache::recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent, std::string sPos) const
+CClaimTrieCache::CClaimTrieCache(CClaimTrie* base, bool fRequireTakeoverHeights)
+    : base(base), fRequireTakeoverHeights(fRequireTakeoverHeights)
 {
-    if (sPos == "" && tnCurrent->empty())
-    {
-        cacheHashes[""] = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+    assert(base);
+    hashBlock = base->hashBlock;
+    nCurrentHeight = base->nCurrentHeight;
+}
+
+CClaimTrieCache::~CClaimTrieCache()
+{
+    clear();
+}
+
+bool CClaimTrieCache::recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent, const std::string& sPos) const
+{
+    if (sPos == "" && tnCurrent->empty()) {
+        cacheHashes[""] = one;
         return true;
     }
     std::vector<unsigned char> vchToHash;
-    nodeCacheType::iterator cachedNode;
+    nodeCacheType::const_iterator cachedNode;
 
 
-    for (nodeMapType::iterator it = tnCurrent->children.begin(); it != tnCurrent->children.end(); ++it)
-    {
+    for (nodeMapType::iterator it = tnCurrent->children.begin(); it != tnCurrent->children.end(); ++it) {
         std::stringstream ss;
         ss << it->first;
         std::string sNextPos = sPos + ss.str();
-        if (dirtyHashes.count(sNextPos) != 0)
-        {
+        if (dirtyHashes.count(sNextPos) != 0) {
             // the child might be in the cache, so look for it there
             cachedNode = cache.find(sNextPos);
-            if (cachedNode != cache.end())
+            if (cachedNode != cache.end()) {
                 recursiveComputeMerkleHash(cachedNode->second, sNextPos);
-            else
+            } else {
                 recursiveComputeMerkleHash(it->second, sNextPos);
+            }
         }
         vchToHash.push_back(it->first);
         hashMapType::iterator ithash = cacheHashes.find(sNextPos);
-        if (ithash != cacheHashes.end())
-        {
+        if (ithash != cacheHashes.end()) {
             vchToHash.insert(vchToHash.end(), ithash->second.begin(), ithash->second.end());
-        }
-        else
-        {
+        } else {
             vchToHash.insert(vchToHash.end(), it->second->hash.begin(), it->second->hash.end());
         }
     }
-    
+
     CClaimValue claim;
     bool hasClaim = tnCurrent->getBestClaim(claim);
 
-    if (hasClaim)
-    {
+    if (hasClaim) {
         int nHeightOfLastTakeover;
         assert(getLastTakeoverForName(sPos, nHeightOfLastTakeover));
         uint256 valueHash = getValueHash(claim.outPoint, nHeightOfLastTakeover);
@@ -1232,31 +733,29 @@ bool CClaimTrieCache::recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent, std:
     hasher.Finalize(&(vchHash[0]));
     cacheHashes[sPos] = uint256(vchHash);
     std::set<std::string>::iterator itDirty = dirtyHashes.find(sPos);
-    if (itDirty != dirtyHashes.end())
+    if (itDirty != dirtyHashes.end()) {
         dirtyHashes.erase(itDirty);
+    }
     return true;
 }
 
 uint256 CClaimTrieCache::getMerkleHash() const
 {
-    if (empty())
-    {
-        uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
-        return one;
-    }
-    if (dirty())
-    {
-        nodeCacheType::iterator cachedNode = cache.find("");
-        if (cachedNode != cache.end())
+    if (empty()) return one;
+    if (dirty()) {
+        nodeCacheType::const_iterator cachedNode = cache.find("");
+        if (cachedNode != cache.end()) {
             recursiveComputeMerkleHash(cachedNode->second, "");
-        else
+        } else {
             recursiveComputeMerkleHash(&(base->root), "");
+        }
     }
-    hashMapType::iterator ithash = cacheHashes.find("");
-    if (ithash != cacheHashes.end())
+    hashMapType::const_iterator ithash = cacheHashes.find("");
+    if (ithash != cacheHashes.end()) {
         return ithash->second;
-    else
+    } else {
         return base->root.hash;
+    }
 }
 
 bool CClaimTrieCache::empty() const
@@ -1264,26 +763,27 @@ bool CClaimTrieCache::empty() const
     return base->empty() && cache.empty();
 }
 
-CClaimTrieNode* CClaimTrieCache::addNodeToCache(const std::string& position, CClaimTrieNode* original) const
+CClaimTrieNode* CClaimTrieCache::addNodeToCache(const std::string& position, CClaimTrieNode* original)
 {
     // create a copy of the node in the cache, if new node, create empty node
     CClaimTrieNode* cacheCopy;
-    if(!original)
+    if (!original) {
         cacheCopy = new CClaimTrieNode();
-    else
+    } else {
         cacheCopy = new CClaimTrieNode(*original);
+    }
     cache[position] = cacheCopy;
 
     // check to see if there is the original node in block_originals,
     // if not, add it to block_originals cache
     nodeCacheType::const_iterator itOriginals = block_originals.find(position);
-    if (block_originals.end() == itOriginals)
-    {
+    if (block_originals.end() == itOriginals) {
         CClaimTrieNode* originalCopy;
-        if(!original)
+        if (!original) {
             originalCopy = new CClaimTrieNode();
-        else
+        } else {
             originalCopy = new CClaimTrieNode(*original);
+        }
         block_originals[position] = originalCopy;
     }
     return cacheCopy;
@@ -1292,39 +792,36 @@ CClaimTrieNode* CClaimTrieCache::addNodeToCache(const std::string& position, CCl
 bool CClaimTrieCache::getOriginalInfoForName(const std::string& name, CClaimValue& claim) const
 {
     nodeCacheType::const_iterator itOriginalCache = block_originals.find(name);
-    if (itOriginalCache == block_originals.end())
-    {
+    if (itOriginalCache == block_originals.end()) {
         return base->getInfoForName(name, claim);
     }
     return itOriginalCache->second->getBestClaim(claim);
 }
 
-bool CClaimTrieCache::insertClaimIntoTrie(const std::string& name, CClaimValue claim, bool fCheckTakeover) const
+bool CClaimTrieCache::insertClaimIntoTrie(const std::string& name, const CClaimValue& claim, bool fCheckTakeover)
 {
     assert(base);
     CClaimTrieNode* currentNode = &(base->root);
     nodeCacheType::iterator cachedNode;
     cachedNode = cache.find("");
-    if (cachedNode != cache.end())
+    if (cachedNode != cache.end()) {
         currentNode = cachedNode->second;
-    for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur)
-    {
+    }
+    for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur) {
         std::string sCurrentSubstring(name.begin(), itCur);
         std::string sNextSubstring(name.begin(), itCur + 1);
 
         cachedNode = cache.find(sNextSubstring);
-        if (cachedNode != cache.end())
-        {
+        if (cachedNode != cache.end()) {
             currentNode = cachedNode->second;
             continue;
         }
         nodeMapType::iterator childNode = currentNode->children.find(*itCur);
-        if (childNode != currentNode->children.end())
-        {
+        if (childNode != currentNode->children.end()) {
             currentNode = childNode->second;
             continue;
         }
-        
+
         // This next substring doesn't exist in the cache and the next
         // character doesn't exist in current node's children, so check
         // if the current node is in the cache, and if it's not, copy
@@ -1335,12 +832,9 @@ bool CClaimTrieCache::insertClaimIntoTrie(const std::string& name, CClaimValue c
         // used to find the child in the cache. This is necessary in
         // order to calculate the merkle hash.
         cachedNode = cache.find(sCurrentSubstring);
-        if (cachedNode != cache.end())
-        {
+        if (cachedNode != cache.end()) {
             assert(cachedNode->second == currentNode);
-        }
-        else
-        {
+        } else {
             currentNode = addNodeToCache(sCurrentSubstring, currentNode);
         }
         CClaimTrieNode* newNode = addNodeToCache(sNextSubstring, NULL);
@@ -1349,68 +843,59 @@ bool CClaimTrieCache::insertClaimIntoTrie(const std::string& name, CClaimValue c
     }
 
     cachedNode = cache.find(name);
-    if (cachedNode != cache.end())
-    {
+    if (cachedNode != cache.end()) {
         assert(cachedNode->second == currentNode);
-    }
-    else
-    {
+    } else {
         currentNode = addNodeToCache(name, currentNode);
     }
     bool fChanged = false;
-    if (currentNode->claims.empty())
-    {
+    if (currentNode->claims.empty()) {
         fChanged = true;
         currentNode->insertClaim(claim);
-    }
-    else
-    {
+    } else {
         CClaimValue currentTop = currentNode->claims.front();
         currentNode->insertClaim(claim);
         supportMapEntryType node;
         getSupportsForName(name, node);
         currentNode->reorderClaims(node);
-        if (currentTop != currentNode->claims.front())
+        if (currentTop != currentNode->claims.front()) {
             fChanged = true;
+        }
     }
-
-    if (fChanged)
-    {
-        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur)
-        {
+    if (fChanged) {
+        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur) {
             std::string sub(name.begin(), itCur);
             dirtyHashes.insert(sub);
         }
         dirtyHashes.insert(name);
-        if (fCheckTakeover)
+        if (fCheckTakeover) {
             namesToCheckForTakeover.insert(name);
+        }
     }
     return true;
 }
 
-bool CClaimTrieCache::removeClaimFromTrie(const std::string& name, const COutPoint& outPoint, CClaimValue& claim, bool fCheckTakeover) const
+bool CClaimTrieCache::removeClaimFromTrie(const std::string& name, const COutPoint& outPoint, CClaimValue& claim, bool fCheckTakeover)
 {
     assert(base);
     CClaimTrieNode* currentNode = &(base->root);
     nodeCacheType::iterator cachedNode;
     cachedNode = cache.find("");
-    if (cachedNode != cache.end())
+    if (cachedNode != cache.end()) {
         currentNode = cachedNode->second;
+    }
     assert(currentNode != NULL); // If there is no root in either the trie or the cache, how can there be any names to remove?
-    for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur)
-    {
+    for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur) {
         std::string sCurrentSubstring(name.begin(), itCur);
         std::string sNextSubstring(name.begin(), itCur + 1);
 
         cachedNode = cache.find(sNextSubstring);
-        if (cachedNode != cache.end())
-        {
+        if (cachedNode != cache.end()) {
             currentNode = cachedNode->second;
             continue;
         }
         nodeMapType::iterator childNode = currentNode->children.find(*itCur);
-        if (childNode != currentNode->children.end())
-        {
+        if (childNode != currentNode->children.end()) {
             currentNode = childNode->second;
             continue;
         }
@@ -1419,87 +904,80 @@ bool CClaimTrieCache::removeClaimFromTrie(const std::string& name, const COutPoi
     }
 
     cachedNode = cache.find(name);
-    if (cachedNode != cache.end())
+    if (cachedNode != cache.end()) {
         assert(cachedNode->second == currentNode);
-    else
-    {
+    } else {
         currentNode = addNodeToCache(name, currentNode);
     }
     bool fChanged = false;
     assert(currentNode != NULL);
     bool success = false;
-    
-    if (currentNode->claims.empty())
-    {
+
+    if (currentNode->claims.empty()) {
         LogPrintf("%s: Asked to remove claim from node without claims\n", __func__);
         return false;
     }
     CClaimValue currentTop = currentNode->claims.front();
 
     success = currentNode->removeClaim(outPoint, claim);
-    if (!currentNode->claims.empty())
-    {
+    if (!currentNode->claims.empty()) {
         supportMapEntryType node;
         getSupportsForName(name, node);
         currentNode->reorderClaims(node);
-        if (currentTop != currentNode->claims.front())
+        if (currentTop != currentNode->claims.front()) {
             fChanged = true;
-    }
-    else
+        }
+    } else {
         fChanged = true;
+    }
 
-    if (!success)
-    {
+    if (!success) {
         LogPrintf("%s: Removing a claim was unsuccessful. name = %s, txhash = %s, nOut = %d", __func__, name.c_str(), outPoint.hash.GetHex(), outPoint.n);
         return false;
     }
 
-    if (fChanged)
-    {
-        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur)
-        {
+    if (fChanged) {
+        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur) {
             std::string sub(name.begin(), itCur);
             dirtyHashes.insert(sub);
         }
         dirtyHashes.insert(name);
-        if (fCheckTakeover)
+        if (fCheckTakeover) {
             namesToCheckForTakeover.insert(name);
+        }
     }
     CClaimTrieNode* rootNode = &(base->root);
     cachedNode = cache.find("");
-    if (cachedNode != cache.end())
+    if (cachedNode != cache.end()) {
         rootNode = cachedNode->second;
+    }
     return recursivePruneName(rootNode, 0, name);
 }
 
-bool CClaimTrieCache::recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, std::string sName, bool* pfNullified) const
+bool CClaimTrieCache::recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, const std::string& sName, bool* pfNullified)
 {
     // Recursively prune leaf node(s) without any claims in it and store
     // the modified nodes in the cache
 
     bool fNullified = false;
     std::string sCurrentSubstring = sName.substr(0, nPos);
-    if (nPos < sName.size())
-    {
+    if (nPos < sName.size()) {
         std::string sNextSubstring = sName.substr(0, nPos + 1);
         unsigned char cNext = sName.at(nPos);
         CClaimTrieNode* tnNext = NULL;
         nodeCacheType::iterator cachedNode = cache.find(sNextSubstring);
-        if (cachedNode != cache.end())
+        if (cachedNode != cache.end()) {
             tnNext = cachedNode->second;
-        else
-        {
+        } else {
             nodeMapType::iterator childNode = tnCurrent->children.find(cNext);
-            if (childNode != tnCurrent->children.end())
+            if (childNode != tnCurrent->children.end()) {
                 tnNext = childNode->second;
+            }
         }
-        if (tnNext == NULL)
-            return false;
+        if (tnNext == NULL) return false;
         bool fChildNullified = false;
-        if (!recursivePruneName(tnNext, nPos + 1, sName, &fChildNullified))
-            return false;
-        if (fChildNullified)
-        {
+        if (!recursivePruneName(tnNext, nPos + 1, sName, &fChildNullified)) return false;
+        if (fChildNullified) {
             // If the child nullified itself, the child should already be
             // out of the cache, and the character must now be removed
             // from the current node's map of child nodes to ensure that
@@ -1507,15 +985,14 @@ bool CClaimTrieCache::recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int
             // tnCurrent isn't necessarily in the cache. If it's not, it
             // has to be added to the cache, so nothing is changed in the
             // trie. If the current node is added to the cache, however,
-            // that does not imply that the parent node must be altered to 
+            // that does not imply that the parent node must be altered to
             // reflect that its child is now in the cache, since it
             // already has a character in its child map which will be used
             // when calculating the merkle root.
 
             // First, find out if this node is in the cache.
             cachedNode = cache.find(sCurrentSubstring);
-            if (cachedNode == cache.end())
-            {
+            if (cachedNode == cache.end()) {
                 // it isn't, so make a copy, stick it in the cache,
                 // and make it the new current node
                 tnCurrent = addNodeToCache(sCurrentSubstring, tnCurrent);
@@ -1523,272 +1000,189 @@ bool CClaimTrieCache::recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int
             // erase the character from the current node, which is
             // now guaranteed to be in the cache
             nodeMapType::iterator childNode = tnCurrent->children.find(cNext);
-            if (childNode != tnCurrent->children.end())
+            if (childNode != tnCurrent->children.end()) {
                 tnCurrent->children.erase(childNode);
-            else
+            } else {
                 return false;
+            }
         }
     }
-    if (sCurrentSubstring.size() != 0 && tnCurrent->empty())
-    {
+    if (sCurrentSubstring.size() != 0 && tnCurrent->empty()) {
         // If the current node is in the cache, remove it from there
         nodeCacheType::iterator cachedNode = cache.find(sCurrentSubstring);
-        if (cachedNode != cache.end())
-        {
+        if (cachedNode != cache.end()) {
             assert(tnCurrent == cachedNode->second);
             delete tnCurrent;
             cache.erase(cachedNode);
         }
         fNullified = true;
     }
-    if (pfNullified)
+    if (pfNullified) {
         *pfNullified = fNullified;
+    }
     return true;
 }
 
-claimQueueType::iterator CClaimTrieCache::getQueueCacheRow(int nHeight, bool createIfNotExists) const
-{
-    claimQueueType::iterator itQueueRow = claimQueueCache.find(nHeight);
-    if (itQueueRow == claimQueueCache.end())
-    {
-        // Have to make a new row it put in the cache, if createIfNotExists is true
-        claimQueueRowType queueRow;
-        // If the row exists in the base, copy its claims into the new row.
-        bool exists = base->getQueueRow(nHeight, queueRow);
-        if (!exists)
-            if (!createIfNotExists)
-                return itQueueRow;
-        // Stick the new row in the cache
-        std::pair<claimQueueType::iterator, bool> ret;
-        ret = claimQueueCache.insert(std::pair<int, claimQueueRowType >(nHeight, queueRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    return itQueueRow;
-}
-
-queueNameType::iterator CClaimTrieCache::getQueueCacheNameRow(const std::string& name, bool createIfNotExists) const
-{
-    queueNameType::iterator itQueueNameRow = claimQueueNameCache.find(name);
-    if (itQueueNameRow == claimQueueNameCache.end())
-    {
-        // Have to make a new name row and put it in the cache, if createIfNotExists is true
-        queueNameRowType queueNameRow;
-        // If the row exists in the base, copy its claims into the new row.
-        bool exists = base->getQueueNameRow(name, queueNameRow);
-        if (!exists)
-            if (!createIfNotExists)
-                return itQueueNameRow;
-        // Stick the new row in the cache
-        std::pair<queueNameType::iterator, bool> ret;
-        ret = claimQueueNameCache.insert(std::pair<std::string, queueNameRowType>(name, queueNameRow));
-        assert(ret.second);
-        itQueueNameRow = ret.first;
-    }
-    return itQueueNameRow;
-}
-
-bool CClaimTrieCache::addClaim(const std::string& name, const COutPoint& outPoint, uint160 claimId, CAmount nAmount, int nHeight) const
+bool CClaimTrieCache::addClaim(const std::string& name, const COutPoint& outPoint, const uint160& claimId, const CAmount& nAmount, int nHeight)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %d, claimId: %s, nAmount: %d, nHeight: %d, nCurrentHeight: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, claimId.GetHex(), nAmount, nHeight, nCurrentHeight);
     assert(nHeight == nCurrentHeight);
     CClaimValue currentClaim;
     int delayForClaim;
-    if (getOriginalInfoForName(name, currentClaim) && currentClaim.claimId == claimId)
-    {
+    if (getOriginalInfoForName(name, currentClaim) && currentClaim.claimId == claimId) {
         LogPrintf("%s: This is an update to a best claim.\n", __func__);
         delayForClaim = 0;
-    }
-    else
-    {
+    } else {
         delayForClaim = getDelayForName(name);
     }
     CClaimValue newClaim(outPoint, claimId, nAmount, nHeight, nHeight + delayForClaim);
     return addClaimToQueues(name, newClaim);
 }
 
-bool CClaimTrieCache::undoSpendClaim(const std::string& name, const COutPoint& outPoint, uint160 claimId, CAmount nAmount, int nHeight, int nValidAtHeight) const
+bool CClaimTrieCache::undoSpendClaim(const std::string& name, const COutPoint& outPoint, const uint160& claimId, const CAmount& nAmount, int nHeight, int nValidAtHeight)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %d, claimId: %s, nAmount: %d, nHeight: %d, nValidAtHeight: %d, nCurrentHeight: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, claimId.GetHex(), nAmount, nHeight, nValidAtHeight, nCurrentHeight);
     CClaimValue claim(outPoint, claimId, nAmount, nHeight, nValidAtHeight);
-    if (nValidAtHeight < nCurrentHeight)
-    {
+    if (nValidAtHeight < nCurrentHeight) {
         nameOutPointType entry(name, claim.outPoint);
         addToExpirationQueue(claim.nHeight + base->nExpirationTime, entry);
-        CClaimIndexElement element = {name, claim};
-        claimsToAdd.push_back(element);
+        base->addToClaimIndex(name, claim);
         return insertClaimIntoTrie(name, claim, false);
-    }
-    else
-    {
+    } else {
         return addClaimToQueues(name, claim);
     }
 }
 
-bool CClaimTrieCache::addClaimToQueues(const std::string& name, CClaimValue& claim) const
+template <typename K, typename V>
+typename std::map<K, V>::iterator CClaimTrieCache::getQueueCacheRow(const K& key, std::map<K, V>& map, bool createIfNotExists)
+{
+    typename std::map<K, V>::iterator itQueueRow = map.find(key);
+    if (itQueueRow == map.end()) {
+        // Have to make a new row it put in the cache, if createIfNotExists is true
+        V queueRow;
+        // If the row exists in the base, copy its claims into the new row.
+        bool exists = base->db.getQueueRow(key, queueRow);
+        if (!exists && !createIfNotExists) return itQueueRow;
+        // Stick the new row in the cache
+        itQueueRow = map.insert(itQueueRow, std::make_pair(key, queueRow));
+    }
+    return itQueueRow;
+}
+
+bool CClaimTrieCache::addClaimToQueues(const std::string& name, CClaimValue& claim)
 {
     LogPrintf("%s: nValidAtHeight: %d\n", __func__, claim.nValidAtHeight);
     claimQueueEntryType entry(name, claim);
-    claimQueueType::iterator itQueueRow = getQueueCacheRow(claim.nValidAtHeight, true);
-    queueNameType::iterator itQueueNameRow = getQueueCacheNameRow(name, true);
+    claimQueueType::iterator itQueueRow = getQueueCacheRow(claim.nValidAtHeight, claimQueueCache, true);
+    queueNameType::iterator itQueueNameRow = getQueueCacheRow(name, claimQueueNameCache, true);
     itQueueRow->second.push_back(entry);
     itQueueNameRow->second.push_back(outPointHeightType(claim.outPoint, claim.nValidAtHeight));
     nameOutPointType expireEntry(name, claim.outPoint);
     addToExpirationQueue(claim.nHeight + base->nExpirationTime, expireEntry);
-    CClaimIndexElement element = {name, claim};
-    claimsToAdd.push_back(element);
+    base->addToClaimIndex(name, claim);
     return true;
 }
 
-bool CClaimTrieCache::removeClaimFromQueue(const std::string& name, const COutPoint& outPoint, CClaimValue& claim) const
+bool CClaimTrieCache::removeClaimFromQueue(const std::string& name, const COutPoint& outPoint, CClaimValue& claim)
 {
-    queueNameType::iterator itQueueNameRow = getQueueCacheNameRow(name, false);
-    if (itQueueNameRow == claimQueueNameCache.end())
-    {
-        return false;
-    }
+    queueNameType::iterator itQueueNameRow = getQueueCacheRow(name, claimQueueNameCache, false);
+    if (itQueueNameRow == claimQueueNameCache.end()) return false;
     queueNameRowType::iterator itQueueName;
-    for (itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName)
-    {
-        if (itQueueName->outPoint == outPoint)
-        {
-            break;
-        }
+    for (itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName) {
+        if (itQueueName->outPoint == outPoint) break;
     }
-    if (itQueueName == itQueueNameRow->second.end())
-    {
-        return false;
-    }
-    claimQueueType::iterator itQueueRow = getQueueCacheRow(itQueueName->nHeight, false);
-    if (itQueueRow != claimQueueCache.end())
-    {
+    if (itQueueName == itQueueNameRow->second.end()) return false;
+    claimQueueType::iterator itQueueRow = getQueueCacheRow(itQueueName->nHeight, claimQueueCache, false);
+    if (itQueueRow != claimQueueCache.end()) {
         claimQueueRowType::iterator itQueue;
-        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue)
-        {
-            if (name == itQueue->first && itQueue->second.outPoint == outPoint)
-            {
-                break;
+        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue) {
+            if (name == itQueue->first && itQueue->second.outPoint == outPoint) {
+                std::swap(claim, itQueue->second);
+                itQueueNameRow->second.erase(itQueueName);
+                itQueueRow->second.erase(itQueue);
+                return true;
             }
-        }
-        if (itQueue != itQueueRow->second.end())
-        {
-            std::swap(claim, itQueue->second);
-            itQueueNameRow->second.erase(itQueueName);
-            itQueueRow->second.erase(itQueue);
-            return true;
         }
     }
     LogPrintf("%s: An inconsistency was found in the claim queue. Please report this to the developers:\nFound in named queue but not in height queue: name: %s, txid: %s, nOut: %d, nValidAtHeight: %d, current height: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, itQueueName->nHeight, nCurrentHeight);
     return false;
 }
 
-bool CClaimTrieCache::undoAddClaim(const std::string& name, const COutPoint& outPoint, int nHeight) const
+bool CClaimTrieCache::undoAddClaim(const std::string& name, const COutPoint& outPoint, int nHeight)
 {
     int throwaway;
     return removeClaim(name, outPoint, nHeight, throwaway, false);
 }
 
-bool CClaimTrieCache::spendClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight) const
+bool CClaimTrieCache::spendClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight)
 {
     return removeClaim(name, outPoint, nHeight, nValidAtHeight, true);
 }
 
-bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover) const
+bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %s, nHeight: %s, nCurrentHeight: %s\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nHeight, nCurrentHeight);
     bool removed = false;
     CClaimValue claim;
-    if (removeClaimFromQueue(name, outPoint, claim))
-    {
+    if (removeClaimFromQueue(name, outPoint, claim)) {
         removed = true;
     }
-    if (removed == false && removeClaimFromTrie(name, outPoint, claim, fCheckTakeover))
-    {
+    if (removed == false && removeClaimFromTrie(name, outPoint, claim, fCheckTakeover)) {
         removed = true;
     }
-    if (removed == true)
-    {
+    if (removed == true) {
         nValidAtHeight = claim.nValidAtHeight;
         int expirationHeight = nHeight + base->nExpirationTime;
         removeFromExpirationQueue(name, outPoint, expirationHeight);
-        claimsToDelete.insert(claim);
+        base->removeFromClaimIndex(claim);
     }
     return removed;
 }
 
-void CClaimTrieCache::addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry) const
+void CClaimTrieCache::addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry)
 {
-    expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(nExpirationHeight, true);
+    expirationQueueType::iterator itQueueRow = getQueueCacheRow(nExpirationHeight, expirationQueueCache, true);
     itQueueRow->second.push_back(entry);
 }
 
-void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int expirationHeight) const
+void CClaimTrieCache::removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int expirationHeight)
 {
-    expirationQueueType::iterator itQueueRow = getExpirationQueueCacheRow(expirationHeight, false);
+    expirationQueueType::iterator itQueueRow = getQueueCacheRow(expirationHeight, expirationQueueCache, false);
     expirationQueueRowType::iterator itQueue;
-    if (itQueueRow != expirationQueueCache.end())
-    {
-        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue)
-        {
-            if (name == itQueue->name && outPoint == itQueue->outPoint)
+    if (itQueueRow != expirationQueueCache.end()) {
+        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue) {
+            if (name == itQueue->name && outPoint == itQueue->outPoint) {
+                itQueueRow->second.erase(itQueue);
                 break;
-        }
-
-        if (itQueue != itQueueRow->second.end())
-        {
-            itQueueRow->second.erase(itQueue);
+            }
         }
     }
 }
 
-expirationQueueType::iterator CClaimTrieCache::getExpirationQueueCacheRow(int nHeight, bool createIfNotExists) const
-{
-    expirationQueueType::iterator itQueueRow = expirationQueueCache.find(nHeight);
-    if (itQueueRow == expirationQueueCache.end())
-    {
-        // Have to make a new row it put in the cache, if createIfNotExists is true
-        expirationQueueRowType queueRow;
-        // If the row exists in the base, copy its claims into the new row.
-        bool exists = base->getExpirationQueueRow(nHeight, queueRow);
-        if (!exists)
-            if (!createIfNotExists)
-                return itQueueRow;
-        // Stick the new row in the cache
-        std::pair<expirationQueueType::iterator, bool> ret;
-        ret = expirationQueueCache.insert(std::pair<int, expirationQueueRowType >(nHeight, queueRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    return itQueueRow;
-}
-
-bool CClaimTrieCache::reorderTrieNode(const std::string& name, bool fCheckTakeover) const
+bool CClaimTrieCache::reorderTrieNode(const std::string& name, bool fCheckTakeover)
 {
     assert(base);
     nodeCacheType::iterator cachedNode;
     cachedNode = cache.find(name);
-    if (cachedNode == cache.end())
-    {
+    if (cachedNode == cache.end()) {
         CClaimTrieNode* currentNode;
         cachedNode = cache.find("");
-        if(cachedNode == cache.end())
+        if (cachedNode == cache.end()) {
             currentNode = &(base->root);
-        else
+        } else {
             currentNode = cachedNode->second;
-        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur)
-        {
+        }
+        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur) {
             std::string sCurrentSubstring(name.begin(), itCur);
             std::string sNextSubstring(name.begin(), itCur + 1);
 
             cachedNode = cache.find(sNextSubstring);
-            if (cachedNode != cache.end())
-            {
+            if (cachedNode != cache.end()) {
                 currentNode = cachedNode->second;
                 continue;
             }
             nodeMapType::iterator childNode = currentNode->children.find(*itCur);
-            if (childNode != currentNode->children.end())
-            {
+            if (childNode != currentNode->children.end()) {
                 currentNode = childNode->second;
                 continue;
             }
@@ -1802,59 +1196,52 @@ bool CClaimTrieCache::reorderTrieNode(const std::string& name, bool fCheckTakeov
         cachedNode = ret.first;
     }
     bool fChanged = false;
-    if (cachedNode->second->claims.empty())
-    {
+    if (cachedNode->second->claims.empty()) {
         // Nothing in there to reorder
         return true;
-    }
-    else
-    {
+    } else {
         CClaimValue currentTop = cachedNode->second->claims.front();
         supportMapEntryType node;
         getSupportsForName(name, node);
         cachedNode->second->reorderClaims(node);
-        if (cachedNode->second->claims.front() != currentTop)
+        if (cachedNode->second->claims.front() != currentTop) {
             fChanged = true;
+        }
     }
-    if (fChanged)
-    {
-        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur)
-        {
+    if (fChanged) {
+        for (std::string::const_iterator itCur = name.begin(); itCur != name.end(); ++itCur) {
             std::string sub(name.begin(), itCur);
             dirtyHashes.insert(sub);
         }
         dirtyHashes.insert(name);
-        if (fCheckTakeover)
+        if (fCheckTakeover) {
             namesToCheckForTakeover.insert(name);
+        }
     }
     return true;
 }
 
 bool CClaimTrieCache::getSupportsForName(const std::string& name, supportMapEntryType& node) const
 {
-    supportMapType::iterator cachedNode;
+    supportMapType::const_iterator cachedNode;
     cachedNode = supportCache.find(name);
-    if (cachedNode != supportCache.end())
-    {
+    if (cachedNode != supportCache.end()) {
         node = cachedNode->second;
         return true;
-    }
-    else
-    {
-        return base->getSupportNode(name, node);
+    } else {
+        return base->db.getQueueRow(name, node);
     }
 }
 
-bool CClaimTrieCache::insertSupportIntoMap(const std::string& name, CSupportValue support, bool fCheckTakeover) const
+bool CClaimTrieCache::insertSupportIntoMap(const std::string& name, const CSupportValue& support, bool fCheckTakeover)
 {
     supportMapType::iterator cachedNode;
     // If this node is already in the cache, use that
     cachedNode = supportCache.find(name);
     // If not, copy the one from base if it exists, and use that
-    if (cachedNode == supportCache.end())
-    {
+    if (cachedNode == supportCache.end()) {
         supportMapEntryType node;
-        base->getSupportNode(name, node);
+        base->db.getQueueRow(name, node);
         std::pair<supportMapType::iterator, bool> ret;
         ret = supportCache.insert(std::pair<std::string, supportMapEntryType>(name, node));
         assert(ret.second);
@@ -1862,18 +1249,16 @@ bool CClaimTrieCache::insertSupportIntoMap(const std::string& name, CSupportValu
     }
     cachedNode->second.push_back(support);
     // See if this changed the biggest bid
-    return reorderTrieNode(name,  fCheckTakeover);
+    return reorderTrieNode(name, fCheckTakeover);
 }
 
-bool CClaimTrieCache::removeSupportFromMap(const std::string& name, const COutPoint& outPoint, CSupportValue& support, bool fCheckTakeover) const
+bool CClaimTrieCache::removeSupportFromMap(const std::string& name, const COutPoint& outPoint, CSupportValue& support, bool fCheckTakeover)
 {
     supportMapType::iterator cachedNode;
     cachedNode = supportCache.find(name);
-    if (cachedNode == supportCache.end())
-    {
+    if (cachedNode == supportCache.end()) {
         supportMapEntryType node;
-        if (!base->getSupportNode(name, node))
-        {
+        if (!base->db.getQueueRow(name, node)) {
             // clearly, this support does not exist
             return false;
         }
@@ -1883,70 +1268,23 @@ bool CClaimTrieCache::removeSupportFromMap(const std::string& name, const COutPo
         cachedNode = ret.first;
     }
     supportMapEntryType::iterator itSupport;
-    for (itSupport = cachedNode->second.begin(); itSupport != cachedNode->second.end(); ++itSupport)
-    {
-        if (itSupport->outPoint == outPoint)
-        {
-            break;
+    for (itSupport = cachedNode->second.begin(); itSupport != cachedNode->second.end(); ++itSupport) {
+        if (itSupport->outPoint == outPoint) {
+            std::swap(support, *itSupport);
+            cachedNode->second.erase(itSupport);
+            return reorderTrieNode(name, fCheckTakeover);
         }
     }
-    if (itSupport != cachedNode->second.end())
-    {
-        std::swap(support, *itSupport);
-        cachedNode->second.erase(itSupport);
-        return reorderTrieNode(name, fCheckTakeover);
-    }
-    else
-    {
-        LogPrintf("CClaimTrieCache::%s() : asked to remove a support that doesn't exist\n", __func__);
-        return false;
-    }
+    LogPrintf("CClaimTrieCache::%s() : asked to remove a support that doesn't exist\n", __func__);
+    return false;
 }
 
-supportQueueType::iterator CClaimTrieCache::getSupportQueueCacheRow(int nHeight, bool createIfNotExists) const
-{
-    supportQueueType::iterator itQueueRow = supportQueueCache.find(nHeight);
-    if (itQueueRow == supportQueueCache.end())
-    {
-        supportQueueRowType queueRow;
-        bool exists = base->getSupportQueueRow(nHeight, queueRow);
-        if (!exists)
-            if (!createIfNotExists)
-                return itQueueRow;
-        // Stick the new row in the cache
-        std::pair<supportQueueType::iterator, bool> ret;
-        ret = supportQueueCache.insert(std::pair<int, supportQueueRowType >(nHeight, queueRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    return itQueueRow;
-}
-
-queueNameType::iterator CClaimTrieCache::getSupportQueueCacheNameRow(const std::string& name, bool createIfNotExists) const
-{
-    queueNameType::iterator itQueueNameRow = supportQueueNameCache.find(name);
-    if (itQueueNameRow == supportQueueNameCache.end())
-    {
-        queueNameRowType queueNameRow;
-        bool exists = base->getSupportQueueNameRow(name, queueNameRow);
-        if (!exists)
-            if (!createIfNotExists)
-                return itQueueNameRow;
-        // Stick the new row in the name cache
-        std::pair<queueNameType::iterator, bool> ret;
-        ret = supportQueueNameCache.insert(std::pair<std::string, queueNameRowType>(name, queueNameRow));
-        assert(ret.second);
-        itQueueNameRow = ret.first;
-    }
-    return itQueueNameRow;
-}
-
-bool CClaimTrieCache::addSupportToQueues(const std::string& name, CSupportValue& support) const
+bool CClaimTrieCache::addSupportToQueues(const std::string& name, CSupportValue& support)
 {
     LogPrintf("%s: nValidAtHeight: %d\n", __func__, support.nValidAtHeight);
     supportQueueEntryType entry(name, support);
-    supportQueueType::iterator itQueueRow = getSupportQueueCacheRow(support.nValidAtHeight, true);
-    queueNameType::iterator itQueueNameRow = getSupportQueueCacheNameRow(name, true);
+    supportQueueType::iterator itQueueRow = getQueueCacheRow(support.nValidAtHeight, supportQueueCache, true);
+    supportQueueNameType::iterator itQueueNameRow = getQueueCacheRow(name, supportQueueNameCache, true);
     itQueueRow->second.push_back(entry);
     itQueueNameRow->second.push_back(outPointHeightType(support.outPoint, support.nValidAtHeight));
     nameOutPointType expireEntry(name, support.outPoint);
@@ -1954,94 +1292,71 @@ bool CClaimTrieCache::addSupportToQueues(const std::string& name, CSupportValue&
     return true;
 }
 
-bool CClaimTrieCache::removeSupportFromQueue(const std::string& name, const COutPoint& outPoint, CSupportValue& support) const
+bool CClaimTrieCache::removeSupportFromQueue(const std::string& name, const COutPoint& outPoint, CSupportValue& support)
 {
-    queueNameType::iterator itQueueNameRow = getSupportQueueCacheNameRow(name, false);
-    if (itQueueNameRow == supportQueueNameCache.end())
-    {
-        return false;
+    supportQueueNameType::iterator itQueueNameRow = getQueueCacheRow(name, supportQueueNameCache, false);
+    if (itQueueNameRow == supportQueueNameCache.end()) return false;
+    supportQueueNameRowType::iterator itQueueName;
+    for (itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName) {
+        if (itQueueName->outPoint == outPoint) break;
     }
-    queueNameRowType::iterator itQueueName;
-    for (itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName)
-    {
-        if (itQueueName->outPoint == outPoint)
-        {
-            break;
-        }
-    }
-    if (itQueueName == itQueueNameRow->second.end())
-    {
-        return false;
-    }
-    supportQueueType::iterator itQueueRow = getSupportQueueCacheRow(itQueueName->nHeight, false);
-    if (itQueueRow != supportQueueCache.end())
-    {
+    if (itQueueName == itQueueNameRow->second.end()) return false;
+    supportQueueType::iterator itQueueRow = getQueueCacheRow(itQueueName->nHeight, supportQueueCache, false);
+    if (itQueueRow != supportQueueCache.end()) {
         supportQueueRowType::iterator itQueue;
-        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue)
-        {
-            CSupportValue& support = itQueue->second;
-            if (name == itQueue->first && support.outPoint == outPoint)
-            {
-                break;
+        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue) {
+            if (name == itQueue->first && itQueue->second.outPoint == outPoint) {
+                std::swap(support, itQueue->second);
+                itQueueNameRow->second.erase(itQueueName);
+                itQueueRow->second.erase(itQueue);
+                return true;
             }
-        }
-        if (itQueue != itQueueRow->second.end())
-        {
-            std::swap(support, itQueue->second);
-            itQueueNameRow->second.erase(itQueueName);
-            itQueueRow->second.erase(itQueue);
-            return true;
         }
     }
     LogPrintf("%s: An inconsistency was found in the claim queue. Please report this to the developers:\nFound in named support queue but not in height support queue: name: %s, txid: %s, nOut: %d, nValidAtHeight: %d, current height: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, itQueueName->nHeight, nCurrentHeight);
     return false;
 }
 
-bool CClaimTrieCache::addSupport(const std::string& name, const COutPoint& outPoint, CAmount nAmount, uint160 supportedClaimId, int nHeight) const
+bool CClaimTrieCache::addSupport(const std::string& name, const COutPoint& outPoint, const CAmount& nAmount, const uint160& supportedClaimId, int nHeight)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %d, nAmount: %d, supportedClaimId: %s, nHeight: %d, nCurrentHeight: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nAmount, supportedClaimId.GetHex(), nHeight, nCurrentHeight);
     assert(nHeight == nCurrentHeight);
     CClaimValue claim;
     int delayForSupport;
-    if (getOriginalInfoForName(name, claim) && claim.claimId == supportedClaimId)
-    {
+    if (getOriginalInfoForName(name, claim) && claim.claimId == supportedClaimId) {
         LogPrintf("%s: This is a support to a best claim.\n", __func__);
         delayForSupport = 0;
-    }
-    else
-    {
+    } else {
         delayForSupport = getDelayForName(name);
     }
     CSupportValue support(outPoint, supportedClaimId, nAmount, nHeight, nHeight + delayForSupport);
     return addSupportToQueues(name, support);
 }
 
-bool CClaimTrieCache::undoSpendSupport(const std::string& name, const COutPoint& outPoint, uint160 supportedClaimId, CAmount nAmount, int nHeight, int nValidAtHeight) const
+bool CClaimTrieCache::undoSpendSupport(const std::string& name, const COutPoint& outPoint, const uint160& supportedClaimId, const CAmount& nAmount, int nHeight, int nValidAtHeight)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %d, nAmount: %d, supportedClaimId: %s, nHeight: %d, nCurrentHeight: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nAmount, supportedClaimId.GetHex(), nHeight, nCurrentHeight);
     CSupportValue support(outPoint, supportedClaimId, nAmount, nHeight, nValidAtHeight);
-    if (nValidAtHeight < nCurrentHeight)
-    {
+    if (nValidAtHeight < nCurrentHeight) {
         nameOutPointType entry(name, support.outPoint);
         addSupportToExpirationQueue(support.nHeight + base->nExpirationTime, entry);
         return insertSupportIntoMap(name, support, false);
-    }
-    else
-    {
+    } else {
         return addSupportToQueues(name, support);
     }
 }
 
-bool CClaimTrieCache::removeSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover) const
+bool CClaimTrieCache::removeSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover)
 {
     bool removed = false;
     CSupportValue support;
-    if (removeSupportFromQueue(name, outPoint, support))
+    if (removeSupportFromQueue(name, outPoint, support)) {
         removed = true;
-    if (removed == false && removeSupportFromMap(name, outPoint, support, fCheckTakeover))
+    }
+    if (removed == false && removeSupportFromMap(name, outPoint, support, fCheckTakeover)) {
         removed = true;
-    if (removed)
-    {
+    }
+    if (removed) {
         int expirationHeight = nHeight + base->nExpirationTime;
         removeSupportFromExpirationQueue(name, outPoint, expirationHeight);
         nValidAtHeight = support.nValidAtHeight;
@@ -2049,100 +1364,65 @@ bool CClaimTrieCache::removeSupport(const std::string& name, const COutPoint& ou
     return removed;
 }
 
-void CClaimTrieCache::addSupportToExpirationQueue(int nExpirationHeight, nameOutPointType& entry) const
+void CClaimTrieCache::addSupportToExpirationQueue(int nExpirationHeight, nameOutPointType& entry)
 {
-    expirationQueueType::iterator itQueueRow = getSupportExpirationQueueCacheRow(nExpirationHeight, true);
+    supportExpirationQueueType::iterator itQueueRow = getQueueCacheRow(nExpirationHeight, supportExpirationQueueCache, true);
     itQueueRow->second.push_back(entry);
 }
 
-void CClaimTrieCache::removeSupportFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int expirationHeight) const
+void CClaimTrieCache::removeSupportFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int expirationHeight)
 {
-    expirationQueueType::iterator itQueueRow = getSupportExpirationQueueCacheRow(expirationHeight, false);
-    expirationQueueRowType::iterator itQueue;
-    if (itQueueRow != supportExpirationQueueCache.end())
-    {
-        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue)
-        {
-            if (name == itQueue->name && outPoint == itQueue->outPoint)
+    supportExpirationQueueType::iterator itQueueRow = getQueueCacheRow(expirationHeight, supportExpirationQueueCache, false);
+    supportExpirationQueueRowType::iterator itQueue;
+    if (itQueueRow != supportExpirationQueueCache.end()) {
+        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue) {
+            if (name == itQueue->name && outPoint == itQueue->outPoint) {
+                itQueueRow->second.erase(itQueue);
                 break;
+            }
         }
     }
-    if (itQueue != itQueueRow->second.end())
-    {
-        itQueueRow->second.erase(itQueue);
-    }
 }
 
-expirationQueueType::iterator CClaimTrieCache::getSupportExpirationQueueCacheRow(int nHeight, bool createIfNotExists) const
-{
-    expirationQueueType::iterator itQueueRow = supportExpirationQueueCache.find(nHeight);
-    if (itQueueRow == supportExpirationQueueCache.end())
-    {
-        // Have to make a new row it put in the cache, if createIfNotExists is true
-        expirationQueueRowType queueRow;
-        // If the row exists in the base, copy its claims into the new row.
-        bool exists = base->getSupportExpirationQueueRow(nHeight, queueRow);
-        if (!exists)
-            if (!createIfNotExists)
-                return itQueueRow;
-        // Stick the new row in the cache
-        std::pair<expirationQueueType::iterator, bool> ret;
-        ret = supportExpirationQueueCache.insert(std::pair<int, expirationQueueRowType >(nHeight, queueRow));
-        assert(ret.second);
-        itQueueRow = ret.first;
-    }
-    return itQueueRow;
-}
-
-bool CClaimTrieCache::undoAddSupport(const std::string& name, const COutPoint& outPoint, int nHeight) const
+bool CClaimTrieCache::undoAddSupport(const std::string& name, const COutPoint& outPoint, int nHeight)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %d, nHeight: %d, nCurrentHeight: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nHeight, nCurrentHeight);
     int throwaway;
     return removeSupport(name, outPoint, nHeight, throwaway, false);
 }
 
-bool CClaimTrieCache::spendSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight) const
+bool CClaimTrieCache::spendSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight)
 {
     LogPrintf("%s: name: %s, txhash: %s, nOut: %d, nHeight: %d, nCurrentHeight: %d\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nHeight, nCurrentHeight);
     return removeSupport(name, outPoint, nHeight, nValidAtHeight, true);
 }
 
-bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const
+bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int> >& takeoverHeightUndo)
 {
     LogPrintf("%s: nCurrentHeight (before increment): %d\n", __func__, nCurrentHeight);
 
-    claimQueueType::iterator itQueueRow = getQueueCacheRow(nCurrentHeight, false);
-    if (itQueueRow != claimQueueCache.end())
-    {
-        for (claimQueueRowType::iterator itEntry = itQueueRow->second.begin(); itEntry != itQueueRow->second.end(); ++itEntry)
-        {
+    claimQueueType::iterator itQueueRow = getQueueCacheRow(nCurrentHeight, claimQueueCache, false);
+    if (itQueueRow != claimQueueCache.end()) {
+        for (claimQueueRowType::iterator itEntry = itQueueRow->second.begin(); itEntry != itQueueRow->second.end(); ++itEntry) {
             bool found = false;
-            queueNameType::iterator itQueueNameRow = getQueueCacheNameRow(itEntry->first, false);
-            if (itQueueNameRow != claimQueueNameCache.end())
-            {
-                for (queueNameRowType::iterator itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName)
-                {
-                    if (itQueueName->outPoint == itEntry->second.outPoint && itQueueName->nHeight == nCurrentHeight)
-                    {
+            queueNameType::iterator itQueueNameRow = getQueueCacheRow(itEntry->first, claimQueueNameCache, false);
+            if (itQueueNameRow != claimQueueNameCache.end()) {
+                for (queueNameRowType::iterator itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName) {
+                    if (itQueueName->outPoint == itEntry->second.outPoint && itQueueName->nHeight == nCurrentHeight) {
                         found = true;
                         itQueueNameRow->second.erase(itQueueName);
                         break;
                     }
                 }
             }
-            if (!found)
-            {
+            if (!found) {
                 LogPrintf("%s: An inconsistency was found in the claim queue. Please report this to the developers:\nFound in height queue but not in named queue: name: %s, txid: %s, nOut: %d, nValidAtHeight: %d, current height: %d\n", __func__, itEntry->first, itEntry->second.outPoint.hash.GetHex(), itEntry->second.outPoint.n, itEntry->second.nValidAtHeight, nCurrentHeight);
-                if (itQueueNameRow != claimQueueNameCache.end())
-                {
+                if (itQueueNameRow != claimQueueNameCache.end()) {
                     LogPrintf("Claims found for that name:\n");
-                    for (queueNameRowType::iterator itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName)
-                    {
+                    for (queueNameRowType::iterator itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName) {
                         LogPrintf("\ttxid: %s, nOut: %d, nValidAtHeight: %d\n", itQueueName->outPoint.hash.GetHex(), itQueueName->outPoint.n, itQueueName->nHeight);
                     }
-                }
-                else
-                {
+                } else {
                     LogPrintf("No claims found for that name\n");
                 }
             }
@@ -2152,51 +1432,39 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
         }
         itQueueRow->second.clear();
     }
-    expirationQueueType::iterator itExpirationRow = getExpirationQueueCacheRow(nCurrentHeight, false);
-    if (itExpirationRow != expirationQueueCache.end())
-    {
-        for (expirationQueueRowType::iterator itEntry = itExpirationRow->second.begin(); itEntry != itExpirationRow->second.end(); ++itEntry)
-        {
+    expirationQueueType::iterator itExpirationRow = getQueueCacheRow(nCurrentHeight, expirationQueueCache, false);
+    if (itExpirationRow != expirationQueueCache.end()) {
+        for (expirationQueueRowType::iterator itEntry = itExpirationRow->second.begin(); itEntry != itExpirationRow->second.end(); ++itEntry) {
             CClaimValue claim;
             assert(removeClaimFromTrie(itEntry->name, itEntry->outPoint, claim, true));
-            claimsToDelete.insert(claim);
+            base->removeFromClaimIndex(claim);
             expireUndo.push_back(std::make_pair(itEntry->name, claim));
             LogPrintf("Expiring claim %s: %s, nHeight: %d, nValidAtHeight: %d\n", claim.claimId.GetHex(), itEntry->name, claim.nHeight, claim.nValidAtHeight);
         }
         itExpirationRow->second.clear();
     }
-    supportQueueType::iterator itSupportRow = getSupportQueueCacheRow(nCurrentHeight, false);
-    if (itSupportRow != supportQueueCache.end())
-    {
-        for (supportQueueRowType::iterator itSupport = itSupportRow->second.begin(); itSupport != itSupportRow->second.end(); ++itSupport)
-        {
+    supportQueueType::iterator itSupportRow = getQueueCacheRow(nCurrentHeight, supportQueueCache, false);
+    if (itSupportRow != supportQueueCache.end()) {
+        for (supportQueueRowType::iterator itSupport = itSupportRow->second.begin(); itSupport != itSupportRow->second.end(); ++itSupport) {
             bool found = false;
-            queueNameType::iterator itSupportNameRow = getSupportQueueCacheNameRow(itSupport->first, false);
-            if (itSupportNameRow != supportQueueNameCache.end())
-            {
-                for (queueNameRowType::iterator itSupportName = itSupportNameRow->second.begin(); itSupportName != itSupportNameRow->second.end(); ++itSupportName)
-                {
-                    if (itSupportName->outPoint == itSupport->second.outPoint && itSupportName->nHeight == itSupport->second.nValidAtHeight)
-                    {
+            supportQueueNameType::iterator itSupportNameRow = getQueueCacheRow(itSupport->first, supportQueueNameCache, false);
+            if (itSupportNameRow != supportQueueNameCache.end()) {
+                for (supportQueueNameRowType::iterator itSupportName = itSupportNameRow->second.begin(); itSupportName != itSupportNameRow->second.end(); ++itSupportName) {
+                    if (itSupportName->outPoint == itSupport->second.outPoint && itSupportName->nHeight == itSupport->second.nValidAtHeight) {
                         found = true;
                         itSupportNameRow->second.erase(itSupportName);
                         break;
                     }
                 }
             }
-            if (!found)
-            {
+            if (!found) {
                 LogPrintf("%s: An inconsistency was found in the support queue. Please report this to the developers:\nFound in height queue but not in named queue: %s, txid: %s, nOut: %d, nValidAtHeight: %d, current height: %d\n", __func__, itSupport->first, itSupport->second.outPoint.hash.GetHex(), itSupport->second.outPoint.n, itSupport->second.nValidAtHeight, nCurrentHeight);
-                if (itSupportNameRow != supportQueueNameCache.end())
-                {
+                if (itSupportNameRow != supportQueueNameCache.end()) {
                     LogPrintf("Supports found for that name:\n");
-                    for (queueNameRowType::iterator itSupportName = itSupportNameRow->second.begin(); itSupportName != itSupportNameRow->second.end(); ++itSupportName)
-                    {
+                    for (supportQueueNameRowType::iterator itSupportName = itSupportNameRow->second.begin(); itSupportName != itSupportNameRow->second.end(); ++itSupportName) {
                         LogPrintf("\ttxid: %s, nOut: %d, nValidAtHeight: %d\n", itSupportName->outPoint.hash.GetHex(), itSupportName->outPoint.n, itSupportName->nHeight);
                     }
-                }
-                else
-                {
+                } else {
                     LogPrintf("No support found for that name\n");
                 }
             }
@@ -2205,11 +1473,9 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
         }
         itSupportRow->second.clear();
     }
-    expirationQueueType::iterator itSupportExpirationRow = getSupportExpirationQueueCacheRow(nCurrentHeight, false);
-    if (itSupportExpirationRow != supportExpirationQueueCache.end())
-    {
-        for (expirationQueueRowType::iterator itEntry = itSupportExpirationRow->second.begin(); itEntry != itSupportExpirationRow->second.end(); ++itEntry)
-        {
+    supportExpirationQueueType::iterator itSupportExpirationRow = getQueueCacheRow(nCurrentHeight, supportExpirationQueueCache, false);
+    if (itSupportExpirationRow != supportExpirationQueueCache.end()) {
+        for (supportExpirationQueueRowType::iterator itEntry = itSupportExpirationRow->second.begin(); itEntry != itSupportExpirationRow->second.end(); ++itEntry) {
             CSupportValue support;
             assert(removeSupportFromMap(itEntry->name, itEntry->outPoint, support, true));
             expireSupportUndo.push_back(std::make_pair(itEntry->name, support));
@@ -2218,14 +1484,13 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
         itSupportExpirationRow->second.clear();
     }
     // check each potentially taken over name to see if a takeover occurred.
-    // if it did, then check the claim and support insertion queues for 
+    // if it did, then check the claim and support insertion queues for
     // the names that have been taken over, immediately insert all claim and
     // supports for those names, and stick them in the insertUndo or
     // insertSupportUndo vectors, with the nValidAtHeight they had prior to
     // this block.
     // Run through all names that have been taken over
-    for (std::set<std::string>::iterator itNamesToCheck = namesToCheckForTakeover.begin(); itNamesToCheck != namesToCheckForTakeover.end(); ++itNamesToCheck)
-    {
+    for (std::set<std::string>::iterator itNamesToCheck = namesToCheckForTakeover.begin(); itNamesToCheck != namesToCheckForTakeover.end(); ++itNamesToCheck) {
         // Check if a takeover has occurred
         nodeCacheType::iterator itCachedNode = cache.find(*itNamesToCheck);
         // many possibilities
@@ -2242,56 +1507,40 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
         CClaimValue claimInTrie;
         bool haveClaimInCache;
         bool haveClaimInTrie;
-        if (itCachedNode == cache.end())
-        {
+        if (itCachedNode == cache.end()) {
             haveClaimInCache = false;
-        }
-        else
-        {
+        } else {
             haveClaimInCache = itCachedNode->second->getBestClaim(claimInCache);
         }
         haveClaimInTrie = getOriginalInfoForName(*itNamesToCheck, claimInTrie);
         bool takeoverHappened = false;
-        if (!haveClaimInTrie)
-        {
+        if (!haveClaimInTrie) {
             takeoverHappened = true;
-        }
-        else if (!haveClaimInCache)
-        {
+        } else if (!haveClaimInCache) {
             takeoverHappened = true;
-        }
-        else if (claimInCache != claimInTrie)
-        {
-            if (claimInCache.claimId != claimInTrie.claimId)
-            {
+        } else if (claimInCache != claimInTrie) {
+            if (claimInCache.claimId != claimInTrie.claimId) {
                 takeoverHappened = true;
             }
         }
-        if (takeoverHappened)
-        {
+        if (takeoverHappened) {
             // Get all claims in the queue for that name
-            queueNameType::iterator itQueueNameRow = getQueueCacheNameRow(*itNamesToCheck, false);
-            if (itQueueNameRow != claimQueueNameCache.end())
-            {
-                for (queueNameRowType::iterator itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName)
-                {
+            queueNameType::iterator itQueueNameRow = getQueueCacheRow(*itNamesToCheck, claimQueueNameCache, false);
+            if (itQueueNameRow != claimQueueNameCache.end()) {
+                for (queueNameRowType::iterator itQueueName = itQueueNameRow->second.begin(); itQueueName != itQueueNameRow->second.end(); ++itQueueName) {
                     bool found = false;
                     // Pull those claims out of the height-based queue
-                    claimQueueType::iterator itQueueRow = getQueueCacheRow(itQueueName->nHeight, false);
+                    claimQueueType::iterator itQueueRow = getQueueCacheRow(itQueueName->nHeight, claimQueueCache, false);
                     claimQueueRowType::iterator itQueue;
-                    if (itQueueRow != claimQueueCache.end())
-                    {
-                        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue)
-                        {
-                            if (*itNamesToCheck == itQueue->first && itQueue->second.outPoint == itQueueName->outPoint && itQueue->second.nValidAtHeight == itQueueName->nHeight)
-                            {
+                    if (itQueueRow != claimQueueCache.end()) {
+                        for (itQueue = itQueueRow->second.begin(); itQueue != itQueueRow->second.end(); ++itQueue) {
+                            if (*itNamesToCheck == itQueue->first && itQueue->second.outPoint == itQueueName->outPoint && itQueue->second.nValidAtHeight == itQueueName->nHeight) {
                                 found = true;
                                 break;
                             }
                         }
                     }
-                    if (found)
-                    {
+                    if (found) {
                         // Insert them into the queue undo with their previous nValidAtHeight
                         insertUndo.push_back(nameOutPointHeightType(itQueue->first, itQueue->second.outPoint, itQueue->second.nValidAtHeight));
                         // Insert them into the name trie with the new nValidAtHeight
@@ -2299,9 +1548,7 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
                         insertClaimIntoTrie(itQueue->first, itQueue->second, false);
                         // Delete them from the height-based queue
                         itQueueRow->second.erase(itQueue);
-                    }
-                    else
-                    {
+                    } else {
                         LogPrintf("%s(): An inconsistency was found in the claim queue. Please report this to the developers:\nClaim found in name queue but not in height based queue:\nname: %s, txid: %s, nOut: %d, nValidAtHeight in name based queue: %d, current height: %d\n", __func__, *itNamesToCheck, itQueueName->outPoint.hash.GetHex(), itQueueName->outPoint.n, itQueueName->nHeight, nCurrentHeight);
                     }
                     assert(found);
@@ -2309,27 +1556,19 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
                 // remove all claims from the queue for that name
                 itQueueNameRow->second.clear();
             }
-            // 
+            //
             // Then, get all supports in the queue for that name
-            queueNameType::iterator itSupportQueueNameRow = getSupportQueueCacheNameRow(*itNamesToCheck, false);
-            if (itSupportQueueNameRow != supportQueueNameCache.end())
-            {
-                for (queueNameRowType::iterator itSupportQueueName = itSupportQueueNameRow->second.begin(); itSupportQueueName != itSupportQueueNameRow->second.end(); ++itSupportQueueName)
-                {
+            supportQueueNameType::iterator itSupportQueueNameRow = getQueueCacheRow(*itNamesToCheck, supportQueueNameCache, false);
+            if (itSupportQueueNameRow != supportQueueNameCache.end()) {
+                for (supportQueueNameRowType::iterator itSupportQueueName = itSupportQueueNameRow->second.begin(); itSupportQueueName != itSupportQueueNameRow->second.end(); ++itSupportQueueName) {
                     // Pull those supports out of the height-based queue
-                    supportQueueType::iterator itSupportQueueRow = getSupportQueueCacheRow(itSupportQueueName->nHeight, false);
-                    if (itSupportQueueRow != supportQueueCache.end())
-                    {
+                    supportQueueType::iterator itSupportQueueRow = getQueueCacheRow(itSupportQueueName->nHeight, supportQueueCache, false);
+                    if (itSupportQueueRow != supportQueueCache.end()) {
                         supportQueueRowType::iterator itSupportQueue;
-                        for (itSupportQueue = itSupportQueueRow->second.begin(); itSupportQueue != itSupportQueueRow->second.end(); ++itSupportQueue)
-                        {
-                            if (*itNamesToCheck == itSupportQueue->first && itSupportQueue->second.outPoint == itSupportQueueName->outPoint && itSupportQueue->second.nValidAtHeight == itSupportQueueName->nHeight)
-                            {
-                                break;
-                            }
+                        for (itSupportQueue = itSupportQueueRow->second.begin(); itSupportQueue != itSupportQueueRow->second.end(); ++itSupportQueue) {
+                            if (*itNamesToCheck == itSupportQueue->first && itSupportQueue->second.outPoint == itSupportQueueName->outPoint && itSupportQueue->second.nValidAtHeight == itSupportQueueName->nHeight) break;
                         }
-                        if (itSupportQueue != itSupportQueueRow->second.end())
-                        {
+                        if (itSupportQueue != itSupportQueueRow->second.end()) {
                             // Insert them into the support queue undo with the previous nValidAtHeight
                             insertSupportUndo.push_back(nameOutPointHeightType(itSupportQueue->first, itSupportQueue->second.outPoint, itSupportQueue->second.nValidAtHeight));
                             // Insert them into the support map with the new nValidAtHeight
@@ -2337,14 +1576,10 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
                             insertSupportIntoMap(itSupportQueue->first, itSupportQueue->second, false);
                             // Delete them from the height-based queue
                             itSupportQueueRow->second.erase(itSupportQueue);
-                        }
-                        else
-                        {
+                        } else {
                             // here be problems TODO: show error, assert false
                         }
-                    }
-                    else
-                    {
+                    } else {
                         // here be problems
                     }
                 }
@@ -2353,26 +1588,22 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
             }
 
             // save the old last height so that it can be restored if the block is undone
-            if (haveClaimInTrie)
-            {
+            if (haveClaimInTrie) {
                 int nHeightOfLastTakeover;
                 assert(getLastTakeoverForName(*itNamesToCheck, nHeightOfLastTakeover));
                 takeoverHeightUndo.push_back(std::make_pair(*itNamesToCheck, nHeightOfLastTakeover));
             }
             itCachedNode = cache.find(*itNamesToCheck);
-            if (itCachedNode != cache.end())
-            {
+            if (itCachedNode != cache.end()) {
                 cacheTakeoverHeights[*itNamesToCheck] = nCurrentHeight;
             }
         }
     }
-    for (nodeCacheType::const_iterator itOriginals = block_originals.begin(); itOriginals != block_originals.end(); ++itOriginals)
-    {
+    for (nodeCacheType::const_iterator itOriginals = block_originals.begin(); itOriginals != block_originals.end(); ++itOriginals) {
         delete itOriginals->second;
     }
     block_originals.clear();
-    for (nodeCacheType::const_iterator itCache = cache.begin(); itCache != cache.end(); ++itCache)
-    {
+    for (nodeCacheType::const_iterator itCache = cache.begin(); itCache != cache.end(); ++itCache) {
         block_originals[itCache->first] = new CClaimTrieNode(*(itCache->second));
     }
     namesToCheckForTakeover.clear();
@@ -2380,70 +1611,60 @@ bool CClaimTrieCache::incrementBlock(insertUndoType& insertUndo, claimQueueRowTy
     return true;
 }
 
-bool CClaimTrieCache::decrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const
+bool CClaimTrieCache::decrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int> >& takeoverHeightUndo)
 {
     LogPrintf("%s: nCurrentHeight (before decrement): %d\n", __func__, nCurrentHeight);
     nCurrentHeight--;
 
-    if (expireSupportUndo.begin() != expireSupportUndo.end())
-    {
-        expirationQueueType::iterator itSupportExpireRow = getSupportExpirationQueueCacheRow(nCurrentHeight, true);
-        for (supportQueueRowType::iterator itSupportExpireUndo = expireSupportUndo.begin(); itSupportExpireUndo != expireSupportUndo.end(); ++itSupportExpireUndo)
-        {
+    if (expireSupportUndo.begin() != expireSupportUndo.end()) {
+        supportExpirationQueueType::iterator itSupportExpireRow = getQueueCacheRow(nCurrentHeight, supportExpirationQueueCache, true);
+        for (supportQueueRowType::iterator itSupportExpireUndo = expireSupportUndo.begin(); itSupportExpireUndo != expireSupportUndo.end(); ++itSupportExpireUndo) {
             insertSupportIntoMap(itSupportExpireUndo->first, itSupportExpireUndo->second, false);
             itSupportExpireRow->second.push_back(nameOutPointType(itSupportExpireUndo->first, itSupportExpireUndo->second.outPoint));
         }
     }
 
-    for (insertUndoType::iterator itSupportUndo = insertSupportUndo.begin(); itSupportUndo != insertSupportUndo.end(); ++itSupportUndo)
-    {
-        supportQueueType::iterator itSupportRow = getSupportQueueCacheRow(itSupportUndo->nHeight, true);
+    for (insertUndoType::iterator itSupportUndo = insertSupportUndo.begin(); itSupportUndo != insertSupportUndo.end(); ++itSupportUndo) {
+        supportQueueType::iterator itSupportRow = getQueueCacheRow(itSupportUndo->nHeight, supportQueueCache, true);
         CSupportValue support;
         assert(removeSupportFromMap(itSupportUndo->name, itSupportUndo->outPoint, support, false));
-        queueNameType::iterator itSupportNameRow = getSupportQueueCacheNameRow(itSupportUndo->name, true);
+        supportQueueNameType::iterator itSupportNameRow = getQueueCacheRow(itSupportUndo->name, supportQueueNameCache, true);
         itSupportRow->second.push_back(std::make_pair(itSupportUndo->name, support));
         itSupportNameRow->second.push_back(outPointHeightType(support.outPoint, support.nValidAtHeight));
     }
 
-    if (expireUndo.begin() != expireUndo.end())
-    {
-        expirationQueueType::iterator itExpireRow = getExpirationQueueCacheRow(nCurrentHeight, true);
-        for (claimQueueRowType::iterator itExpireUndo = expireUndo.begin(); itExpireUndo != expireUndo.end(); ++itExpireUndo)
-        {
+    if (expireUndo.begin() != expireUndo.end()) {
+        expirationQueueType::iterator itExpireRow = getQueueCacheRow(nCurrentHeight, expirationQueueCache, true);
+        for (claimQueueRowType::iterator itExpireUndo = expireUndo.begin(); itExpireUndo != expireUndo.end(); ++itExpireUndo) {
             insertClaimIntoTrie(itExpireUndo->first, itExpireUndo->second, false);
-            CClaimIndexElement element = {itExpireUndo->first, itExpireUndo->second};
-            claimsToAdd.push_back(element);
+            base->addToClaimIndex(itExpireUndo->first, itExpireUndo->second);
             itExpireRow->second.push_back(nameOutPointType(itExpireUndo->first, itExpireUndo->second.outPoint));
         }
     }
 
-    for (insertUndoType::iterator itInsertUndo = insertUndo.begin(); itInsertUndo != insertUndo.end(); ++itInsertUndo)
-    {
-        claimQueueType::iterator itQueueRow = getQueueCacheRow(itInsertUndo->nHeight, true);
+    for (insertUndoType::iterator itInsertUndo = insertUndo.begin(); itInsertUndo != insertUndo.end(); ++itInsertUndo) {
+        claimQueueType::iterator itQueueRow = getQueueCacheRow(itInsertUndo->nHeight, claimQueueCache, true);
         CClaimValue claim;
         assert(removeClaimFromTrie(itInsertUndo->name, itInsertUndo->outPoint, claim, false));
-        queueNameType::iterator itQueueNameRow = getQueueCacheNameRow(itInsertUndo->name, true);
+        queueNameType::iterator itQueueNameRow = getQueueCacheRow(itInsertUndo->name, claimQueueNameCache, true);
         itQueueRow->second.push_back(std::make_pair(itInsertUndo->name, claim));
-        itQueueNameRow->second.push_back(outPointHeightType(itInsertUndo->outPoint, itInsertUndo->nHeight)); 
+        itQueueNameRow->second.push_back(outPointHeightType(itInsertUndo->outPoint, itInsertUndo->nHeight));
     }
 
-    for (std::vector<std::pair<std::string, int> >::iterator itTakeoverHeightUndo = takeoverHeightUndo.begin(); itTakeoverHeightUndo != takeoverHeightUndo.end(); ++itTakeoverHeightUndo)
-    {
+    for (std::vector<std::pair<std::string, int> >::iterator itTakeoverHeightUndo = takeoverHeightUndo.begin(); itTakeoverHeightUndo != takeoverHeightUndo.end(); ++itTakeoverHeightUndo) {
         cacheTakeoverHeights[itTakeoverHeightUndo->first] = itTakeoverHeightUndo->second;
     }
 
     return true;
 }
 
-bool CClaimTrieCache::finalizeDecrement() const
+bool CClaimTrieCache::finalizeDecrement()
 {
-    for (nodeCacheType::iterator itOriginals = block_originals.begin(); itOriginals != block_originals.end(); ++itOriginals)
-    {
+    for (nodeCacheType::iterator itOriginals = block_originals.begin(); itOriginals != block_originals.end(); ++itOriginals) {
         delete itOriginals->second;
     }
     block_originals.clear();
-    for (nodeCacheType::const_iterator itCache = cache.begin(); itCache != cache.end(); ++itCache)
-    {
+    for (nodeCacheType::const_iterator itCache = cache.begin(); itCache != cache.end(); ++itCache) {
         block_originals[itCache->first] = new CClaimTrieNode(*(itCache->second));
     }
     return true;
@@ -2451,14 +1672,12 @@ bool CClaimTrieCache::finalizeDecrement() const
 
 bool CClaimTrieCache::getLastTakeoverForName(const std::string& name, int& nLastTakeoverForName) const
 {
-    if (!fRequireTakeoverHeights)
-    {
+    if (!fRequireTakeoverHeights) {
         nLastTakeoverForName = 0;
         return true;
     }
-    std::map<std::string, int>::iterator itHeights = cacheTakeoverHeights.find(name);
-    if (itHeights == cacheTakeoverHeights.end())
-    {
+    std::map<std::string, int>::const_iterator itHeights = cacheTakeoverHeights.find(name);
+    if (itHeights == cacheTakeoverHeights.end()) {
         return base->getLastTakeoverForName(name, nLastTakeoverForName);
     }
     nLastTakeoverForName = itHeights->second;
@@ -2469,16 +1688,13 @@ int CClaimTrieCache::getNumBlocksOfContinuousOwnership(const std::string& name) 
 {
     const CClaimTrieNode* node = NULL;
     nodeCacheType::const_iterator itCache = cache.find(name);
-    if (itCache != cache.end())
-    {
+    if (itCache != cache.end()) {
         node = itCache->second;
     }
-    if (!node)
-    {
+    if (!node) {
         node = base->getNodeForName(name);
     }
-    if (!node || node->claims.empty())
-    {
+    if (!node || node->claims.empty()) {
         return 0;
     }
     int nLastTakeoverHeight;
@@ -2488,19 +1704,13 @@ int CClaimTrieCache::getNumBlocksOfContinuousOwnership(const std::string& name) 
 
 int CClaimTrieCache::getDelayForName(const std::string& name) const
 {
-    if (!fRequireTakeoverHeights)
-    {
-        return 0;
-    }
+    if (!fRequireTakeoverHeights) return 0;
     int nBlocksOfContinuousOwnership = getNumBlocksOfContinuousOwnership(name);
     return std::min(nBlocksOfContinuousOwnership / base->nProportionalDelayFactor, 4032);
 }
 
-uint256 CClaimTrieCache::getBestBlock()
+uint256 CClaimTrieCache::getBestBlock() const
 {
-    if (hashBlock.IsNull())
-        if (base != NULL)
-            hashBlock = base->hashBlock;
     return hashBlock;
 }
 
@@ -2509,15 +1719,13 @@ void CClaimTrieCache::setBestBlock(const uint256& hashBlockIn)
     hashBlock = hashBlockIn;
 }
 
-bool CClaimTrieCache::clear() const
+bool CClaimTrieCache::clear()
 {
-    for (nodeCacheType::iterator itcache = cache.begin(); itcache != cache.end(); ++itcache)
-    {
+    for (nodeCacheType::iterator itcache = cache.begin(); itcache != cache.end(); ++itcache) {
         delete itcache->second;
     }
     cache.clear();
-    for (nodeCacheType::iterator itOriginals = block_originals.begin(); itOriginals != block_originals.end(); ++itOriginals)
-    {
+    for (nodeCacheType::iterator itOriginals = block_originals.begin(); itOriginals != block_originals.end(); ++itOriginals) {
         delete itOriginals->second;
     }
     block_originals.clear();
@@ -2535,91 +1743,102 @@ bool CClaimTrieCache::clear() const
     return true;
 }
 
+template <typename K, typename V>
+void CClaimTrieCache::update(std::map<K, V>& map)
+{
+    for (typename std::map<K, V>::iterator itQueue = map.begin(); itQueue != map.end(); ++itQueue) {
+        base->db.updateQueueRow(itQueue->first, itQueue->second);
+    }
+}
+
 bool CClaimTrieCache::flush()
 {
-    if (dirty())
-        getMerkleHash();
+    if (dirty()) getMerkleHash();
+    for (nodeCacheType::iterator itcache = cache.begin(); itcache != cache.end(); ++itcache) {
+        if (!base->updateName(itcache->first, itcache->second)) {
+            LogPrintf("%s: Failed to update name for:%s\n", __func__, itcache->first);
+            return false;
+        }
+    }
+    for (hashMapType::iterator ithash = cacheHashes.begin(); ithash != cacheHashes.end(); ++ithash) {
+        if (!base->updateHash(ithash->first, ithash->second)) {
+            LogPrintf("%s: Failed to update hash for:%s\n", __func__, ithash->first);
+            return false;
+        }
+    }
+    for (std::map<std::string, int>::iterator itheight = cacheTakeoverHeights.begin(); itheight != cacheTakeoverHeights.end(); ++itheight) {
+        if (!base->updateTakeoverHeight(itheight->first, itheight->second)) {
+            LogPrintf("%s: Failed to update takeover height for:%s\n", __func__, itheight->first);
+            return false;
+        }
+    }
+    update(claimQueueCache);
+    update(claimQueueNameCache);
+    update(expirationQueueCache);
+    update(supportCache);
+    update(supportQueueCache);
+    update(supportQueueNameCache);
+    update(supportExpirationQueueCache);
+    base->hashBlock = getBestBlock();
+    base->nCurrentHeight = nCurrentHeight;
+    return clear();
+}
 
-    if (!claimsToDelete.empty()) {
-        for (claimIndexClaimListType::iterator it = claimsToDelete.begin(); it != claimsToDelete.end(); ++it)
-            base->removeFromClaimIndex(*it);
-        claimsToDelete.clear();
-    }
-    if (!claimsToAdd.empty()) {
-        for (claimIndexElementListType::iterator it = claimsToAdd.begin(); it != claimsToAdd.end(); ++it)
-            base->addToClaimIndex(it->name, it->claim);
-        claimsToAdd.clear();
-    }
-
-    bool success = base->update(cache, cacheHashes, cacheTakeoverHeights, getBestBlock(), claimQueueCache, claimQueueNameCache, expirationQueueCache, nCurrentHeight, supportCache, supportQueueCache, supportQueueNameCache, supportExpirationQueueCache);
-    if (success)
-    {
-        success = clear();
-    }
-    return success;
+bool CClaimTrieCache::dirty() const
+{
+    return !dirtyHashes.empty();
 }
 
 uint256 CClaimTrieCache::getLeafHashForProof(const std::string& currentPosition, unsigned char nodeChar, const CClaimTrieNode* currentNode) const
 {
     std::stringstream leafPosition;
     leafPosition << currentPosition << nodeChar;
-    hashMapType::iterator cachedHash = cacheHashes.find(leafPosition.str());
-    if (cachedHash != cacheHashes.end())
-    {
+    hashMapType::const_iterator cachedHash = cacheHashes.find(leafPosition.str());
+    if (cachedHash != cacheHashes.end()) {
         return cachedHash->second;
-    }
-    else
-    {
+    } else {
         return currentNode->hash;
     }
 }
 
 CClaimTrieProof CClaimTrieCache::getProofForName(const std::string& name) const
 {
-    if (dirty())
-        getMerkleHash();
+    if (dirty()) getMerkleHash();
     std::vector<CClaimTrieProofNode> nodes;
     CClaimTrieNode* current = &(base->root);
     nodeCacheType::const_iterator cachedNode;
     bool fNameHasValue = false;
     COutPoint outPoint;
     int nHeightOfLastTakeover = 0;
-    for (std::string::const_iterator itName = name.begin(); current; ++itName)
-    {
+    for (std::string::const_iterator itName = name.begin(); current; ++itName) {
         std::string currentPosition(name.begin(), itName);
         cachedNode = cache.find(currentPosition);
-        if (cachedNode != cache.end())
+        if (cachedNode != cache.end()) {
             current = cachedNode->second;
+        }
         CClaimValue claim;
         bool fNodeHasValue = current->getBestClaim(claim);
         uint256 valueHash;
-        if (fNodeHasValue)
-        {
+        if (fNodeHasValue) {
             int nHeightOfLastTakeover;
             assert(getLastTakeoverForName(currentPosition, nHeightOfLastTakeover));
             valueHash = getValueHash(claim.outPoint, nHeightOfLastTakeover);
         }
         std::vector<std::pair<unsigned char, uint256> > children;
         CClaimTrieNode* nextCurrent = NULL;
-        for (nodeMapType::const_iterator itChildren = current->children.begin(); itChildren != current->children.end(); ++itChildren)
-        {
-            if (itName == name.end() || itChildren->first != *itName) // Leaf node
-            {
+        for (nodeMapType::const_iterator itChildren = current->children.begin(); itChildren != current->children.end(); ++itChildren) {
+            if (itName == name.end() || itChildren->first != *itName) { // Leaf node
                 uint256 childHash = getLeafHashForProof(currentPosition, itChildren->first, itChildren->second);
                 children.push_back(std::make_pair(itChildren->first, childHash));
-            }
-            else // Full node
-            {
+            } else { // Full node
                 nextCurrent = itChildren->second;
                 uint256 childHash;
                 children.push_back(std::make_pair(itChildren->first, childHash));
             }
         }
-        if (currentPosition == name)
-        {
+        if (currentPosition == name) {
             fNameHasValue = fNodeHasValue;
-            if (fNameHasValue)
-            {
+            if (fNameHasValue) {
                 outPoint = claim.outPoint;
                 assert(getLastTakeoverForName(name, nHeightOfLastTakeover));
             }
@@ -2629,15 +1848,12 @@ CClaimTrieProof CClaimTrieCache::getProofForName(const std::string& name) const
         nodes.push_back(node);
         current = nextCurrent;
     }
-    return CClaimTrieProof(nodes, fNameHasValue, outPoint,
-                           nHeightOfLastTakeover);
+    return CClaimTrieProof(nodes, fNameHasValue, outPoint, nHeightOfLastTakeover);
 }
 
-
-void CClaimTrieCache::removeAndAddToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const
+void CClaimTrieCache::removeAndAddToExpirationQueue(expirationQueueRowType& row, int height, bool increment)
 {
-    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e)
-    {
+    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e) {
         // remove and insert with new expiration time
         removeFromExpirationQueue(e->name, e->outPoint, height);
         int extend_expiration = Params().GetConsensus().nExtendedClaimExpirationTime - Params().GetConsensus().nOriginalClaimExpirationTime;
@@ -2645,13 +1861,11 @@ void CClaimTrieCache::removeAndAddToExpirationQueue(expirationQueueRowType &row,
         nameOutPointType entry(e->name, e->outPoint);
         addToExpirationQueue(new_expiration_height, entry);
     }
-
 }
 
-void CClaimTrieCache::removeAndAddSupportToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const
+void CClaimTrieCache::removeAndAddSupportToExpirationQueue(supportExpirationQueueRowType& row, int height, bool increment)
 {
-    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e)
-    {
+    for (supportExpirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e) {
         // remove and insert with new expiration time
         removeSupportFromExpirationQueue(e->name, e->outPoint, height);
         int extend_expiration = Params().GetConsensus().nExtendedClaimExpirationTime - Params().GetConsensus().nOriginalClaimExpirationTime;
@@ -2659,10 +1873,9 @@ void CClaimTrieCache::removeAndAddSupportToExpirationQueue(expirationQueueRowTyp
         nameOutPointType entry(e->name, e->outPoint);
         addSupportToExpirationQueue(new_expiration_height, entry);
     }
-
 }
 
-bool CClaimTrieCache::forkForExpirationChange(bool increment) const
+bool CClaimTrieCache::forkForExpirationChange(bool increment)
 {
     /*
     If increment is True, we have forked to extend the expiration time, thus items in the expiration queue
@@ -2672,66 +1885,27 @@ bool CClaimTrieCache::forkForExpirationChange(bool increment) const
     will have their expiration extension removed.
     */
 
-    // look through dirty expiration queues
-    std::set<int> dirtyHeights;
-    for (expirationQueueType::const_iterator i = base->dirtyExpirationQueueRows.begin(); i != base->dirtyExpirationQueueRows.end(); ++i)
-    {
+    expirationQueueType dirtyExpirationQueueRows;
+    if (!base->db.getQueueMap(dirtyExpirationQueueRows)) {
+        return error("%s(): error reading expiration queue rows from disk", __func__);
+    }
+
+    supportExpirationQueueType dirtySupportExpirationQueueRows;
+    if (!base->db.getQueueMap(dirtySupportExpirationQueueRows)) {
+        return error("%s(): error reading support expiration queue rows from disk", __func__);
+    }
+
+    for (expirationQueueType::const_iterator i = dirtyExpirationQueueRows.begin(); i != dirtyExpirationQueueRows.end(); ++i) {
         int height = i->first;
-        dirtyHeights.insert(height);
         expirationQueueRowType row = i->second;
         removeAndAddToExpirationQueue(row, height, increment);
     }
 
-    std::set<int> dirtySupportHeights;
-    for (expirationQueueType::const_iterator i = base->dirtySupportExpirationQueueRows.begin(); i != base->dirtySupportExpirationQueueRows.end(); ++i)
-    {
+    for (supportExpirationQueueType::const_iterator i = dirtySupportExpirationQueueRows.begin(); i != dirtySupportExpirationQueueRows.end(); ++i) {
         int height = i->first;
-        dirtySupportHeights.insert(height);
-        expirationQueueRowType row = i->second;
+        supportExpirationQueueRowType row = i->second;
         removeAndAddSupportToExpirationQueue(row, height, increment);
-    }
-
-
-    //look through db for expiration queues, if we haven't already found it in dirty expiration queue
-    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&base->db)->NewIterator());
-    pcursor->SeekToFirst();
-    while (pcursor->Valid())
-    {
-        std::pair<char, int> key;
-        if (pcursor->GetKey(key))
-        {
-            int height = key.second;
-            // if we've looked through this in dirtyExprirationQueueRows, don't use it
-            // because its stale
-            if ((key.first == EXP_QUEUE_ROW) & (dirtyHeights.count(height) == 0))
-            {
-                expirationQueueRowType row;
-                if (pcursor->GetValue(row))
-                {
-                    removeAndAddToExpirationQueue(row, height, increment);
-                }
-                else
-                {
-                    return error("%s(): error reading expiration queue rows from disk", __func__);
-                }
-            }
-            else if ((key.first == SUPPORT_EXP_QUEUE_ROW) & (dirtySupportHeights.count(height) == 0))
-            {
-                expirationQueueRowType row;
-                if (pcursor->GetValue(row))
-                {
-                    removeAndAddSupportToExpirationQueue(row, height, increment);
-                }
-                else
-                {
-                    return error("%s(): error reading support expiration queue rows from disk", __func__);
-                }
-            }
-
-        }
-        pcursor->Next();
     }
 
     return true;
 }
-

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -2,55 +2,35 @@
 #define BITCOIN_CLAIMTRIE_H
 
 #include "amount.h"
+#include "chainparams.h"
+#include "claimtriedb.h"
+#include "primitives/transaction.h"
 #include "serialize.h"
 #include "uint256.h"
 #include "util.h"
-#include "dbwrapper.h"
-#include "chainparams.h"
-#include "primitives/transaction.h"
 
 #include <string>
 #include <vector>
-#include <map>
 
-// leveldb keys
-#define HASH_BLOCK 'h'
-#define CURRENT_HEIGHT 't'
-#define TRIE_NODE 'n'
-#define CLAIM_BY_ID 'i'
-#define CLAIM_QUEUE_ROW 'r'
-#define CLAIM_QUEUE_NAME_ROW 'm'
-#define EXP_QUEUE_ROW 'e'
-#define SUPPORT 's'
-#define SUPPORT_QUEUE_ROW 'u'
-#define SUPPORT_QUEUE_NAME_ROW 'p'
-#define SUPPORT_EXP_QUEUE_ROW 'x'
-
-uint256 getValueHash(COutPoint outPoint, int nHeightOfLastTakeover);
+uint256 getValueHash(const COutPoint& outPoint, int nHeightOfLastTakeover);
 
 class CClaimValue
 {
 public:
-    COutPoint outPoint;
-    uint160 claimId;
-    CAmount nAmount;
-    CAmount nEffectiveAmount;
-    int nHeight;
-    int nValidAtHeight;
+    CClaimValue()
+    {
+    }
 
-    CClaimValue() {};
-
-    CClaimValue(COutPoint outPoint, uint160 claimId, CAmount nAmount, int nHeight,
-                int nValidAtHeight)
-                : outPoint(outPoint), claimId(claimId)
-                , nAmount(nAmount), nEffectiveAmount(nAmount)
-                , nHeight(nHeight), nValidAtHeight(nValidAtHeight)
-    {}
+    CClaimValue(const COutPoint& outPoint, const uint160& claimId, const CAmount& nAmount, const int nHeight, const int nValidAtHeight)
+        : outPoint(outPoint), claimId(claimId), nAmount(nAmount), nEffectiveAmount(nAmount), nHeight(nHeight), nValidAtHeight(nValidAtHeight)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
         READWRITE(outPoint);
         READWRITE(claimId);
         READWRITE(nAmount);
@@ -60,16 +40,15 @@ public:
 
     bool operator<(const CClaimValue& other) const
     {
-        if (nEffectiveAmount < other.nEffectiveAmount)
+        if (nEffectiveAmount < other.nEffectiveAmount) {
             return true;
-        else if (nEffectiveAmount == other.nEffectiveAmount)
-        {
-            if (nHeight > other.nHeight)
+        } else if (nEffectiveAmount == other.nEffectiveAmount) {
+            if (nHeight > other.nHeight) {
                 return true;
-            else if (nHeight == other.nHeight)
-            {
-                if (outPoint != other.outPoint && !(outPoint < other.outPoint))
+            } else if (nHeight == other.nHeight) {
+                if (outPoint != other.outPoint && !(outPoint < other.outPoint)) {
                     return true;
+                }
             }
         }
         return false;
@@ -84,29 +63,36 @@ public:
     {
         return !(*this == other);
     }
+
+    COutPoint outPoint;
+    uint160 claimId;
+    CAmount nAmount;
+    CAmount nEffectiveAmount;
+    int nHeight;
+    int nValidAtHeight;
 };
 
 class CSupportValue
 {
 public:
-    COutPoint outPoint;
-    uint160 supportedClaimId;
-    CAmount nAmount;
-    int nHeight;
-    int nValidAtHeight;
+    CSupportValue()
+    {
+    }
 
-    CSupportValue() {};
-    CSupportValue(COutPoint outPoint, uint160 supportedClaimId,
-                  CAmount nAmount, int nHeight, int nValidAtHeight)
-                  : outPoint(outPoint), supportedClaimId(supportedClaimId)
-                  , nAmount(nAmount), nHeight(nHeight)
-                  , nValidAtHeight(nValidAtHeight)
-    {}
+    CSupportValue(const COutPoint& outPoint,
+        const uint160& supportedClaimId,
+        const CAmount& nAmount,
+        const int nHeight,
+        const int nValidAtHeight)
+        : outPoint(outPoint), supportedClaimId(supportedClaimId), nAmount(nAmount), nHeight(nHeight), nValidAtHeight(nValidAtHeight)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
         READWRITE(outPoint);
         READWRITE(supportedClaimId);
         READWRITE(nAmount);
@@ -123,6 +109,12 @@ public:
     {
         return !(*this == other);
     }
+
+    COutPoint outPoint;
+    uint160 supportedClaimId;
+    CAmount nAmount;
+    int nHeight;
+    int nValidAtHeight;
 };
 
 class CClaimTrieNode;
@@ -137,24 +129,31 @@ typedef std::pair<std::string, CClaimTrieNode> namedNodeType;
 class CClaimTrieNode
 {
 public:
-    CClaimTrieNode() : nHeightOfLastTakeover(0) {}
-    CClaimTrieNode(uint256 hash) : hash(hash), nHeightOfLastTakeover(0) {}
-    uint256 hash;
-    nodeMapType children;
-    int nHeightOfLastTakeover;
-    std::vector<CClaimValue> claims;
+    CClaimTrieNode() : nHeightOfLastTakeover(0)
+    {
+    }
 
-    bool insertClaim(CClaimValue claim);
+    CClaimTrieNode(const uint256& hash) : hash(hash), nHeightOfLastTakeover(0)
+    {
+    }
+
+    bool insertClaim(const CClaimValue& claim);
+
     bool removeClaim(const COutPoint& outPoint, CClaimValue& claim);
+
     bool getBestClaim(CClaimValue& claim) const;
-    bool empty() const {return children.empty() && claims.empty();}
+
+    bool empty() const;
+
     bool haveClaim(const COutPoint& outPoint) const;
+
     void reorderClaims(supportMapEntryType& supports);
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
         READWRITE(hash);
         READWRITE(claims);
         READWRITE(nHeightOfLastTakeover);
@@ -169,27 +168,37 @@ public:
     {
         return !(*this == other);
     }
+
+    uint256 hash;
+    nodeMapType children;
+    int nHeightOfLastTakeover;
+    std::vector<CClaimValue> claims;
 };
 
-struct nodenamecompare
+class nodeNameCompare
 {
-    bool operator() (const std::string& i, const std::string& j) const
+public:
+    bool operator()(const std::string& i, const std::string& j) const
     {
-        if (i.size() == j.size())
+        if (i.size() == j.size()) {
             return i < j;
+        }
         return i.size() < j.size();
     }
 };
 
-struct outPointHeightType
+class outPointHeightType
 {
-    COutPoint outPoint;
-    int nHeight;
+public:
+    outPointHeightType()
+    {
+    }
 
-    outPointHeightType() {}
-
-    outPointHeightType(COutPoint outPoint, int nHeight)
-    : outPoint(outPoint), nHeight(nHeight) {}
+    outPointHeightType(const COutPoint& outPoint,
+        const int nHeight)
+        : outPoint(outPoint), nHeight(nHeight)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
@@ -200,19 +209,22 @@ struct outPointHeightType
         READWRITE(nHeight);
     }
 
-};
-
-struct nameOutPointHeightType
-{
-    std::string name;
     COutPoint outPoint;
     int nHeight;
+};
 
-    nameOutPointHeightType() {}
+class nameOutPointHeightType
+{
+public:
+    nameOutPointHeightType()
+    {
+    }
 
-    nameOutPointHeightType(std::string name, COutPoint outPoint, int nHeight)
-    : name(name), outPoint(outPoint), nHeight(nHeight) {}
-   
+    nameOutPointHeightType(const std::string& name, const COutPoint& outPoint, const int nHeight)
+        : name(name), outPoint(outPoint), nHeight(nHeight)
+    {
+    }
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -222,17 +234,23 @@ struct nameOutPointHeightType
         READWRITE(outPoint);
         READWRITE(nHeight);
     }
-};
 
-struct nameOutPointType
-{
     std::string name;
     COutPoint outPoint;
+    int nHeight;
+};
 
-    nameOutPointType() {}
+class nameOutPointType
+{
+public:
+    nameOutPointType()
+    {
+    }
 
-    nameOutPointType(std::string name, COutPoint outPoint)
-    : name(name), outPoint(outPoint) {}
+    nameOutPointType(const std::string& name, const COutPoint& outPoint)
+        : name(name), outPoint(outPoint)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
@@ -242,36 +260,105 @@ struct nameOutPointType
         READWRITE(name);
         READWRITE(outPoint);
     }
+
+    std::string name;
+    COutPoint outPoint;
 };
 
 class CClaimIndexElement
 {
-  public:
+public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
         READWRITE(name);
         READWRITE(claim);
+    }
+
+    bool empty() const
+    {
+        return name.empty() && claim.claimId.IsNull();
     }
 
     std::string name;
     CClaimValue claim;
 };
 
-typedef std::pair<std::string, CClaimValue> claimQueueEntryType;
+// Helpers to separate queue types from each other
+class claimQueueEntryHelper;
+class supportQueueEntryHelper;
 
-typedef std::pair<std::string, CSupportValue> supportQueueEntryType;
+class queueNameRowHelper;
+class supportQueueNameRowHelper;
+
+class expirationQueueRowHelper;
+class supportExpirationQueueRowHelper;
+
+template <typename Base, typename Form>
+class CGeneric : public Base
+{
+public:
+    CGeneric() : Base()
+    {
+    }
+
+    CGeneric(const Base& base) : Base(base)
+    {
+    }
+
+    CGeneric(const CGeneric& CGeneric) : Base(CGeneric)
+    {
+    }
+};
+
+// Make std::swap to work with custom types
+namespace std {
+template <typename Base, typename Form>
+inline void swap(CGeneric<Base, Form>& CGeneric, Base& base)
+{
+    Base base1 = CGeneric;
+    CGeneric = base;
+    base = base1;
+}
+
+template <typename Base, typename Form>
+inline void swap(Base& base, CGeneric<Base, Form>& CGeneric)
+{
+    swap(CGeneric, base);
+}
+} // namespace std
+
+// Each of these CGeneric types will be stored in the database
+typedef CGeneric<CClaimValue, claimQueueEntryHelper> claimQueueValueType;
+typedef CGeneric<CSupportValue, supportQueueEntryHelper> supportQueueValueType;
+
+typedef CGeneric<outPointHeightType, queueNameRowHelper> queueNameRowValueType;
+typedef CGeneric<outPointHeightType, supportQueueNameRowHelper> supportQueueNameRowValueType;
+
+typedef CGeneric<nameOutPointType, expirationQueueRowHelper> expirationQueueRowValueType;
+typedef CGeneric<nameOutPointType, supportExpirationQueueRowHelper> supportExpirationQueueRowValueType;
+
+typedef std::pair<std::string, claimQueueValueType> claimQueueEntryType;
+
+typedef std::pair<std::string, supportQueueValueType> supportQueueEntryType;
 
 typedef std::map<std::string, supportMapEntryType> supportMapType;
 
-typedef std::vector<outPointHeightType> queueNameRowType;
+typedef std::vector<queueNameRowValueType> queueNameRowType;
 typedef std::map<std::string, queueNameRowType> queueNameType;
+
+typedef std::vector<supportQueueNameRowValueType> supportQueueNameRowType;
+typedef std::map<std::string, supportQueueNameRowType> supportQueueNameType;
 
 typedef std::vector<nameOutPointHeightType> insertUndoType;
 
-typedef std::vector<nameOutPointType> expirationQueueRowType;
+typedef std::vector<expirationQueueRowValueType> expirationQueueRowType;
 typedef std::map<int, expirationQueueRowType> expirationQueueType;
+
+typedef std::vector<supportExpirationQueueRowValueType> supportExpirationQueueRowType;
+typedef std::map<int, supportExpirationQueueRowType> supportExpirationQueueType;
 
 typedef std::vector<claimQueueEntryType> claimQueueRowType;
 typedef std::map<int, claimQueueRowType> claimQueueType;
@@ -279,21 +366,23 @@ typedef std::map<int, claimQueueRowType> claimQueueType;
 typedef std::vector<supportQueueEntryType> supportQueueRowType;
 typedef std::map<int, supportQueueRowType> supportQueueType;
 
-typedef std::map<std::string, CClaimTrieNode*, nodenamecompare> nodeCacheType;
+typedef std::map<std::string, CClaimTrieNode*, nodeNameCompare> nodeCacheType;
 
 typedef std::map<std::string, uint256> hashMapType;
 
-typedef std::set<CClaimValue> claimIndexClaimListType;
-typedef std::vector<CClaimIndexElement> claimIndexElementListType;
-
-struct claimsForNameType
+class claimsForNameType
 {
+public:
+    claimsForNameType(const std::vector<CClaimValue>& claims,
+        const std::vector<CSupportValue>& supports,
+        const int nLastTakeoverHeight)
+        : claims(claims), supports(supports), nLastTakeoverHeight(nLastTakeoverHeight)
+    {
+    }
+
     std::vector<CClaimValue> claims;
     std::vector<CSupportValue> supports;
     int nLastTakeoverHeight;
-
-    claimsForNameType(std::vector<CClaimValue> claims, std::vector<CSupportValue> supports, int nLastTakeoverHeight)
-    : claims(claims), supports(supports), nLastTakeoverHeight(nLastTakeoverHeight) {}
 };
 
 class CClaimTrieCache;
@@ -301,88 +390,85 @@ class CClaimTrieCache;
 class CClaimTrie
 {
 public:
-    CClaimTrie(bool fMemory = false, bool fWipe = false, int nProportionalDelayFactor = 32)
-               : db(GetDataDir() / "claimtrie", 100, fMemory, fWipe, false)
-               , nCurrentHeight(0), nExpirationTime(Params().GetConsensus().nOriginalClaimExpirationTime)
-               , nProportionalDelayFactor(nProportionalDelayFactor)
-               , root(uint256S("0000000000000000000000000000000000000000000000000000000000000001"))
-    {}
+    CClaimTrie(bool fMemory = false, bool fWipe = false, int nProportionalDelayFactor = 32);
+
+    ~CClaimTrie();
 
     uint256 getMerkleHash();
 
     bool empty() const;
+
     void clear();
 
     bool checkConsistency() const;
 
     bool WriteToDisk();
+
     bool ReadFromDisk(bool check = false);
 
     std::vector<namedNodeType> flattenTrie() const;
+
     bool getInfoForName(const std::string& name, CClaimValue& claim) const;
+
     bool getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const;
 
     claimsForNameType getClaimsForName(const std::string& name) const;
-    CAmount getEffectiveAmountForClaim(const std::string& name, uint160 claimId) const;   
-    CAmount getEffectiveAmountForClaimWithSupports(const std::string& name, uint160 claimId,
-                                                   std::vector<CSupportValue>& supports) const;
+
+    CAmount getEffectiveAmountForClaim(const std::string& name, const uint160& claimId) const;
+
+    CAmount getEffectiveAmountForClaimWithSupports(const std::string& name,
+        const uint160& claimId,
+        std::vector<CSupportValue>& supports) const;
 
     bool queueEmpty() const;
+
     bool supportEmpty() const;
+
     bool supportQueueEmpty() const;
+
     bool expirationQueueEmpty() const;
+
     bool supportExpirationQueueEmpty() const;
 
     void setExpirationTime(int t);
 
     void addToClaimIndex(const std::string& name, const CClaimValue& claim);
+
     void removeFromClaimIndex(const CClaimValue& claim);
 
-    bool getClaimById(const uint160 claimId, std::string& name, CClaimValue& claim) const;
-    bool getQueueRow(int nHeight, claimQueueRowType& row) const;
-    bool getQueueNameRow(const std::string& name, queueNameRowType& row) const;
-    bool getExpirationQueueRow(int nHeight, expirationQueueRowType& row) const;
-    bool getSupportNode(std::string name, supportMapEntryType& node) const;
-    bool getSupportQueueRow(int nHeight, supportQueueRowType& row) const;
-    bool getSupportQueueNameRow(const std::string& name, queueNameRowType& row) const;
-    bool getSupportExpirationQueueRow(int nHeight, expirationQueueRowType& row) const;
-
+    bool getClaimById(const uint160& claimId, std::string& name, CClaimValue& claim) const;
 
     bool haveClaim(const std::string& name, const COutPoint& outPoint) const;
-    bool haveClaimInQueue(const std::string& name, const COutPoint& outPoint,
-                          int& nValidAtHeight) const;
+
+    bool haveClaimInQueue(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight) const;
 
     bool haveSupport(const std::string& name, const COutPoint& outPoint) const;
-    bool haveSupportInQueue(const std::string& name, const COutPoint& outPoint,
-                            int& nValidAtHeight) const;
+
+    bool haveSupportInQueue(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight) const;
 
     unsigned int getTotalNamesInTrie() const;
+
     unsigned int getTotalClaimsInTrie() const;
+
     CAmount getTotalValueOfClaimsInTrie(bool fControllingOnly) const;
 
     friend class CClaimTrieCache;
 
-    CDBWrapper db;
     int nCurrentHeight;
     int nExpirationTime;
     int nProportionalDelayFactor;
+
 private:
     void clear(CClaimTrieNode* current);
 
     const CClaimTrieNode* getNodeForName(const std::string& name) const;
 
-    bool update(nodeCacheType& cache, hashMapType& hashes,
-                std::map<std::string, int>& takeoverHeights,
-                const uint256& hashBlock, claimQueueType& queueCache,
-                queueNameType& queueNameCache,
-                expirationQueueType& expirationQueueCache, int nNewHeight,
-                supportMapType& supportCache,
-                supportQueueType& supportQueueCache,
-                queueNameType& supportQueueNameCache,
-                expirationQueueType& supportExpirationQueueCache);
     bool updateName(const std::string& name, CClaimTrieNode* updatedNode);
-    bool updateHash(const std::string& name, uint256& hash);
+
+    bool updateHash(const std::string& name, const uint256& hash);
+
     bool updateTakeoverHeight(const std::string& name, int nTakeoverHeight);
+
     bool recursiveNullify(CClaimTrieNode* node, std::string& name);
 
     bool recursiveCheckConsistency(const CClaimTrieNode* node) const;
@@ -390,60 +476,37 @@ private:
     bool InsertFromDisk(const std::string& name, CClaimTrieNode* node);
 
     unsigned int getTotalNamesRecursive(const CClaimTrieNode* current) const;
+
     unsigned int getTotalClaimsRecursive(const CClaimTrieNode* current) const;
-    CAmount getTotalValueOfClaimsRecursive(const CClaimTrieNode* current,
-                                           bool fControllingOnly) const;
+
+    CAmount getTotalValueOfClaimsRecursive(const CClaimTrieNode* current, bool fControllingOnly) const;
+
     bool recursiveFlattenTrie(const std::string& name,
-                              const CClaimTrieNode* current,
-                              std::vector<namedNodeType>& nodes) const;
+        const CClaimTrieNode* current,
+        std::vector<namedNodeType>& nodes) const;
 
     void markNodeDirty(const std::string& name, CClaimTrieNode* node);
-    void updateQueueRow(int nHeight, claimQueueRowType& row);
-    void updateQueueNameRow(const std::string& name,
-                            queueNameRowType& row);
-    void updateExpirationRow(int nHeight, expirationQueueRowType& row);
-    void updateSupportMap(const std::string& name, supportMapEntryType& node);
-    void updateSupportQueue(int nHeight, supportQueueRowType& row);
-    void updateSupportNameQueue(const std::string& name,
-                                queueNameRowType& row);
-    void updateSupportExpirationQueue(int nHeight, expirationQueueRowType& row);
 
-    void BatchWriteNode(CDBBatch& batch, const std::string& name,
-                        const CClaimTrieNode* pNode) const;
-    void BatchEraseNode(CDBBatch& batch, const std::string& nome) const;
-    void BatchWriteClaimIndex(CDBBatch& batch) const;
-    void BatchWriteQueueRows(CDBBatch& batch);
-    void BatchWriteQueueNameRows(CDBBatch& batch);
-    void BatchWriteExpirationQueueRows(CDBBatch& batch);
-    void BatchWriteSupportNodes(CDBBatch& batch);
-    void BatchWriteSupportQueueRows(CDBBatch& batch);
-    void BatchWriteSupportQueueNameRows(CDBBatch& batch);
-    void BatchWriteSupportExpirationQueueRows(CDBBatch& batch);
-    template<typename K> bool keyTypeEmpty(char key, K& dummy) const;
-
+    CClaimTrieDb db;
     CClaimTrieNode root;
     uint256 hashBlock;
-
-    claimQueueType dirtyQueueRows;
-    queueNameType dirtyQueueNameRows;
-    expirationQueueType dirtyExpirationQueueRows;
-
-    supportQueueType dirtySupportQueueRows;
-    queueNameType dirtySupportQueueNameRows;
-    expirationQueueType dirtySupportExpirationQueueRows;
-
     nodeCacheType dirtyNodes;
-    supportMapType dirtySupportNodes;
 };
 
 class CClaimTrieProofNode
 {
 public:
-    CClaimTrieProofNode() {};
-    CClaimTrieProofNode(std::vector<std::pair<unsigned char, uint256> > children,
-                        bool hasValue, uint256 valHash)
+    CClaimTrieProofNode()
+    {
+    }
+
+    CClaimTrieProofNode(const std::vector<std::pair<unsigned char, uint256> >& children,
+        const bool hasValue,
+        const uint256& valHash)
         : children(children), hasValue(hasValue), valHash(valHash)
-        {};
+    {
+    }
+
     std::vector<std::pair<unsigned char, uint256> > children;
     bool hasValue;
     uint256 valHash;
@@ -452,8 +515,18 @@ public:
 class CClaimTrieProof
 {
 public:
-    CClaimTrieProof() {};
-    CClaimTrieProof(std::vector<CClaimTrieProofNode> nodes, bool hasValue, COutPoint outPoint, int nHeightOfLastTakeover) : nodes(nodes), hasValue(hasValue), outPoint(outPoint), nHeightOfLastTakeover(nHeightOfLastTakeover) {}
+    CClaimTrieProof()
+    {
+    }
+
+    CClaimTrieProof(const std::vector<CClaimTrieProofNode>& nodes,
+        const bool hasValue,
+        const COutPoint& outPoint,
+        const int nHeightOfLastTakeover)
+        : nodes(nodes), hasValue(hasValue), outPoint(outPoint), nHeightOfLastTakeover(nHeightOfLastTakeover)
+    {
+    }
+
     std::vector<CClaimTrieProofNode> nodes;
     bool hasValue;
     COutPoint outPoint;
@@ -463,168 +536,178 @@ public:
 class CClaimTrieCache
 {
 public:
-    CClaimTrieCache(CClaimTrie* base, bool fRequireTakeoverHeights = true)
-                    : base(base),
-                      fRequireTakeoverHeights(fRequireTakeoverHeights)
-    {
-        assert(base);
-        nCurrentHeight = base->nCurrentHeight;
-    }
+    CClaimTrieCache(CClaimTrie* base, bool fRequireTakeoverHeights = true);
 
     uint256 getMerkleHash() const;
 
     bool empty() const;
+
     bool flush();
-    bool dirty() const { return !dirtyHashes.empty(); }
 
-    bool addClaim(const std::string& name, const COutPoint& outPoint,
-                  uint160 claimId, CAmount nAmount, int nHeight) const;
-    bool undoAddClaim(const std::string& name, const COutPoint& outPoint,
-                      int nHeight) const;
-    bool spendClaim(const std::string& name, const COutPoint& outPoint,
-                    int nHeight, int& nValidAtHeight) const;
-    bool undoSpendClaim(const std::string& name, const COutPoint& outPoint,
-                        uint160 claimId, CAmount nAmount, int nHeight,
-                        int nValidAtHeight) const;
+    bool dirty() const;
 
-    bool addSupport(const std::string& name, const COutPoint& outPoint,
-                    CAmount nAmount, uint160 supportedClaimId,
-                    int nHeight) const;
-    bool undoAddSupport(const std::string& name, const COutPoint& outPoint,
-                        int nHeight) const;
-    bool spendSupport(const std::string& name, const COutPoint& outPoint,
-                      int nHeight, int& nValidAtHeight) const;
-    bool undoSpendSupport(const std::string& name, const COutPoint& outPoint,
-                          uint160 supportedClaimId, CAmount nAmount,
-                          int nHeight, int nValidAtHeight) const;
+    bool addClaim(const std::string& name,
+        const COutPoint& outPoint,
+        const uint160& claimId,
+        const CAmount& nAmount,
+        int nHeight);
 
-    uint256 getBestBlock();
+    bool undoAddClaim(const std::string& name, const COutPoint& outPoint, int nHeight);
+
+    bool spendClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight);
+
+    bool undoSpendClaim(const std::string& name,
+        const COutPoint& outPoint,
+        const uint160& claimId,
+        const CAmount& nAmount,
+        int nHeight,
+        int nValidAtHeight);
+
+    bool addSupport(const std::string& name,
+        const COutPoint& outPoint,
+        const CAmount& nAmount,
+        const uint160& supportedClaimId,
+        int nHeight);
+
+    bool undoAddSupport(const std::string& name, const COutPoint& outPoint, int nHeight);
+
+    bool spendSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight);
+
+    bool undoSpendSupport(const std::string& name,
+        const COutPoint& outPoint,
+        const uint160& supportedClaimId,
+        const CAmount& nAmount,
+        int nHeight,
+        int nValidAtHeight);
+
+    uint256 getBestBlock() const;
+
     void setBestBlock(const uint256& hashBlock);
 
     bool incrementBlock(insertUndoType& insertUndo,
-                        claimQueueRowType& expireUndo,
-                        insertUndoType& insertSupportUndo,
-                        supportQueueRowType& expireSupportUndo,
-                        std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const;
+        claimQueueRowType& expireUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo,
+        std::vector<std::pair<std::string, int> >& takeoverHeightUndo);
+
     bool decrementBlock(insertUndoType& insertUndo,
-                        claimQueueRowType& expireUndo,
-                        insertUndoType& insertSupportUndo,
-                        supportQueueRowType& expireSupportUndo,
-                        std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const;
+        claimQueueRowType& expireUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo,
+        std::vector<std::pair<std::string, int> >& takeoverHeightUndo);
 
-    ~CClaimTrieCache() { clear(); }
+    ~CClaimTrieCache();
 
-    bool insertClaimIntoTrie(const std::string& name, CClaimValue claim,
-                             bool fCheckTakeover = false) const;
-    bool removeClaimFromTrie(const std::string& name, const COutPoint& outPoint,
-                             CClaimValue& claim,
-                             bool fCheckTakeover = false) const;
+    bool insertClaimIntoTrie(const std::string& name,
+        const CClaimValue& claim,
+        bool fCheckTakeover = false);
+
+    bool removeClaimFromTrie(const std::string& name,
+        const COutPoint& outPoint,
+        CClaimValue& claim,
+        bool fCheckTakeover = false);
+
     CClaimTrieProof getProofForName(const std::string& name) const;
 
-    bool finalizeDecrement() const;
+    bool finalizeDecrement();
 
-    void removeAndAddSupportToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const;
-    void removeAndAddToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const;
+    void removeAndAddSupportToExpirationQueue(supportExpirationQueueRowType& row, int height, bool increment);
 
-    bool forkForExpirationChange(bool increment) const;
+    void removeAndAddToExpirationQueue(expirationQueueRowType& row, int height, bool increment);
 
+    bool forkForExpirationChange(bool increment);
 
 protected:
-    CClaimTrie* base;
-
-    bool fRequireTakeoverHeights;
-
-    mutable nodeCacheType cache;
-    mutable nodeCacheType block_originals;
-    mutable std::set<std::string> dirtyHashes;
-    mutable hashMapType cacheHashes;
-    mutable claimQueueType claimQueueCache;
-    mutable queueNameType claimQueueNameCache;
-    mutable expirationQueueType expirationQueueCache;
-    mutable supportMapType supportCache;
-    mutable supportQueueType supportQueueCache;
-    mutable queueNameType supportQueueNameCache;
-    mutable expirationQueueType supportExpirationQueueCache;
-    mutable std::set<std::string> namesToCheckForTakeover;
-    mutable std::map<std::string, int> cacheTakeoverHeights; 
-    mutable int nCurrentHeight; // Height of the block that is being worked on, which is
-                                // one greater than the height of the chain's tip
-    mutable claimIndexElementListType claimsToAdd;
-    mutable claimIndexClaimListType claimsToDelete;
-
-    uint256 hashBlock;
-
     uint256 computeHash() const;
 
-    bool reorderTrieNode(const std::string& name, bool fCheckTakeover) const;
-    bool recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent,
-                                    std::string sPos) const;
-    bool recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos,
-                            std::string sName,
-                            bool* pfNullified = NULL) const;
+    bool reorderTrieNode(const std::string& name, bool fCheckTakeover);
 
-    bool clear() const;
+    bool recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent, const std::string& sPos) const;
 
-    bool removeClaim(const std::string& name, const COutPoint& outPoint,
-                     int nHeight, int& nValidAtHeight, bool fCheckTakeover) const;
+    bool recursivePruneName(CClaimTrieNode* tnCurrent,
+        unsigned int nPos,
+        const std::string& sName,
+        bool* pfNullified = NULL);
 
-    bool addClaimToQueues(const std::string& name, CClaimValue& claim) const;
-    bool removeClaimFromQueue(const std::string& name, const COutPoint& outPoint,
-                              CClaimValue& claim) const;
-    void addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry) const;
-    void removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint,
-                                   int nHeight) const;
+    bool clear();
 
-    claimQueueType::iterator getQueueCacheRow(int nHeight,
-                                              bool createIfNotExists) const;
-    queueNameType::iterator getQueueCacheNameRow(const std::string& name,
-                                                 bool createIfNotExists) const;
-    expirationQueueType::iterator getExpirationQueueCacheRow(int nHeight,
-                                                             bool createIfNotExists) const;
+    bool removeClaim(const std::string& name,
+        const COutPoint& outPoint,
+        int nHeight,
+        int& nValidAtHeight,
+        bool fCheckTakeover);
 
-    bool removeSupport(const std::string& name, const COutPoint& outPoint,
-                       int nHeight, int& nValidAtHeight,
-                       bool fCheckTakeover) const;
-    bool removeSupportFromMap(const std::string& name, const COutPoint& outPoint,
-                              CSupportValue& support,
-                              bool fCheckTakeover) const;
+    bool addClaimToQueues(const std::string& name, CClaimValue& claim);
 
-    bool insertSupportIntoMap(const std::string& name,
-                              CSupportValue support,
-                              bool fCheckTakeover) const;
+    bool removeClaimFromQueue(const std::string& name, const COutPoint& outPoint, CClaimValue& claim);
 
-    supportQueueType::iterator getSupportQueueCacheRow(int nHeight,
-                                                       bool createIfNotExists) const;
-    queueNameType::iterator getSupportQueueCacheNameRow(const std::string& name,
-                                                                 bool createIfNotExists) const;
-    expirationQueueType::iterator getSupportExpirationQueueCacheRow(int nHeight,
-                                                                     bool createIfNotExists) const;
+    void addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry);
 
-    bool addSupportToQueues(const std::string& name, CSupportValue& support) const;
-    bool removeSupportFromQueue(const std::string& name, const COutPoint& outPoint,
-                                CSupportValue& support) const;
+    void removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight);
 
-    void addSupportToExpirationQueue(int nExpirationHeight,
-                                     nameOutPointType& entry) const;
-    void removeSupportFromExpirationQueue(const std::string& name,
-                                          const COutPoint& outPoint,
-                                          int nHeight) const;
+    bool removeSupport(const std::string& name,
+        const COutPoint& outPoint,
+        int nHeight,
+        int& nValidAtHeight,
+        bool fCheckTakeover);
 
-    bool getSupportsForName(const std::string& name,
-                            supportMapEntryType& node) const;
+    bool removeSupportFromMap(const std::string& name,
+        const COutPoint& outPoint,
+        CSupportValue& support,
+        bool fCheckTakeover);
+
+    bool insertSupportIntoMap(const std::string& name, const CSupportValue& support, bool fCheckTakeover);
+
+    bool addSupportToQueues(const std::string& name, CSupportValue& support);
+
+    bool removeSupportFromQueue(const std::string& name, const COutPoint& outPoint, CSupportValue& support);
+
+    void addSupportToExpirationQueue(int nExpirationHeight, nameOutPointType& entry);
+
+    void removeSupportFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight);
+
+    bool getSupportsForName(const std::string& name, supportMapEntryType& node) const;
 
     bool getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const;
 
     int getDelayForName(const std::string& name) const;
 
-    uint256 getLeafHashForProof(const std::string& currentPosition, unsigned char nodeChar,
-                                const CClaimTrieNode* currentNode) const;
+    uint256 getLeafHashForProof(const std::string& currentPosition,
+        unsigned char nodeChar,
+        const CClaimTrieNode* currentNode) const;
 
-    CClaimTrieNode* addNodeToCache(const std::string& position, CClaimTrieNode* original) const;
+    CClaimTrieNode* addNodeToCache(const std::string& position, CClaimTrieNode* original);
 
     bool getOriginalInfoForName(const std::string& name, CClaimValue& claim) const;
 
     int getNumBlocksOfContinuousOwnership(const std::string& name) const;
+
+    template <typename K, typename V>
+    void update(std::map<K, V>& map);
+
+    template <typename K, typename V>
+    typename std::map<K, V>::iterator getQueueCacheRow(const K& key, std::map<K, V>& map, bool createIfNotExists);
+
+    CClaimTrie* base;
+    bool fRequireTakeoverHeights;
+    nodeCacheType cache;
+    nodeCacheType block_originals;
+    claimQueueType claimQueueCache;
+    queueNameType claimQueueNameCache;
+    expirationQueueType expirationQueueCache;
+    supportMapType supportCache;
+    supportQueueType supportQueueCache;
+    supportQueueNameType supportQueueNameCache;
+    supportExpirationQueueType supportExpirationQueueCache;
+    std::set<std::string> namesToCheckForTakeover;
+    std::map<std::string, int> cacheTakeoverHeights;
+    int nCurrentHeight; // Height of the block that is being worked on, which is
+    // one greater than the height of the chain's tip
+
+    // used in merkle hash computing
+    mutable hashMapType cacheHashes;
+    mutable std::set<std::string> dirtyHashes;
+    uint256 hashBlock;
 };
 
 #endif // BITCOIN_CLAIMTRIE_H

--- a/src/claimtriedb.cpp
+++ b/src/claimtriedb.cpp
@@ -1,0 +1,227 @@
+
+#include "claimtriedb.h"
+#include "claimtrie.h"
+
+#include <boost/scoped_ptr.hpp>
+#include <iterator>
+#include <list>
+
+/**
+ * Function to provide unique char of types pair
+ */
+template <class T1, class T2>
+unsigned char hashType();
+
+#define TEMPLATE_HASH_TYPE(type1, type2, ret) \
+    template <>                               \
+    unsigned char hashType<type1, type2>()    \
+    {                                         \
+        return ret;                           \
+    }
+
+TEMPLATE_HASH_TYPE(std::string, CClaimTrieNode, 'n')
+TEMPLATE_HASH_TYPE(uint160, CClaimIndexElement, 'i')
+TEMPLATE_HASH_TYPE(int, claimQueueRowType, 'r')
+TEMPLATE_HASH_TYPE(std::string, queueNameRowType, 'm')
+TEMPLATE_HASH_TYPE(int, expirationQueueRowType, 'e')
+TEMPLATE_HASH_TYPE(std::string, supportMapEntryType, 's')
+TEMPLATE_HASH_TYPE(int, supportQueueRowType, 'u')
+TEMPLATE_HASH_TYPE(std::string, supportQueueNameRowType, 'p')
+TEMPLATE_HASH_TYPE(int, supportExpirationQueueRowType, 'x')
+
+/*
+ * Concrete implementation of buffer
+ */
+template <typename K, typename V>
+class CActualBuffer : public CAbstractBuffer
+{
+public:
+    CActualBuffer() : data()
+    {
+    }
+
+    typedef std::list<std::pair<K, V> > dataType;
+
+    typename dataType::iterator find(const K& key)
+    {
+        typename dataType::iterator itData = data.begin();
+        while (itData != data.end()) {
+            if (key == itData->first) break;
+            ++itData;
+        }
+        return itData;
+    }
+
+    typename dataType::iterator end()
+    {
+        return data.end();
+    }
+
+    typename dataType::iterator push_back(const std::pair<K, V>& element)
+    {
+        return data.insert(data.end(), element);
+    }
+
+    void write(const unsigned char key, CClaimTrieDb* db)
+    {
+        for (typename dataType::iterator it = data.begin(); it != data.end(); ++it) {
+            if (it->second.empty()) {
+                db->Erase(std::make_pair(key, it->first));
+            } else {
+                db->Write(std::make_pair(key, it->first), it->second);
+            }
+        }
+        data.clear();
+    }
+
+    dataType data;
+};
+
+CClaimTrieDb::CClaimTrieDb(bool fMemory, bool fWipe)
+    : CDBWrapper(GetDataDir() / "claimtrie", 100, fMemory, fWipe, false)
+{
+}
+
+CClaimTrieDb::~CClaimTrieDb()
+{
+    for (std::map<unsigned char, CAbstractBuffer*>::iterator itQueue = queues.begin(); itQueue != queues.end(); ++itQueue) {
+        delete itQueue->second;
+    }
+}
+
+void CClaimTrieDb::writeQueues()
+{
+    for (std::map<unsigned char, CAbstractBuffer*>::iterator itQueue = queues.begin(); itQueue != queues.end(); ++itQueue) {
+        itQueue->second->write(itQueue->first, this);
+    }
+}
+
+template <typename K, typename V>
+bool CClaimTrieDb::getQueueRow(const K& key, V& row) const
+{
+    const unsigned char hash = hashType<K, V>();
+    std::map<unsigned char, CAbstractBuffer*>::const_iterator itQueue = queues.find(hash);
+    if (itQueue != queues.end()) {
+        CActualBuffer<K, V>* map = static_cast<CActualBuffer<K, V>*>(itQueue->second);
+        typename CActualBuffer<K, V>::dataType::const_iterator itData = map->find(key);
+        if (itData != map->end()) {
+            row = itData->second;
+            return true;
+        }
+    }
+    return Read(std::make_pair(hash, key), row);
+}
+
+template <typename K, typename V>
+void CClaimTrieDb::updateQueueRow(const K& key, V& row)
+{
+    const unsigned char hash = hashType<K, V>();
+    std::map<unsigned char, CAbstractBuffer*>::iterator itQueue = queues.find(hash);
+    if (itQueue == queues.end()) {
+        itQueue = queues.insert(itQueue, std::pair<unsigned char, CAbstractBuffer*>(hash, new CActualBuffer<K, V>));
+    }
+    CActualBuffer<K, V>* map = static_cast<CActualBuffer<K, V>*>(itQueue->second);
+    typename CActualBuffer<K, V>::dataType::iterator itData = map->find(key);
+    if (itData == map->end()) {
+        itData = map->push_back(std::make_pair(key, V()));
+    }
+    std::swap(itData->second, row);
+}
+
+template <typename K, typename V>
+bool CClaimTrieDb::keyTypeEmpty() const
+{
+    const unsigned char hash = hashType<K, V>();
+    std::map<unsigned char, CAbstractBuffer*>::const_iterator itQueue = queues.find(hash);
+    if (itQueue != queues.end()) {
+        const typename CActualBuffer<K, V>::dataType& data = (static_cast<CActualBuffer<K, V>*>(itQueue->second))->data;
+        for (typename CActualBuffer<K, V>::dataType::const_iterator itData = data.begin(); itData != data.end(); ++itData) {
+            if (!itData->second.empty()) return false;
+        }
+    }
+
+    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CClaimTrieDb*>(this)->NewIterator());
+
+    for (pcursor->SeekToFirst(); pcursor->Valid(); pcursor->Next()) {
+        std::pair<unsigned char, K> key;
+        if (pcursor->GetKey(key)) {
+            if (hash == key.first) return false;
+        } else {
+            break;
+        }
+    }
+    return true;
+}
+
+template <typename K, typename V, typename C>
+bool CClaimTrieDb::seekByKey(std::map<K, V, C>& map) const
+{
+    const unsigned char hash = hashType<K, V>();
+    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CClaimTrieDb*>(this)->NewIterator());
+
+    for (pcursor->SeekToFirst(); pcursor->Valid(); pcursor->Next()) {
+        std::pair<unsigned char, K> key;
+        if (pcursor->GetKey(key)) {
+            if (hash == key.first) {
+                V value;
+                if (!pcursor->GetValue(value)) return false;
+                map.insert(std::make_pair(key.second, value));
+            }
+        }
+    }
+    return true;
+}
+
+template <typename K, typename V, typename C>
+bool CClaimTrieDb::getQueueMap(std::map<K, V, C>& map) const
+{
+    const unsigned char hash = hashType<K, V>();
+    std::map<unsigned char, CAbstractBuffer*>::const_iterator itQueue = queues.find(hash);
+    if (itQueue != queues.end()) {
+        const typename CActualBuffer<K, V>::dataType& data = (static_cast<CActualBuffer<K, V>*>(itQueue->second))->data;
+        std::copy(data.begin(), data.end(), std::inserter(map, map.end()));
+    }
+
+    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CClaimTrieDb*>(this)->NewIterator());
+
+    for (pcursor->SeekToFirst(); pcursor->Valid(); pcursor->Next()) {
+        std::pair<unsigned char, K> key;
+        if (pcursor->GetKey(key)) {
+            if (hash == key.first) {
+                typename std::map<K, V, C>::iterator itMap = map.find(key.second);
+                if (itMap != map.end()) continue;
+                V value;
+                if (!pcursor->GetValue(value)) return false;
+                map.insert(itMap, std::make_pair(key.second, value));
+            }
+        }
+    }
+    return true;
+}
+
+/*
+ * Explicit template instantiation for every pair of types
+ */
+#define TEMPLATE_INSTANTIATE2(type1, type2)                                        \
+    template bool CClaimTrieDb::getQueueMap<>(std::map<type1, type2> & map) const; \
+    template bool CClaimTrieDb::getQueueRow<>(const type1& key, type2& row) const; \
+    template void CClaimTrieDb::updateQueueRow<>(const type1& key, type2& row);    \
+    template bool CClaimTrieDb::keyTypeEmpty<type1, type2>() const;                \
+    template bool CClaimTrieDb::seekByKey<>(std::map<type1, type2> & map) const
+
+#define TEMPLATE_INSTANTIATE3(type1, type2, type3)                                        \
+    template bool CClaimTrieDb::getQueueMap<>(std::map<type1, type2, type3> & map) const; \
+    template bool CClaimTrieDb::getQueueRow<>(const type1& key, type2& row) const;        \
+    template void CClaimTrieDb::updateQueueRow<>(const type1& key, type2& row);           \
+    template bool CClaimTrieDb::keyTypeEmpty<type1, type2>() const;                       \
+    template bool CClaimTrieDb::seekByKey<>(std::map<type1, type2, type3> & map) const
+
+TEMPLATE_INSTANTIATE3(std::string, CClaimTrieNode, nodeNameCompare);
+TEMPLATE_INSTANTIATE2(uint160, CClaimIndexElement);
+TEMPLATE_INSTANTIATE2(int, claimQueueRowType);
+TEMPLATE_INSTANTIATE2(std::string, queueNameRowType);
+TEMPLATE_INSTANTIATE2(int, expirationQueueRowType);
+TEMPLATE_INSTANTIATE2(std::string, supportMapEntryType);
+TEMPLATE_INSTANTIATE2(int, supportQueueRowType);
+TEMPLATE_INSTANTIATE2(std::string, supportQueueNameRowType);
+TEMPLATE_INSTANTIATE2(int, supportExpirationQueueRowType);

--- a/src/claimtriedb.h
+++ b/src/claimtriedb.h
@@ -1,0 +1,94 @@
+#ifndef BITCOIN_CLAIMTRIE_DB_H
+#define BITCOIN_CLAIMTRIE_DB_H
+
+#include "dbwrapper.h"
+
+#include <utility>
+
+#include <map>
+
+
+class CClaimTrieDb;
+
+/**
+ * Interface between buffer and database
+ */
+class CAbstractBuffer
+{
+public:
+    virtual ~CAbstractBuffer()
+    {
+    }
+
+    virtual void write(const unsigned char key, CClaimTrieDb* db) = 0;
+};
+
+/**
+ * This class implements key value storage. It is used by the CClaimTrie
+ * class to store queues of claim information. It allows for the storage
+ * of values of datatype V that can be retrieved using key datatype K.
+ * Changes to the key value storage is buffered until they are written to
+ * disk using writeQueues()
+ */
+class CClaimTrieDb : public CDBWrapper
+{
+public:
+    CClaimTrieDb(bool fMemory = false, bool fWipe = false);
+
+    ~CClaimTrieDb();
+
+    /**
+     * Write to disk the buffered changes to the key value storage
+     */
+    void writeQueues();
+
+    /**
+     * Gets a map representation of K type / V type stored by their hash
+     * on disk with buffered changes applied.
+     * @param[out] map  key / value pairs to read
+     */
+    template <typename K, typename V, typename C>
+    bool getQueueMap(std::map<K, V, C>& map) const;
+
+    /**
+     * Gets a value of type V found by key of type K stored by their hash
+     * on disk with with buffered changes applied.
+     * @param[in] key   key to look for
+     * @param[out] row  value which is found
+     */
+    template <typename K, typename V>
+    bool getQueueRow(const K& key, V& row) const;
+
+    /**
+     * Update value of type V by key of type K in the buffer through
+     * their hash
+     * @param[in] key       key to look for
+     * @param[in/out] row   update value and gets its last value
+     */
+    template <typename K, typename V>
+    void updateQueueRow(const K& key, V& row);
+
+    /**
+     * Check that there are no data stored under key datatype K and value
+     * datatype V. Checks both the buffer and disk
+     */
+    template <typename K, typename V>
+    bool keyTypeEmpty() const;
+
+    /**
+     * Get a map representation of K type / V type stored by their hash.
+     * Look only in the disk, and not the buffer.
+     * Returns false if database read fails.
+     * @param[out] map  key / value pairs readed only from disk
+     */
+    template <typename K, typename V, typename C>
+    bool seekByKey(std::map<K, V, C>& map) const;
+
+private:
+    /**
+     * Represents buffer of changes before being stored to disk
+     */
+    std::map<unsigned char, CAbstractBuffer*> queues;
+};
+
+#endif // BITCOIN_CLAIMTRIE_DB_H

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -2,58 +2,56 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://opensource.org/licenses/mit-license.php
 
-#include "main.h"
-#include "consensus/validation.h"
-#include "consensus/merkle.h"
-#include "primitives/transaction.h"
-#include "miner.h"
-#include "txmempool.h"
-#include "claimtrie.h"
-#include "nameclaim.h"
-#include "coins.h"
-#include "streams.h"
 #include "chainparams.h"
+#include "claimtrie.h"
+#include "coins.h"
+#include "consensus/merkle.h"
+#include "consensus/validation.h"
+#include "main.h"
+#include "miner.h"
+#include "nameclaim.h"
 #include "policy/policy.h"
+#include "primitives/transaction.h"
+#include "streams.h"
+#include "test/test_bitcoin.h"
+#include "txmempool.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
-#include "test/test_bitcoin.h"
 
 using namespace std;
 
 
 BOOST_FIXTURE_TEST_SUITE(claimtriebranching_tests, RegTestingSetup)
 
-//is a claim in queue 
+//is a claim in queue
 boost::test_tools::predicate_result
-is_claim_in_queue(std::string name, const CTransaction &tx)
+is_claim_in_queue(std::string name, const CTransaction& tx)
 {
     COutPoint outPoint(tx.GetHash(), 0);
-    int validAtHeight; 
-    bool have_claim = pclaimTrie->haveClaimInQueue(name,outPoint,validAtHeight); 
-    if (have_claim){
+    int validAtHeight;
+    bool have_claim = pclaimTrie->haveClaimInQueue(name, outPoint, validAtHeight);
+    if (have_claim) {
         return true;
-    }
-    else{
+    } else {
         boost::test_tools::predicate_result res(false);
-        res.message()<<"Is not a claim in queue."; 
+        res.message() << "Is not a claim in queue.";
         return res;
     }
 }
 
-// check if tx is best claim based on outpoint 
+// check if tx is best claim based on outpoint
 boost::test_tools::predicate_result
-is_best_claim(std::string name, const CTransaction &tx)
+is_best_claim(std::string name, const CTransaction& tx)
 {
     CClaimValue val;
     COutPoint outPoint(tx.GetHash(), 0);
-    bool have_claim = pclaimTrie->haveClaim(name,outPoint); 
+    bool have_claim = pclaimTrie->haveClaim(name, outPoint);
     bool have_info = pclaimTrie->getInfoForName(name, val);
-    if (have_claim && have_info && val.outPoint == outPoint){
+    if (have_claim && have_info && val.outPoint == outPoint) {
         return true;
-    }
-    else{
+    } else {
         boost::test_tools::predicate_result res(false);
-        res.message()<<"Is not best claim"; 
+        res.message() << "Is not best claim";
         return res;
     }
 }
@@ -63,29 +61,23 @@ best_claim_effective_amount_equals(std::string name, CAmount amount)
 {
     CClaimValue val;
     bool have_info = pclaimTrie->getInfoForName(name, val);
-    if (!have_info)
-    {
+    if (!have_info) {
         boost::test_tools::predicate_result res(false);
-        res.message()<<"No claim found";
+        res.message() << "No claim found";
         return res;
-    }
-    else
-    {
+    } else {
         CAmount effective_amount = pclaimTrie->getEffectiveAmountForClaim(name, val.claimId);
-        if (effective_amount != amount)
-        {
+        if (effective_amount != amount) {
             boost::test_tools::predicate_result res(false);
-            res.message()<<amount<<" != "<<effective_amount;
+            res.message() << amount << " != " << effective_amount;
             return res;
-        }
-        else
-        {
+        } else {
             return true;
         }
     }
 }
 
-CMutableTransaction BuildTransaction(const CMutableTransaction& prev, uint32_t prevout=0, unsigned int numOutputs=1)
+CMutableTransaction BuildTransaction(const CMutableTransaction& prev, uint32_t prevout = 0, unsigned int numOutputs = 1)
 {
     CMutableTransaction tx;
     tx.nVersion = 1;
@@ -98,12 +90,10 @@ CMutableTransaction BuildTransaction(const CMutableTransaction& prev, uint32_t p
     tx.vin[0].nSequence = std::numeric_limits<unsigned int>::max();
     CAmount valuePerOutput = prev.vout[prevout].nValue;
     unsigned int numOutputsCopy = numOutputs;
-    while ((numOutputsCopy = numOutputsCopy >> 1) > 0)
-    {
+    while ((numOutputsCopy = numOutputsCopy >> 1) > 0) {
         valuePerOutput = valuePerOutput >> 1;
     }
-    for (unsigned int i = 0; i < numOutputs; ++i)
-    {
+    for (unsigned int i = 0; i < numOutputs; ++i) {
         tx.vout[i].scriptPubKey = CScript();
         tx.vout[i].nValue = valuePerOutput;
     }
@@ -115,7 +105,7 @@ bool CreateBlock(CBlockTemplate* pblocktemplate)
     static int unique_block_counter = 0;
     CBlock* pblock = &pblocktemplate->block;
     pblock->nVersion = 1;
-    pblock->nTime = chainActive.Tip()->GetBlockTime()+Params().GetConsensus().nPowTargetSpacing;
+    pblock->nTime = chainActive.Tip()->GetBlockTime() + Params().GetConsensus().nPowTargetSpacing;
     CMutableTransaction txCoinbase(pblock->vtx[0]);
     txCoinbase.vin[0].scriptSig = CScript() << CScriptNum(unique_block_counter++) << CScriptNum(chainActive.Height());
     txCoinbase.vout[0].nValue = GetBlockSubsidy(chainActive.Height() + 1, Params().GetConsensus());
@@ -123,60 +113,54 @@ bool CreateBlock(CBlockTemplate* pblocktemplate)
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
     for (uint32_t i = 0;; ++i) {
         pblock->nNonce = i;
-        if (CheckProofOfWork(pblock->GetPoWHash(), pblock->nBits, Params().GetConsensus()))
-        {
-            break;
-        }
+        if (CheckProofOfWork(pblock->GetPoWHash(), pblock->nBits, Params().GetConsensus())) break;
     }
     CValidationState state;
     bool success = (ProcessNewBlock(state, Params(), NULL, pblock, true, NULL) && state.IsValid() && pblock->GetHash() == chainActive.Tip()->GetBlockHash());
     pblock->hashPrevBlock = pblock->GetHash();
     return success;
-
 }
 
 bool CreateCoinbases(unsigned int num_coinbases, std::vector<CTransaction>& coinbases)
 {
-    CBlockTemplate *pblocktemplate;
+    CBlockTemplate* pblocktemplate;
     coinbases.clear();
-    BOOST_CHECK(pblocktemplate = CreateNewBlock(Params(), CScript()<<OP_TRUE ));
+    BOOST_CHECK(pblocktemplate = CreateNewBlock(Params(), CScript() << OP_TRUE));
     BOOST_CHECK(pblocktemplate->block.vtx.size() == 1);
     pblocktemplate->block.hashPrevBlock = chainActive.Tip()->GetBlockHash();
-    for (unsigned int i = 0; i < 100 + num_coinbases; ++i)
-    {
+    for (unsigned int i = 0; i < 100 + num_coinbases; ++i) {
         BOOST_CHECK(CreateBlock(pblocktemplate));
-        if (coinbases.size() < num_coinbases)
+        if (coinbases.size() < num_coinbases) {
             coinbases.push_back(CTransaction(pblocktemplate->block.vtx[0]));
+        }
     }
     delete pblocktemplate;
     return true;
 }
 
 
-// Test Fixtures 
-struct ClaimTrieChainFixture{
+// Test Fixtures
+struct ClaimTrieChainFixture {
     std::vector<CTransaction> coinbase_txs;
     std::vector<int> marks;
-    int coinbase_txs_used; 
-    unsigned int num_txs; 
-    unsigned int num_txs_for_next_block; 
+    int coinbase_txs_used;
+    unsigned int num_txs;
+    unsigned int num_txs_for_next_block;
 
     // these will take on regtest parameters
     const int expirationForkHeight;
     const int originalExpiration;
     const int extendedExpiration;
 
-
-    ClaimTrieChainFixture():
-        expirationForkHeight(Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationForkHeight),
-        originalExpiration(Params(CBaseChainParams::REGTEST).GetConsensus().nOriginalClaimExpirationTime),
-        extendedExpiration(Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationTime)
+    ClaimTrieChainFixture() : expirationForkHeight(Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationForkHeight),
+                              originalExpiration(Params(CBaseChainParams::REGTEST).GetConsensus().nOriginalClaimExpirationTime),
+                              extendedExpiration(Params(CBaseChainParams::REGTEST).GetConsensus().nExtendedClaimExpirationTime)
     {
         fRequireStandard = false;
         ENTER_CRITICAL_SECTION(cs_main);
         BOOST_CHECK(pclaimTrie->nCurrentHeight == chainActive.Height() + 1);
         num_txs_for_next_block = 0;
-        num_txs = 0; 
+        num_txs = 0;
         coinbase_txs_used = 0;
         // generate coinbases to spend
         CreateCoinbases(40, coinbase_txs);
@@ -189,11 +173,11 @@ struct ClaimTrieChainFixture{
     }
 
 
-    void CommitTx(CMutableTransaction &tx){
+    void CommitTx(CMutableTransaction& tx)
+    {
         num_txs_for_next_block++;
         num_txs++;
-        if(num_txs > coinbase_txs.size())
-        {
+        if (num_txs > coinbase_txs.size()) {
             //ran out of coinbases to spend
             assert(0);
         }
@@ -204,30 +188,29 @@ struct ClaimTrieChainFixture{
         BOOST_CHECK(AcceptToMemoryPool(mempool, state, tx, false, &fMissingInputs, &txFeeRate));
     }
 
-    //spend a bid into some non claimtrie related unspent 
-    CMutableTransaction Spend(const CTransaction &prev){
-
+    //spend a bid into some non claimtrie related unspent
+    CMutableTransaction Spend(const CTransaction& prev)
+    {
         uint32_t prevout = 0;
-        CMutableTransaction tx = BuildTransaction(prev,prevout); 
+        CMutableTransaction tx = BuildTransaction(prev, prevout);
         tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
         tx.vout[0].nValue = 1;
 
-        CommitTx(tx); 
-        return tx; 
+        CommitTx(tx);
+        return tx;
     }
 
     //make claim at the current block
-    CMutableTransaction MakeClaim(const CTransaction &prev, std::string name, std::string value, 
-                                  CAmount quantity)
+    CMutableTransaction MakeClaim(const CTransaction& prev, std::string name, std::string value, CAmount quantity)
     {
-        uint32_t prevout = 0; 
+        uint32_t prevout = 0;
 
-        CMutableTransaction tx = BuildTransaction(prev,prevout);
-        tx.vout[0].scriptPubKey = ClaimNameScript(name,value); 
+        CMutableTransaction tx = BuildTransaction(prev, prevout);
+        tx.vout[0].scriptPubKey = ClaimNameScript(name, value);
         tx.vout[0].nValue = quantity;
 
-        CommitTx(tx); 
-        return tx; 
+        CommitTx(tx);
+        return tx;
     }
 
     CMutableTransaction MakeClaim(const CTransaction& prev, std::string name, std::string value)
@@ -236,30 +219,29 @@ struct ClaimTrieChainFixture{
     }
 
     //make support at the current block
-    CMutableTransaction MakeSupport(const CTransaction &prev, const CTransaction &claimtx, std::string name, CAmount quantity)
+    CMutableTransaction MakeSupport(const CTransaction& prev, const CTransaction& claimtx, std::string name, CAmount quantity)
     {
         uint160 claimId = ClaimIdHash(claimtx.GetHash(), 0);
         uint32_t prevout = 0;
 
-        CMutableTransaction tx = BuildTransaction(prev,prevout);
-        tx.vout[0].scriptPubKey = SupportClaimScript(name,claimId); 
+        CMutableTransaction tx = BuildTransaction(prev, prevout);
+        tx.vout[0].scriptPubKey = SupportClaimScript(name, claimId);
         tx.vout[0].nValue = quantity;
 
-        CommitTx(tx); 
+        CommitTx(tx);
         return tx;
     }
 
     //make update at the current block
-    CMutableTransaction MakeUpdate(const CTransaction &prev, std::string name, std::string value,
-                               uint160 claimId, CAmount quantity)
+    CMutableTransaction MakeUpdate(const CTransaction& prev, std::string name, std::string value, uint160 claimId, CAmount quantity)
     {
         uint32_t prevout = 0;
 
-        CMutableTransaction tx = BuildTransaction(prev,prevout);
-        tx.vout[0].scriptPubKey = UpdateClaimScript(name,claimId,value); 
+        CMutableTransaction tx = BuildTransaction(prev, prevout);
+        tx.vout[0].scriptPubKey = UpdateClaimScript(name, claimId, value);
         tx.vout[0].nValue = quantity;
 
-        CommitTx(tx); 
+        CommitTx(tx);
         return tx;
     }
 
@@ -273,21 +255,21 @@ struct ClaimTrieChainFixture{
     //create i blocks
     void IncrementBlocks(int num_blocks, bool mark = false)
     {
-        if (mark)
+        if (mark) {
             marks.push_back(chainActive.Height());
+        }
 
-        for (int i = 0; i < num_blocks; ++i)
-        {
-            CBlockTemplate *pblocktemplate;
-            CScript coinbase_scriptpubkey; 
+        for (int i = 0; i < num_blocks; ++i) {
+            CBlockTemplate* pblocktemplate;
+            CScript coinbase_scriptpubkey;
             coinbase_scriptpubkey << CScriptNum(chainActive.Height());
             BOOST_CHECK(pblocktemplate = CreateNewBlock(Params(), coinbase_scriptpubkey));
-            BOOST_CHECK(pblocktemplate->block.vtx.size() == num_txs_for_next_block+1);
+            BOOST_CHECK(pblocktemplate->block.vtx.size() == num_txs_for_next_block + 1);
             pblocktemplate->block.hashPrevBlock = chainActive.Tip()->GetBlockHash();
             BOOST_CHECK(CreateBlock(pblocktemplate));
             delete pblocktemplate;
 
-            num_txs_for_next_block = 0 ;
+            num_txs_for_next_block = 0;
         }
     }
 
@@ -298,12 +280,9 @@ struct ClaimTrieChainFixture{
             CValidationState state;
             CBlockIndex* pblockindex = chainActive.Tip();
             InvalidateBlock(state, Params().GetConsensus(), pblockindex);
-            if (state.IsValid())
-            {
+            if (state.IsValid()) {
                 ActivateBestChain(state, Params());
-            }
-            else
-            {
+            } else {
                 BOOST_FAIL("removing block failed");
             }
         }
@@ -326,7 +305,7 @@ struct ClaimTrieChainFixture{
         // from disk
         pclaimTrie->WriteToDisk();
         pclaimTrie->clear();
-        pclaimTrie->ReadFromDisk(true);
+        BOOST_CHECK(pclaimTrie->ReadFromDisk(true));
     }
 };
 
@@ -337,8 +316,8 @@ struct ClaimTrieChainFixture{
         there is a competing bid inserted same height
             check the greater one wins
                 - quantity is same, check outpoint greater wins
-        there is an existing competing bid 
-            check that rules for delays are observed 
+        there is an existing competing bid
+            check that rules for delays are observed
             check that a greater amount wins
             check that a smaller amount does not win
 
@@ -347,161 +326,161 @@ BOOST_AUTO_TEST_CASE(claim_test)
 {
     // no competing bids
     ClaimTrieChainFixture fixture;
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(is_best_claim("test", tx1));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(!is_best_claim("test",tx1));
-     
+    BOOST_CHECK(!is_best_claim("test", tx1));
+
     // there is a competing bid inserted same height
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx3));
+    BOOST_CHECK(is_best_claim("test", tx3));
     BOOST_CHECK_EQUAL(2U, pclaimTrie->getClaimsForName("test").claims.size());
 
-    fixture.DecrementBlocks(1); 
-    BOOST_CHECK(!is_best_claim("test",tx2));
-    BOOST_CHECK(!is_best_claim("test",tx3));
+    fixture.DecrementBlocks(1);
+    BOOST_CHECK(!is_best_claim("test", tx2));
+    BOOST_CHECK(!is_best_claim("test", tx3));
     BOOST_CHECK_EQUAL(0U, pclaimTrie->getClaimsForName("test").claims.size());
 
-    // make two claims , one older 
-    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    fixture.IncrementBlocks(1); 
-    BOOST_CHECK(is_best_claim("test",tx4));
-    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(),"test","two",1);
+    // make two claims , one older
+    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_claim_in_queue("test",tx5));
-    BOOST_CHECK(is_best_claim("test",tx4)); 
+    BOOST_CHECK(is_best_claim("test", tx4));
+    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "two", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx4));
+    BOOST_CHECK(is_claim_in_queue("test", tx5));
+    BOOST_CHECK(is_best_claim("test", tx4));
+    fixture.IncrementBlocks(1);
+    BOOST_CHECK(is_best_claim("test", tx4));
     BOOST_CHECK_EQUAL(2U, pclaimTrie->getClaimsForName("test").claims.size());
 
-    fixture.DecrementBlocks(1); 
-    BOOST_CHECK(is_best_claim("test",tx4)); 
-    BOOST_CHECK(is_claim_in_queue("test",tx5));
-    fixture.DecrementBlocks(1); 
-    BOOST_CHECK(is_best_claim("test",tx4)); 
+    fixture.DecrementBlocks(1);
+    BOOST_CHECK(is_best_claim("test", tx4));
+    BOOST_CHECK(is_claim_in_queue("test", tx5));
+    fixture.DecrementBlocks(1);
+    BOOST_CHECK(is_best_claim("test", tx4));
     fixture.DecrementBlocks(1);
 
     // check claim takeover, note that CClaimTrie.nProportionalDelayFactor is set to 1
     // instead of 32 in test_bitcoin.cpp
-    CMutableTransaction tx6 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    fixture.IncrementBlocks(10); 
-    BOOST_CHECK(is_best_claim("test",tx6));
-    CMutableTransaction tx7 = fixture.MakeClaim(fixture.GetCoinbase(),"test","two",2);
+    CMutableTransaction tx6 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    fixture.IncrementBlocks(10);
+    BOOST_CHECK(is_best_claim("test", tx6));
+    CMutableTransaction tx7 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "two", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_claim_in_queue("test",tx7));
+    BOOST_CHECK(is_claim_in_queue("test", tx7));
     BOOST_CHECK(is_best_claim("test", tx6));
     fixture.IncrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx7));
+    BOOST_CHECK(is_best_claim("test", tx7));
     BOOST_CHECK_EQUAL(2U, pclaimTrie->getClaimsForName("test").claims.size());
 
     fixture.DecrementBlocks(10);
-    BOOST_CHECK(is_claim_in_queue("test",tx7));
-    BOOST_CHECK(is_best_claim("test",tx6)); 
+    BOOST_CHECK(is_claim_in_queue("test", tx7));
+    BOOST_CHECK(is_best_claim("test", tx6));
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx6));
+    BOOST_CHECK(is_best_claim("test", tx6));
     fixture.DecrementBlocks(10);
 }
 
 /*
     spent claims
-        spending winning claim will make losing active claim winner    
+        spending winning claim will make losing active claim winner
         spending winning claim will make inactive claim winner
-        spending winning claim will empty out claim trie 
+        spending winning claim will empty out claim trie
 */
 BOOST_AUTO_TEST_CASE(spend_claim_test)
 {
     ClaimTrieChainFixture fixture;
 
-    // spending winning claim will make losing active claim winner    
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    // spending winning claim will make losing active claim winner
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1)); 
+    BOOST_CHECK(is_best_claim("test", tx1));
     fixture.Spend(tx1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx2)); 
-    
+    BOOST_CHECK(is_best_claim("test", tx2));
+
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1)); 
-    fixture.DecrementBlocks(1); 
+    BOOST_CHECK(is_best_claim("test", tx1));
+    fixture.DecrementBlocks(1);
 
 
     // spending winning claim will make inactive claim winner
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx3));
-    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    fixture.IncrementBlocks(1); 
-    BOOST_CHECK(is_best_claim("test",tx3));
+    BOOST_CHECK(is_best_claim("test", tx3));
+    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    fixture.IncrementBlocks(1);
+    BOOST_CHECK(is_best_claim("test", tx3));
     fixture.Spend(tx3);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx4));
+    BOOST_CHECK(is_best_claim("test", tx4));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx3));
+    BOOST_CHECK(is_best_claim("test", tx3));
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx3));
+    BOOST_CHECK(is_best_claim("test", tx3));
     fixture.DecrementBlocks(10);
 
 
-    //spending winning claim will empty out claim trie 
-    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    //spending winning claim will empty out claim trie
+    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx5));
+    BOOST_CHECK(is_best_claim("test", tx5));
     fixture.Spend(tx5);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(!is_best_claim("test",tx5));
+    BOOST_CHECK(!is_best_claim("test", tx5));
     BOOST_CHECK(pclaimTrie->empty());
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx5));
+    BOOST_CHECK(is_best_claim("test", tx5));
     fixture.DecrementBlocks(1);
 }
 
 
 /*
     supports
-        check support with wrong name does not work 
+        check support with wrong name does not work
         check claim with more support wins
-        check support delay 
+        check support delay
 */
 BOOST_AUTO_TEST_CASE(support_test)
 {
     ClaimTrieChainFixture fixture;
-    // check claim with more support wins 
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",1);
-    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(),tx2,"test",10);
+    // check claim with more support wins
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 1);
+    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(), tx2, "test", 10);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx2));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",11));
+    BOOST_CHECK(is_best_claim("test", tx2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 11));
     fixture.DecrementBlocks(1);
 
-    // check support delay  
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(),"test","two",2);
+    // check support delay
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "two", 2);
     fixture.IncrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx4));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
-    CMutableTransaction s4 = fixture.MakeSupport(fixture.GetCoinbase(),tx3,"test",10); //10 delay 
+    BOOST_CHECK(is_best_claim("test", tx4));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
+    CMutableTransaction s4 = fixture.MakeSupport(fixture.GetCoinbase(), tx3, "test", 10); //10 delay
     fixture.IncrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx4));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    BOOST_CHECK(is_best_claim("test", tx4));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx3));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",11));
+    BOOST_CHECK(is_best_claim("test", tx3));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 11));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx4));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    BOOST_CHECK(is_best_claim("test", tx4));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
     fixture.DecrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx4)); 
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    BOOST_CHECK(is_best_claim("test", tx4));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
     fixture.DecrementBlocks(10);
 }
 
@@ -516,35 +495,34 @@ BOOST_AUTO_TEST_CASE(support_test)
 BOOST_AUTO_TEST_CASE(support_on_abandon_test)
 {
     ClaimTrieChainFixture fixture;
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(1);
 
     //supporting and abandoing on the same block will cause it to crash
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 1);
     fixture.Spend(tx1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    BOOST_CHECK(!is_best_claim("test", tx1));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1));
-
+    BOOST_CHECK(is_best_claim("test", tx1));
 }
 
 BOOST_AUTO_TEST_CASE(support_on_abandon_2_test)
 {
     ClaimTrieChainFixture fixture;
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",1);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 1);
     fixture.IncrementBlocks(1);
 
     //abandoning a support and abandoing claim on the same block will cause it to crash
     fixture.Spend(tx1);
     fixture.Spend(s1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    BOOST_CHECK(!is_best_claim("test", tx1));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(is_best_claim("test", tx1));
 }
 
 BOOST_AUTO_TEST_CASE(update_on_support_test)
@@ -553,15 +531,15 @@ BOOST_AUTO_TEST_CASE(update_on_support_test)
     // updates happening on the same block as a support
     // (it should not)
     ClaimTrieChainFixture fixture;
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",3);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 3);
     fixture.IncrementBlocks(1);
 
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",1);
-    CMutableTransaction u1 = fixture.MakeUpdate(tx1,"test","two",ClaimIdHash(tx1.GetHash(),0),1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 1);
+    CMutableTransaction u1 = fixture.MakeUpdate(tx1, "test", "two", ClaimIdHash(tx1.GetHash(), 0), 1);
     fixture.IncrementBlocks(1);
 
-    BOOST_CHECK(is_best_claim("test",u1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    BOOST_CHECK(is_best_claim("test", u1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
 
     fixture.DecrementBlocks(1);
     BOOST_CHECK(is_best_claim("test", tx1));
@@ -571,36 +549,35 @@ BOOST_AUTO_TEST_CASE(update_on_support_test)
     support spend
         spending suport on winning claim will cause it to lose
 
-        spending a support on txin[i] where i is not 0 
+        spending a support on txin[i] where i is not 0
 */
 BOOST_AUTO_TEST_CASE(support_spend_test)
 {
-
     ClaimTrieChainFixture fixture;
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",2);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1)); 
+    BOOST_CHECK(is_best_claim("test", tx1));
     CMutableTransaction sp1 = fixture.Spend(s1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx2));
+    BOOST_CHECK(is_best_claim("test", tx2));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(is_best_claim("test", tx1));
     fixture.DecrementBlocks(1);
 
-    // spend a support on txin[i] where i is not 0 
-    
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"x","one",3);
-    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(),"test","two",2);
-    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(),"test","three",1);
-    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(),tx5,"test",2);
+    // spend a support on txin[i] where i is not 0
+
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "x", "one", 3);
+    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "two", 2);
+    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "three", 1);
+    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(), tx5, "test", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx5));
+    BOOST_CHECK(is_best_claim("test", tx5));
     BOOST_CHECK_EQUAL(2U, pclaimTrie->getClaimsForName("test").claims.size());
 
-    // build the spend where s2 is sppent on txin[1] and tx3 is  spent on txin[0]   
+    // build the spend where s2 is sppent on txin[1] and tx3 is  spent on txin[0]
     uint32_t prevout = 0;
     CMutableTransaction tx;
     tx.nVersion = 1;
@@ -618,73 +595,73 @@ BOOST_AUTO_TEST_CASE(support_spend_test)
     tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
     tx.vout[0].nValue = 1;
 
-    fixture.CommitTx(tx); 
+    fixture.CommitTx(tx);
     fixture.IncrementBlocks(1);
 
-    BOOST_CHECK(is_best_claim("test",tx4)); 
+    BOOST_CHECK(is_best_claim("test", tx4));
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx5));
+    BOOST_CHECK(is_best_claim("test", tx5));
 }
 /*
     update
         update preserves claim id
-        update preserves supports 
+        update preserves supports
         winning update on winning claim happens without delay
         losing update on winning claim happens without delay
         update on losing claim happens with delay , and wins
-    
-       
+
+
 */
 BOOST_AUTO_TEST_CASE(claimtrie_update_test)
 {
-    //update preserves claim id 
+    //update preserves claim id
     ClaimTrieChainFixture fixture;
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction u1 = fixture.MakeUpdate(tx1,"test","one",ClaimIdHash(tx1.GetHash(),0),2); 
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction u1 = fixture.MakeUpdate(tx1, "test", "one", ClaimIdHash(tx1.GetHash(), 0), 2);
     fixture.IncrementBlocks(1);
-    CClaimValue val; 
-    pclaimTrie->getInfoForName("test",val);
-    BOOST_CHECK(val.claimId == ClaimIdHash(tx1.GetHash(),0));
-    BOOST_CHECK(is_best_claim("test",u1));
-    fixture.DecrementBlocks(1); 
-    
+    CClaimValue val;
+    pclaimTrie->getInfoForName("test", val);
+    BOOST_CHECK(val.claimId == ClaimIdHash(tx1.GetHash(), 0));
+    BOOST_CHECK(is_best_claim("test", u1));
+    fixture.DecrementBlocks(1);
+
     // update preserves supports
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx2,"test",1); 
-    CMutableTransaction u2 = fixture.MakeUpdate(tx2,"test","one",ClaimIdHash(tx2.GetHash(),0),1);  
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx2, "test", 1);
+    CMutableTransaction u2 = fixture.MakeUpdate(tx2, "test", "one", ClaimIdHash(tx2.GetHash(), 0), 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
     fixture.DecrementBlocks(1);
 
     // winning update on winning claim happens without delay
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
     fixture.IncrementBlocks(10);
-    CMutableTransaction u3 = fixture.MakeUpdate(tx3,"test","one",ClaimIdHash(tx3.GetHash(),0),2);  
+    CMutableTransaction u3 = fixture.MakeUpdate(tx3, "test", "one", ClaimIdHash(tx3.GetHash(), 0), 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",u3));
+    BOOST_CHECK(is_best_claim("test", u3));
     BOOST_CHECK_EQUAL(2U, pclaimTrie->getClaimsForName("test").claims.size());
     fixture.DecrementBlocks(11);
 
     // losing update on winning claim happens without delay
-    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",3);
-    CMutableTransaction tx6 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 3);
+    CMutableTransaction tx6 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(10);
     BOOST_CHECK(is_best_claim("test", tx5));
     BOOST_CHECK_EQUAL(2U, pclaimTrie->getClaimsForName("test").claims.size());
     CMutableTransaction u4 = fixture.MakeUpdate(tx5, "test", "one", ClaimIdHash(tx5.GetHash(), 0), 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx6));
+    BOOST_CHECK(is_best_claim("test", tx6));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx5)); 
+    BOOST_CHECK(is_best_claim("test", tx5));
     fixture.DecrementBlocks(10);
 
     // update on losing claim happens with delay , and wins
-    CMutableTransaction tx7 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",3);
-    CMutableTransaction tx8 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx7 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 3);
+    CMutableTransaction tx8 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx7)); 
+    BOOST_CHECK(is_best_claim("test", tx7));
 
     CMutableTransaction tx;
     tx.nVersion = 1;
@@ -699,17 +676,17 @@ BOOST_AUTO_TEST_CASE(claimtrie_update_test)
     tx.vin[1].prevout.n = 0;
     tx.vin[1].scriptSig = CScript();
     tx.vin[1].nSequence = std::numeric_limits<unsigned int>::max();
-    tx.vout[0].scriptPubKey = UpdateClaimScript("test",ClaimIdHash(tx8.GetHash(),0),"one");
+    tx.vout[0].scriptPubKey = UpdateClaimScript("test", ClaimIdHash(tx8.GetHash(), 0), "one");
     tx.vout[0].nValue = 4;
-    fixture.CommitTx(tx); 
+    fixture.CommitTx(tx);
 
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx7));
+    BOOST_CHECK(is_best_claim("test", tx7));
     fixture.IncrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx));
+    BOOST_CHECK(is_best_claim("test", tx));
 
     fixture.DecrementBlocks(10);
-    BOOST_CHECK(is_best_claim("test",tx7));
+    BOOST_CHECK(is_best_claim("test", tx7));
     fixture.DecrementBlocks(11);
 }
 
@@ -717,7 +694,7 @@ BOOST_AUTO_TEST_CASE(claimtrie_update_test)
     expiration
         check claims expire and loses claim
         check claims expire and is not updateable (may be changed in future soft fork)
-        check supports expire and can cause supported bid to lose claim 
+        check supports expire and can cause supported bid to lose claim
 */
 BOOST_AUTO_TEST_CASE(claimtrie_expire_test)
 {
@@ -725,58 +702,58 @@ BOOST_AUTO_TEST_CASE(claimtrie_expire_test)
     pclaimTrie->setExpirationTime(5);
 
     // check claims expire and loses claim
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(pclaimTrie->nExpirationTime);
-    BOOST_CHECK(is_best_claim("test",tx1));
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    BOOST_CHECK(is_best_claim("test", tx1));
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx2));
+    BOOST_CHECK(is_best_claim("test", tx2));
 
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(is_best_claim("test", tx1));
     fixture.DecrementBlocks(pclaimTrie->nExpirationTime);
 
     // check claims expire and is not updateable (may be changed in future soft fork)
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx3));
+    BOOST_CHECK(is_best_claim("test", tx3));
     fixture.IncrementBlocks(pclaimTrie->nExpirationTime);
-    CMutableTransaction u1 = fixture.MakeUpdate(tx3,"test","two",ClaimIdHash(tx3.GetHash(),0) ,2);
-    BOOST_CHECK(!is_best_claim("test",u1));
+    CMutableTransaction u1 = fixture.MakeUpdate(tx3, "test", "two", ClaimIdHash(tx3.GetHash(), 0), 2);
+    BOOST_CHECK(!is_best_claim("test", u1));
 
     fixture.DecrementBlocks(pclaimTrie->nExpirationTime);
-    BOOST_CHECK(is_best_claim("test",tx3));
+    BOOST_CHECK(is_best_claim("test", tx3));
     fixture.DecrementBlocks(1);
 
     // check supports expire and can cause supported bid to lose claim
-    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx4,"test",2);
+    CMutableTransaction tx4 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction tx5 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx4, "test", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx4));
-    CMutableTransaction u2 = fixture.MakeUpdate(tx4,"test","two",ClaimIdHash(tx4.GetHash(),0) ,1);
-    CMutableTransaction u3 = fixture.MakeUpdate(tx5,"test","two",ClaimIdHash(tx5.GetHash(),0) ,2);
+    BOOST_CHECK(is_best_claim("test", tx4));
+    CMutableTransaction u2 = fixture.MakeUpdate(tx4, "test", "two", ClaimIdHash(tx4.GetHash(), 0), 1);
+    CMutableTransaction u3 = fixture.MakeUpdate(tx5, "test", "two", ClaimIdHash(tx5.GetHash(), 0), 2);
     fixture.IncrementBlocks(pclaimTrie->nExpirationTime);
-    BOOST_CHECK(is_best_claim("test",u3));
+    BOOST_CHECK(is_best_claim("test", u3));
     fixture.DecrementBlocks(pclaimTrie->nExpirationTime);
-    BOOST_CHECK(is_best_claim("test",tx4));
+    BOOST_CHECK(is_best_claim("test", tx4));
     fixture.DecrementBlocks(1);
 
     // check updated claims will extend expiration
-    CMutableTransaction tx6 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx6 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",tx6));
-    CMutableTransaction u4 = fixture.MakeUpdate(tx6,"test","two",ClaimIdHash(tx6.GetHash(),0) ,2);
+    BOOST_CHECK(is_best_claim("test", tx6));
+    CMutableTransaction u4 = fixture.MakeUpdate(tx6, "test", "two", ClaimIdHash(tx6.GetHash(), 0), 2);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",u4));
-    fixture.IncrementBlocks(pclaimTrie->nExpirationTime-1);
-    BOOST_CHECK(is_best_claim("test",u4));
+    BOOST_CHECK(is_best_claim("test", u4));
+    fixture.IncrementBlocks(pclaimTrie->nExpirationTime - 1);
+    BOOST_CHECK(is_best_claim("test", u4));
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(!is_best_claim("test",u4));
+    BOOST_CHECK(!is_best_claim("test", u4));
     fixture.DecrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",u4));
+    BOOST_CHECK(is_best_claim("test", u4));
     fixture.DecrementBlocks(pclaimTrie->nExpirationTime);
-    BOOST_CHECK(is_best_claim("test",tx6));
+    BOOST_CHECK(is_best_claim("test", tx6));
 }
 
 /*
@@ -885,6 +862,89 @@ BOOST_AUTO_TEST_CASE(get_claim_by_id_test)
     BOOST_CHECK(claimValue2.claimId != claimId);
 }
 
+BOOST_AUTO_TEST_CASE(get_claim_by_id_test_2)
+{
+    ClaimTrieChainFixture fixture;
+    const std::string name = "test";
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 1);
+    uint160 claimId = ClaimIdHash(tx1.GetHash(), 0);
+    CMutableTransaction txx = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 1);
+    uint160 claimIdx = ClaimIdHash(txx.GetHash(), 0);
+
+    fixture.IncrementBlocks(1);
+
+    CClaimValue claimValue;
+    std::string claimName;
+    pclaimTrie->getClaimById(claimId, claimName, claimValue);
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId);
+
+    CMutableTransaction txa = fixture.Spend(tx1);
+    CMutableTransaction txb = fixture.Spend(txx);
+
+    fixture.IncrementBlocks(1);
+    BOOST_CHECK(!pclaimTrie->getClaimById(claimId, claimName, claimValue));
+    BOOST_CHECK(!pclaimTrie->getClaimById(claimIdx, claimName, claimValue));
+
+    fixture.DecrementBlocks(1);
+    pclaimTrie->getClaimById(claimId, claimName, claimValue);
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId);
+
+    pclaimTrie->getClaimById(claimIdx, claimName, claimValue);
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimIdx);
+}
+
+BOOST_AUTO_TEST_CASE(get_claim_by_id_test_3)
+{
+    ClaimTrieChainFixture fixture;
+    pclaimTrie->setExpirationTime(5);
+    const std::string name = "test";
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 1);
+    uint160 claimId = ClaimIdHash(tx1.GetHash(), 0);
+
+    fixture.IncrementBlocks(1);
+
+    CClaimValue claimValue;
+    std::string claimName;
+    pclaimTrie->getClaimById(claimId, claimName, claimValue);
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId);
+    // make second claim with activation delay 1
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 2);
+    uint160 claimId2 = ClaimIdHash(tx2.GetHash(), 0);
+
+    fixture.IncrementBlocks(1);
+    // second claim is not activated yet, but can still access by claim id
+    BOOST_CHECK(is_best_claim(name, tx1));
+    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId2);
+
+    fixture.IncrementBlocks(1);
+    // second claim has activated
+    BOOST_CHECK(is_best_claim(name, tx2));
+    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId2);
+
+    fixture.DecrementBlocks(1);
+    // second claim has been deactivated via decrement
+    // should still be accesible via claim id
+    BOOST_CHECK(is_best_claim(name, tx1));
+    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId2);
+
+    fixture.IncrementBlocks(1);
+    // second claim should have been re activated via increment
+    BOOST_CHECK(is_best_claim(name, tx2));
+    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
+    BOOST_CHECK(claimName == name);
+    BOOST_CHECK(claimValue.claimId == claimId2);
+}
+
 /*
     claim expiration for hard fork
         check claims do not expire post ExpirationForkHeight
@@ -896,19 +956,19 @@ BOOST_AUTO_TEST_CASE(hardfork_claim_test)
 
     BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.originalExpiration);
     // First create a claim and make sure it expires pre-fork
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",3);
-    fixture.IncrementBlocks(fixture.originalExpiration+1);
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 3);
+    fixture.IncrementBlocks(fixture.originalExpiration + 1);
+    BOOST_CHECK(!is_best_claim("test", tx1));
     fixture.DecrementBlocks(fixture.originalExpiration);
-    BOOST_CHECK(is_best_claim("test",tx1));
+    BOOST_CHECK(is_best_claim("test", tx1));
     fixture.IncrementBlocks(fixture.originalExpiration);
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    BOOST_CHECK(!is_best_claim("test", tx1));
 
     // Create a claim 1 block before the fork height that will expire after the fork height
-    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height() -2);
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test2","one",3);
+    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height() - 2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test2", "one", 3);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight -1);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight - 1);
 
     // Disable future expirations and fast-forward past the fork height
     fixture.IncrementBlocks(1);
@@ -923,49 +983,49 @@ BOOST_AUTO_TEST_CASE(hardfork_claim_test)
     // make sure that claim created 1 block before the fork expires as expected
     // at the extended expiration times
     BOOST_CHECK(is_best_claim("test2", tx2));
-    fixture.IncrementBlocks(fixture.extendedExpiration-1);
+    fixture.IncrementBlocks(fixture.extendedExpiration - 1);
     BOOST_CHECK(!is_best_claim("test2", tx2));
-    fixture.DecrementBlocks(fixture.extendedExpiration-1);
+    fixture.DecrementBlocks(fixture.extendedExpiration - 1);
 
     // This first claim is still expired since it's pre-fork, even
     // after fork activation
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    BOOST_CHECK(!is_best_claim("test", tx1));
 
     // This new claim created at the fork height cannot expire at original expiration
     BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight);
-    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
+    CMutableTransaction tx3 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
     fixture.IncrementBlocks(1);
     fixture.IncrementBlocks(fixture.originalExpiration);
-    BOOST_CHECK(is_best_claim("test",tx3));
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    BOOST_CHECK(is_best_claim("test", tx3));
+    BOOST_CHECK(!is_best_claim("test", tx1));
     fixture.DecrementBlocks(fixture.originalExpiration);
 
     // but it expires at the extended expiration, and not a single block below
     fixture.IncrementBlocks(fixture.extendedExpiration);
-    BOOST_CHECK(!is_best_claim("test",tx3));
+    BOOST_CHECK(!is_best_claim("test", tx3));
     fixture.DecrementBlocks(fixture.extendedExpiration);
-    fixture.IncrementBlocks(fixture.extendedExpiration-1);
-    BOOST_CHECK(is_best_claim("test",tx3));
-    fixture.DecrementBlocks(fixture.extendedExpiration-1);
+    fixture.IncrementBlocks(fixture.extendedExpiration - 1);
+    BOOST_CHECK(is_best_claim("test", tx3));
+    fixture.DecrementBlocks(fixture.extendedExpiration - 1);
 
 
     // Ensure that we cannot update the original pre-fork expired claim
-    CMutableTransaction u1 = fixture.MakeUpdate(tx1,"test","two",ClaimIdHash(tx1.GetHash(),0), 3);
+    CMutableTransaction u1 = fixture.MakeUpdate(tx1, "test", "two", ClaimIdHash(tx1.GetHash(), 0), 3);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(!is_best_claim("test",u1));
+    BOOST_CHECK(!is_best_claim("test", u1));
 
     // Ensure that supports for the expired claim don't support it
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),u1,"test",10);
-    BOOST_CHECK(!is_best_claim("test",u1));
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), u1, "test", 10);
+    BOOST_CHECK(!is_best_claim("test", u1));
 
     // Ensure that we can update the new post-fork claim
-    CMutableTransaction u2 = fixture.MakeUpdate(tx3,"test","two",ClaimIdHash(tx3.GetHash(),0), 1);
+    CMutableTransaction u2 = fixture.MakeUpdate(tx3, "test", "two", ClaimIdHash(tx3.GetHash(), 0), 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(is_best_claim("test",u2));
+    BOOST_CHECK(is_best_claim("test", u2));
 
     // Ensure that supports for the new post-fork claim
-    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(),u2,"test",3);
-    BOOST_CHECK(is_best_claim("test",u2));
+    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(), u2, "test", 3);
+    BOOST_CHECK(is_best_claim("test", u2));
 }
 
 /*
@@ -976,48 +1036,47 @@ BOOST_AUTO_TEST_CASE(hardfork_support_test)
     ClaimTrieChainFixture fixture;
 
     int blocks_before_fork = 10;
-    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height() - blocks_before_fork-1); 
+    fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height() - blocks_before_fork - 1);
     // Create claim and support it before the fork height
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",2);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 2);
     // this claim will win without the support
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 2);
     fixture.IncrementBlocks(1);
     fixture.IncrementBlocks(blocks_before_fork);
 
     // check that the claim expires as expected at the extended time, as does the support
     fixture.IncrementBlocks(fixture.originalExpiration - blocks_before_fork);
-    BOOST_CHECK(is_best_claim("test",tx1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
+    BOOST_CHECK(is_best_claim("test", tx1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 3));
     fixture.DecrementBlocks(fixture.originalExpiration - blocks_before_fork);
     fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork);
-    BOOST_CHECK(!is_best_claim("test",tx1));
+    BOOST_CHECK(!is_best_claim("test", tx1));
     fixture.DecrementBlocks(fixture.extendedExpiration - blocks_before_fork);
     fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork - 1);
-    BOOST_CHECK(is_best_claim("test",tx1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
+    BOOST_CHECK(is_best_claim("test", tx1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 3));
     fixture.DecrementBlocks(fixture.extendedExpiration - blocks_before_fork - 1);
 
     // update the claims at fork
     fixture.DecrementBlocks(1);
-    CMutableTransaction u1 = fixture.MakeUpdate(tx1,"test","two",ClaimIdHash(tx1.GetHash(),0),1);
-    CMutableTransaction u2 = fixture.MakeUpdate(tx2,"test","two",ClaimIdHash(tx2.GetHash(),0),2);
+    CMutableTransaction u1 = fixture.MakeUpdate(tx1, "test", "two", ClaimIdHash(tx1.GetHash(), 0), 1);
+    CMutableTransaction u2 = fixture.MakeUpdate(tx2, "test", "two", ClaimIdHash(tx2.GetHash(), 0), 2);
     fixture.IncrementBlocks(1);
     BOOST_CHECK_EQUAL(fixture.expirationForkHeight, chainActive.Height());
 
     BOOST_CHECK(is_best_claim("test", u1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
-    BOOST_CHECK(!is_claim_in_queue("test",tx1));
-    BOOST_CHECK(!is_claim_in_queue("test",tx2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 3));
+    BOOST_CHECK(!is_claim_in_queue("test", tx1));
+    BOOST_CHECK(!is_claim_in_queue("test", tx2));
 
     // check that the support expires as expected
     fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork);
     BOOST_CHECK(is_best_claim("test", u2));
     fixture.DecrementBlocks(fixture.extendedExpiration - blocks_before_fork);
     fixture.IncrementBlocks(fixture.extendedExpiration - blocks_before_fork - 1);
-    BOOST_CHECK(is_best_claim("test",u1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",3));
-
+    BOOST_CHECK(is_best_claim("test", u1));
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 3));
 }
 
 /*
@@ -1039,38 +1098,38 @@ BOOST_AUTO_TEST_CASE(hardfork_disk_test)
     // Reset to disk, increment past the fork height and make sure we get
     // proper behavior
     fixture.DecrementBlocks(2);
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(),"test","one",1);
-    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(),tx1,"test",1);
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), "test", "one", 1);
+    CMutableTransaction s1 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, "test", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight -1);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight - 1);
 
     fixture.WriteClearReadClaimTrie();
-    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight-1);
+    BOOST_CHECK_EQUAL(chainActive.Height(), fixture.expirationForkHeight - 1);
     BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.originalExpiration);
     fixture.IncrementBlocks(1);
     BOOST_CHECK_EQUAL(pclaimTrie->nExpirationTime, fixture.extendedExpiration);
     BOOST_CHECK(is_best_claim("test", tx1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
-    fixture.IncrementBlocks(fixture.originalExpiration-1);
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
+    fixture.IncrementBlocks(fixture.originalExpiration - 1);
     BOOST_CHECK(is_best_claim("test", tx1));
-    BOOST_CHECK(best_claim_effective_amount_equals("test",2));
-    fixture.DecrementBlocks(fixture.originalExpiration-1);
-    fixture.IncrementBlocks(fixture.extendedExpiration-1);
+    BOOST_CHECK(best_claim_effective_amount_equals("test", 2));
+    fixture.DecrementBlocks(fixture.originalExpiration - 1);
+    fixture.IncrementBlocks(fixture.extendedExpiration - 1);
     BOOST_CHECK(!is_best_claim("test", tx1));
 
     // Create a claim and support before the fork height, reset to disk, update the claim
     // increment past the fork height and make sure we get proper behavior
-    int  height_of_update_before_expiration = 50;
-    fixture.DecrementBlocks(chainActive.Height() - fixture.expirationForkHeight + height_of_update_before_expiration+2);
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(),"test2","one",1);
-    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(),tx2,"test2",1);
+    int height_of_update_before_expiration = 50;
+    fixture.DecrementBlocks(chainActive.Height() - fixture.expirationForkHeight + height_of_update_before_expiration + 2);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "test2", "one", 1);
+    CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(), tx2, "test2", 1);
     fixture.IncrementBlocks(1);
     fixture.WriteClearReadClaimTrie();
-    CMutableTransaction u2 = fixture.MakeUpdate(tx2,"test2","two",ClaimIdHash(tx2.GetHash(),0),1);
+    CMutableTransaction u2 = fixture.MakeUpdate(tx2, "test2", "two", ClaimIdHash(tx2.GetHash(), 0), 1);
     // increment to fork
     fixture.IncrementBlocks(fixture.expirationForkHeight - chainActive.Height());
     BOOST_CHECK(is_best_claim("test2", u2));
-    BOOST_CHECK(best_claim_effective_amount_equals("test2",2));
+    BOOST_CHECK(best_claim_effective_amount_equals("test2", 2));
     // increment to original expiration, should not be expired
     fixture.IncrementBlocks(fixture.originalExpiration - height_of_update_before_expiration);
     BOOST_CHECK(is_best_claim("test2", u2));
@@ -3043,94 +3102,6 @@ BOOST_AUTO_TEST_CASE(bogus_claimtrie_hash_test)
     BOOST_CHECK(pblockTemp->block.GetHash() != chainActive.Tip()->GetBlockHash());
     BOOST_CHECK_EQUAL(orig_chain_height, chainActive.Height());
     delete pblockTemp;
-}
-
-/*
- * tests for CClaimTrie::getClaimById basic consistency checks
- */
-BOOST_AUTO_TEST_CASE(get_claim_by_id_test_2)
-{
-    ClaimTrieChainFixture fixture;
-    const std::string name = "test";
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 1);
-    uint160 claimId = ClaimIdHash(tx1.GetHash(), 0);
-    CMutableTransaction txx = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 1);
-    uint160 claimIdx = ClaimIdHash(txx.GetHash(), 0);
-
-    fixture.IncrementBlocks(1);
-
-    CClaimValue claimValue;
-    std::string claimName;
-    pclaimTrie->getClaimById(claimId, claimName, claimValue);
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId);
-
-    CMutableTransaction txa = fixture.Spend(tx1);
-    CMutableTransaction txb = fixture.Spend(txx);
-
-    fixture.IncrementBlocks(1);
-    BOOST_CHECK(!pclaimTrie->getClaimById(claimId, claimName, claimValue));
-    BOOST_CHECK(!pclaimTrie->getClaimById(claimIdx, claimName, claimValue));
-
-    fixture.DecrementBlocks(1);
-    pclaimTrie->getClaimById(claimId, claimName, claimValue);
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId);
-
-    // this test fails
-    pclaimTrie->getClaimById(claimIdx, claimName, claimValue);
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimIdx);
-}
-
-BOOST_AUTO_TEST_CASE(get_claim_by_id_test_3)
-{
-    ClaimTrieChainFixture fixture;
-    pclaimTrie->setExpirationTime(5);
-    const std::string name = "test";
-    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 1);
-    uint160 claimId = ClaimIdHash(tx1.GetHash(), 0);
-
-    fixture.IncrementBlocks(1);
-
-    CClaimValue claimValue;
-    std::string claimName;
-    pclaimTrie->getClaimById(claimId, claimName, claimValue);
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId);
-    // make second claim with activation delay 1
-    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 2);
-    uint160 claimId2 = ClaimIdHash(tx2.GetHash(), 0);
-
-    fixture.IncrementBlocks(1);
-    // second claim is not activated yet, but can still access by claim id
-    BOOST_CHECK(is_best_claim(name, tx1));
-    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId2);
-
-    fixture.IncrementBlocks(1);
-    // second claim has activated
-    BOOST_CHECK(is_best_claim(name, tx2));
-    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId2);
-
-
-    fixture.DecrementBlocks(1);
-    // second claim has been deactivated via decrement
-    // should still be accesible via claim id
-    BOOST_CHECK(is_best_claim(name, tx1));
-    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId2);
-
-    fixture.IncrementBlocks(1);
-    // second claim should have been re activated via increment
-    BOOST_CHECK(is_best_claim(name, tx2));
-    BOOST_CHECK(pclaimTrie->getClaimById(claimId2, claimName, claimValue));
-    BOOST_CHECK(claimName == name);
-    BOOST_CHECK(claimValue.claimId == claimId2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/claimtriecache_tests.cpp
+++ b/src/test/claimtriecache_tests.cpp
@@ -18,7 +18,7 @@ public:
         return CClaimTrieCache::recursiveComputeMerkleHash(tnCurrent, sPos);
     }
 
-    bool recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, std::string sName, bool* pfNullified) const
+    bool recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, std::string sName, bool* pfNullified)
     {
         return CClaimTrieCache::recursivePruneName(tnCurrent,nPos,sName, pfNullified);
     }

--- a/src/test/claimtriedb_tests.cpp
+++ b/src/test/claimtriedb_tests.cpp
@@ -1,0 +1,91 @@
+#include "claimtrie.h"
+#include "main.h"
+#include "uint256.h"
+
+#include "test/test_bitcoin.h"
+#include <boost/test/unit_test.hpp>
+using namespace std;
+
+BOOST_FIXTURE_TEST_SUITE(claimtriedb_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(compatibility_test)
+{
+    const int value = 20;
+    const std::string test("test");
+
+    CClaimTrieNode base_node;
+    const CClaimValue test_claim(COutPoint(), uint160(), CAmount(value), 0, 0);
+    const CClaimIndexElement test_element = {test, test_claim};
+    const CSupportValue test_support(COutPoint(), uint160(), CAmount(value), 0, 0);
+
+    base_node.claims.push_back(test_claim);
+    const supportMapEntryType supportMap(1, test_support);
+    const queueNameRowType nameRows(1, outPointHeightType(COutPoint(), value));
+    const claimQueueRowType claimRows(1, claimQueueEntryType(test, test_claim));
+    const supportQueueRowType supportRows(1, supportQueueEntryType(test, test_support));
+    const expirationQueueRowType expirationRows(1, nameOutPointType(test, COutPoint()));
+    const supportQueueNameRowType supportNameRows(1, outPointHeightType(COutPoint(), value));
+    const supportExpirationQueueRowType supportExpirationRows(1, nameOutPointType(test, COutPoint()));
+
+    CClaimTrieDb db(true, false);
+
+    /// fill out char keys
+    db.Write(std::make_pair('n', test), base_node);
+    db.Write(std::make_pair('i', uint160()), test_element);
+    db.Write(std::make_pair('r', value), claimRows);
+    db.Write(std::make_pair('m', test), nameRows);
+    db.Write(std::make_pair('e', value), expirationRows);
+    db.Write(std::make_pair('s', test), supportMap);
+    db.Write(std::make_pair('u', value), supportRows);
+    db.Write(std::make_pair('p', test), supportNameRows);
+    db.Write(std::make_pair('x', value), supportExpirationRows);
+    db.Sync();
+
+    /// it should read same by types
+    CClaimTrieNode node;
+    db.getQueueRow(test, node);
+    BOOST_CHECK(node == base_node);
+
+    CClaimIndexElement element;
+    db.getQueueRow(uint160(), element);
+    BOOST_CHECK(element.name == test_element.name);
+    BOOST_CHECK(element.claim == test_element.claim);
+
+    claimQueueRowType claims;
+    db.getQueueRow(value, claims);
+    BOOST_CHECK(claims.size() == 1);
+    BOOST_CHECK(claims[0].first == claimRows[0].first);
+    BOOST_CHECK(claims[0].second == claimRows[0].second);
+
+    queueNameRowType names;
+    db.getQueueRow(test, names);
+    BOOST_CHECK(names.size() == 1);
+    BOOST_CHECK(names[0].nHeight == nameRows[0].nHeight);
+
+    expirationQueueRowType exps;
+    db.getQueueRow(value, exps);
+    BOOST_CHECK(exps.size() == 1);
+    BOOST_CHECK(exps[0].name == expirationRows[0].name);
+
+    supportMapEntryType sups;
+    db.getQueueRow(test, sups);
+    BOOST_CHECK(sups.size() == 1);
+    BOOST_CHECK(sups[0] == supportMap[0]);
+
+    supportQueueRowType supRows;
+    db.getQueueRow(value, supRows);
+    BOOST_CHECK(supRows.size() == 1);
+    BOOST_CHECK(supRows[0] == supportRows[0]);
+
+    supportQueueNameRowType supNames;
+    db.getQueueRow(test, supNames);
+    BOOST_CHECK(supNames.size() == 1);
+    BOOST_CHECK(supNames[0].nHeight == supportNameRows[0].nHeight);
+
+    supportExpirationQueueRowType supExps;
+    db.getQueueRow(value, supExps);
+    BOOST_CHECK(supExps.size() == 1);
+    BOOST_CHECK(supExps[0].name == supportExpirationRows[0].name);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a rebased and squashed version of @bvbfan 's CClaimTrieDb commits which separates disk related function from the claimtrie into its own class (from https://github.com/lbryio/lbrycrd/pull/160)

I removed here commits which renamed CClaimTrieCache and nCurrentHeight, as well as the new management of CClaimTrieNode, they will be put into seperate PR's. 

This PR is not downgrade compatible (once you upgrade to this commit, you will not be able to downgrade to previous versions without wiping your claim database) and should be accompanied by a version bump.