### PR TITLE
Updates to allow successful build on OpenSSL 1.1+

### DIFF
--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -22,7 +22,7 @@
 class SSLVerifyError : public std::runtime_error
 {
 public:
-    SSLVerifyError(std::string err) : std::runtime_error(err) { }
+    SSLVerifyError(std::string err) : std::runtime_error(err) {}
 };
 
 bool PaymentRequestPlus::parse(const QByteArray& data)
@@ -38,8 +38,7 @@ bool PaymentRequestPlus::parse(const QByteArray& data)
     }
 
     parseOK = details.ParseFromString(paymentRequest.serialized_payment_details());
-    if (!parseOK)
-    {
+    if (!parseOK) {
         qWarning() << "PaymentRequestPlus::parse: Error parsing payment details";
         paymentRequest.Clear();
         return false;
@@ -69,15 +68,12 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
     const EVP_MD* digestAlgorithm = NULL;
     if (paymentRequest.pki_type() == "x509+sha256") {
         digestAlgorithm = EVP_sha256();
-    }
-    else if (paymentRequest.pki_type() == "x509+sha1") {
+    } else if (paymentRequest.pki_type() == "x509+sha1") {
         digestAlgorithm = EVP_sha1();
-    }
-    else if (paymentRequest.pki_type() == "none") {
+    } else if (paymentRequest.pki_type() == "none") {
         qWarning() << "PaymentRequestPlus::getMerchant: Payment request: pki_type == none";
         return false;
-    }
-    else {
+    } else {
         qWarning() << "PaymentRequestPlus::getMerchant: Payment request: unknown pki_type " << QString::fromStdString(paymentRequest.pki_type());
         return false;
     }
@@ -103,8 +99,8 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
             return false;
         }
 #endif
-        const unsigned char *data = (const unsigned char *)certChain.certificate(i).data();
-        X509 *cert = d2i_X509(NULL, &data, certChain.certificate(i).size());
+        const unsigned char* data = (const unsigned char*)certChain.certificate(i).data();
+        X509* cert = d2i_X509(NULL, &data, certChain.certificate(i).size());
         if (cert)
             certs.push_back(cert);
     }
@@ -115,26 +111,24 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
 
     // The first cert is the signing cert, the rest are untrusted certs that chain
     // to a valid root authority. OpenSSL needs them separately.
-    STACK_OF(X509) *chain = sk_X509_new_null();
+    STACK_OF(X509)* chain = sk_X509_new_null();
     for (int i = certs.size() - 1; i > 0; i--) {
         sk_X509_push(chain, certs[i]);
     }
-    X509 *signing_cert = certs[0];
+    X509* signing_cert = certs[0];
 
     // Now create a "store context", which is a single use object for checking,
     // load the signing cert into it and verify.
-    X509_STORE_CTX *store_ctx = X509_STORE_CTX_new();
+    X509_STORE_CTX* store_ctx = X509_STORE_CTX_new();
     if (!store_ctx) {
         qWarning() << "PaymentRequestPlus::getMerchant: Payment request: error creating X509_STORE_CTX";
         return false;
     }
 
-    char *website = NULL;
+    char* website = NULL;
     bool fResult = true;
-    try
-    {
-        if (!X509_STORE_CTX_init(store_ctx, certStore, signing_cert, chain))
-        {
+    try {
+        if (!X509_STORE_CTX_init(store_ctx, certStore, signing_cert, chain)) {
             int error = X509_STORE_CTX_get_error(store_ctx);
             throw SSLVerifyError(X509_verify_cert_error_string(error));
         }
@@ -148,38 +142,49 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
             if (!(error == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT && GetBoolArg("-allowselfsignedrootcertificates", DEFAULT_SELFSIGNED_ROOTCERTS))) {
                 throw SSLVerifyError(X509_verify_cert_error_string(error));
             } else {
-               qDebug() << "PaymentRequestPlus::getMerchant: Allowing self signed root certificate, because -allowselfsignedrootcertificates is true.";
+                qDebug() << "PaymentRequestPlus::getMerchant: Allowing self signed root certificate, because -allowselfsignedrootcertificates is true.";
             }
         }
-        X509_NAME *certname = X509_get_subject_name(signing_cert);
+        X509_NAME* certname = X509_get_subject_name(signing_cert);
 
         // Valid cert; check signature:
         payments::PaymentRequest rcopy(paymentRequest); // Copy
         rcopy.set_signature(std::string(""));
-        std::string data_to_verify;                     // Everything but the signature
+        std::string data_to_verify; // Everything but the signature
         rcopy.SerializeToString(&data_to_verify);
 
-        EVP_MD_CTX ctx;
-        EVP_PKEY *pubkey = X509_get_pubkey(signing_cert);
-        EVP_MD_CTX_init(&ctx);
-        if (!EVP_VerifyInit_ex(&ctx, digestAlgorithm, NULL) ||
-            !EVP_VerifyUpdate(&ctx, data_to_verify.data(), data_to_verify.size()) ||
-            !EVP_VerifyFinal(&ctx, (const unsigned char*)paymentRequest.signature().data(), (unsigned int)paymentRequest.signature().size(), pubkey)) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+        if (!ctx) throw SSLVerifyError("Error allocating OpenSSL context.");
+#else
+        EVP_MD_CTX _ctx;
+        EVP_MD_CTX* ctx;
+        ctx = &_ctx;
+#endif
+
+        EVP_PKEY* pubkey = X509_get_pubkey(signing_cert);
+
+        EVP_MD_CTX_init(ctx);
+        if (!EVP_VerifyInit_ex(ctx, digestAlgorithm, NULL) ||
+            !EVP_VerifyUpdate(ctx, data_to_verify.data(), data_to_verify.size()) ||
+            !EVP_VerifyFinal(ctx, (const unsigned char*)paymentRequest.signature().data(), (unsigned int)paymentRequest.signature().size(), pubkey)) {
             throw SSLVerifyError("Bad signature, invalid payment request.");
         }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        EVP_MD_CTX_free(ctx);
+#endif
 
         // OpenSSL API for getting human printable strings from certs is baroque.
         int textlen = X509_NAME_get_text_by_NID(certname, NID_commonName, NULL, 0);
         website = new char[textlen + 1];
         if (X509_NAME_get_text_by_NID(certname, NID_commonName, website, textlen + 1) == textlen && textlen > 0) {
             merchant = website;
-        }
-        else {
+        } else {
             throw SSLVerifyError("Bad certificate, missing common name.");
         }
         // TODO: detect EV certificates and set merchant = business name instead of unfriendly NID_commonName ?
-    }
-    catch (const SSLVerifyError& err) {
+    } catch (const SSLVerifyError& err) {
         fResult = false;
         qWarning() << "PaymentRequestPlus::getMerchant: SSL error: " << err.what();
     }
@@ -193,13 +198,12 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
     return fResult;
 }
 
-QList<std::pair<CScript,CAmount> > PaymentRequestPlus::getPayTo() const
+QList<std::pair<CScript, CAmount> > PaymentRequestPlus::getPayTo() const
 {
-    QList<std::pair<CScript,CAmount> > result;
-    for (int i = 0; i < details.outputs_size(); i++)
-    {
+    QList<std::pair<CScript, CAmount> > result;
+    for (int i = 0; i < details.outputs_size(); i++) {
         const unsigned char* scriptStr = (const unsigned char*)details.outputs(i).script().data();
-        CScript s(scriptStr, scriptStr+details.outputs(i).script().size());
+        CScript s(scriptStr, scriptStr + details.outputs(i).script().size());
 
         result.append(std::make_pair(s, details.outputs(i).amount()));
     }


### PR DESCRIPTION
Updating;

-- paymentrequestplus.cpp
-- crypter.cpp

To allow successful build on new releases of Debian (stretch), Ubuntu (18+), Fedora wherein OpenSSL is version 1.1

Following the update lbrycrdd builds successfully.