### PR TITLE
added minconf to claimtrie RPC methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ share/BitcoindComparisonTool.jar
 /doc/doxygen/
 
 libbitcoinconsensus.pc
+
+cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.7)
+project(lbrycrd_clion) # not expecting a full compile -- just something that allows clion syntax checking
+
+set (CMAKE_CXX_STANDARD 98) # 03 is not supported by cmake, but this will soon be 11 (after upstream bitcoin merge)
+# I thought that setting the standard would disable the clang-tidy c++11 tips; nope.
+
+set(BOOST_ROOT "build/boost" CACHE PATH "Boost library path")
+set(Boost_NO_SYSTEM_PATHS on CACHE BOOL "Do not search system for Boost")
+find_package(Boost REQUIRED COMPONENTS filesystem program_options thread chrono) # locale coming shortly
+
+file(GLOB sources
+        src/*.h src/*.cpp
+        src/wallet/*.h src/wallet/*.cpp
+        src/support/*.h src/support/*.cpp src/support/allocators/*.h
+        src/script/*.h src/script/*.cpp
+        src/rpc/*.h src/rpc/*.cpp
+        src/primitives/*.h src/primitives/*.cpp
+        src/policy/*.h src/policy/*.cpp
+        src/crypto/*.h src/crypto/*.cpp
+        src/consensus/*.h src/consensus/*.cpp
+        src/compat/*.h src/compat/*.cpp
+    )
+list(FILTER sources EXCLUDE REGEX "src/bitcoin*.cpp$")
+
+include_directories(${Boost_INCLUDE_DIRS}
+        build/bdb/include
+        build/libevent/include
+        build/openssl/include
+        src/support/allocators
+        src/support
+        src/rpc
+        src/policy
+        src/wallet src/script
+        src/leveldb/helpers/memenv
+        src/leveldb/include
+        src/config
+        src/crypto
+        src/compat
+        src/obj
+        src/univalue/include
+        src/secp256k1/include
+        src/
+    )
+
+add_compile_definitions(HAVE_CONFIG_H)
+
+add_executable(lbrycrd-cli src/bitcoin-cli.cpp ${sources})
+add_executable(lbrycrd-tx src/bitcoin-tx.cpp ${sources})
+add_executable(lbrycrdd src/bitcoind.cpp ${sources})
+
+file(GLOB tests src/test/*.cpp)
+foreach(test ${tests})
+    get_filename_component(filename ${test} NAME_WE)
+    add_executable(${filename} ${test} ${sources})
+    target_include_directories(${filename} PRIVATE src/test)
+endforeach(test)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Run `./lbrycrd-cli help` to get a list of all commands that you can run. To get 
 Lbrycrdd will use the below default data directories
 
 Windows < Vista: C:\Documents and Settings\Username\Application Data\lbrycrd
+
 Windows >= Vista: C:\Users\Username\AppData\Roaming\lbrycrd
+
 Mac: ~/Library/Application Support/lbrycrd
+
 Unix: ~/.lbrycrd
 
 The data directory contains various things such as your default wallet (wallet.dat), debug logs (debug.log), and blockchain data. You can optionally

--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -90,16 +90,23 @@ bool CClaimTrieNode::removeClaim(const COutPoint& outPoint, CClaimValue& claim)
     return true;
 }
 
-bool CClaimTrieNode::getBestClaim(CClaimValue& claim) const
+bool CClaimTrieNode::getBestClaim(CClaimValue& claim, int maxHeight) const
 {
     if (claims.empty())
     {
         return false;
-    }
-    else
-    {
+    } else if (maxHeight < 0) {
         claim = claims.front();
         return true;
+    } else {
+        // we are already sorted (with reorder getting called on insert/remove)
+        for (std::vector<CClaimValue>::const_iterator itclaim = claims.begin(); itclaim != claims.end(); ++itclaim) {
+            if (itclaim->nHeight <= maxHeight) {
+                claim = *itclaim;
+                return true;
+            }
+        }
+        return false;
     }
 }
 
@@ -133,8 +140,8 @@ void CClaimTrieNode::reorderClaims(supportMapEntryType& supports)
             }
         }
     }
-    
-    std::make_heap(claims.begin(), claims.end());
+
+    std::sort(claims.rbegin(), claims.rend()); // max of effectiveAmount should be first
 }
 
 uint256 CClaimTrie::getMerkleHash()
@@ -438,12 +445,12 @@ const CClaimTrieNode* CClaimTrie::getNodeForName(const std::string& name) const
     return current;
 }
 
-bool CClaimTrie::getInfoForName(const std::string& name, CClaimValue& claim) const
+bool CClaimTrie::getInfoForName(const std::string& name, CClaimValue& claim, int maxHeight) const
 {
     const CClaimTrieNode* current = getNodeForName(name);
     if (current)
     {
-        return current->getBestClaim(claim);
+        return current->getBestClaim(claim, maxHeight);
     }
     return false;
 }

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -146,7 +146,7 @@ public:
 
     bool insertClaim(CClaimValue claim);
     bool removeClaim(const COutPoint& outPoint, CClaimValue& claim);
-    bool getBestClaim(CClaimValue& claim) const;
+    bool getBestClaim(CClaimValue& claim, int maxHeight = -1) const;
     bool empty() const {return children.empty() && claims.empty();}
     bool haveClaim(const COutPoint& outPoint) const;
     void reorderClaims(supportMapEntryType& supports);
@@ -316,7 +316,7 @@ public:
     bool ReadFromDisk(bool check = false);
 
     std::vector<namedNodeType> flattenTrie() const;
-    bool getInfoForName(const std::string& name, CClaimValue& claim) const;
+    bool getInfoForName(const std::string& name, CClaimValue& claim, int maxHeight = -1) const;
     bool getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const;
 
     claimsForNameType getClaimsForName(const std::string& name) const;

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -1064,4 +1064,25 @@ BOOST_AUTO_TEST_CASE(claimtriebranching_hardfork_disktest)
     BOOST_CHECK(best_claim_effective_amount_equals("test2",1)); // the support expires one block before
 }
 
+BOOST_AUTO_TEST_CASE(claimtriebranching_getBest_supports_confirmations)
+{
+    ClaimTrieChainFixture fixture;
+    int height = chainActive.Tip()->nHeight;
+
+    std::string name("test");
+    CMutableTransaction tx1 = fixture.MakeClaim(fixture.GetCoinbase(), name, "one", 42);
+    CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), name, "two", 43);
+    fixture.IncrementBlocks(1);
+    CClaimValue claim;
+    BOOST_CHECK(pclaimTrie->getInfoForName(name, claim));
+    BOOST_CHECK(claim.nAmount == 43);
+
+    BOOST_CHECK(pclaimTrie->getInfoForName(name, claim, height + 1));
+    BOOST_CHECK(!pclaimTrie->getInfoForName(name, claim, height));
+    fixture.IncrementBlocks(4);
+    BOOST_CHECK_EQUAL(height + 5, chainActive.Tip()->nHeight);
+    BOOST_CHECK(pclaimTrie->getInfoForName(name, claim, height + 2));
+    BOOST_CHECK(!pclaimTrie->getInfoForName(name, claim, height));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
for #44 . I was unsure who should handle the current height; right now the RPC commands themselves query that. (Some of them did that before.)

I also have no way to tell if the sort call negatively affects performance (vs make_heap). My guess is that we don't have enough claim competition yet to tell a difference in even our largest dataset.