### PR TITLE
implemented hard fork to include nonwinning claims in hash

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -131,6 +131,7 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 150; //retarget every block
         consensus.nPowTargetSpacing = 150;
+        consensus.nAllClaimsInMerkleForkHeight = 1000000; // TODO: pick me
         consensus.nOriginalClaimExpirationTime = 262974;
         consensus.nExtendedClaimExpirationTime = 2102400;
         consensus.nExtendedClaimExpirationForkHeight = 400155;
@@ -218,6 +219,7 @@ public:
         consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 150;
         consensus.nPowTargetSpacing = 150;
+        consensus.nAllClaimsInMerkleForkHeight = 1000000; // TODO: pick me
         consensus.nOriginalClaimExpirationTime = 262974;
         consensus.nExtendedClaimExpirationTime = 2102400;
         consensus.nExtendedClaimExpirationForkHeight = 278160;
@@ -298,6 +300,7 @@ public:
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 1;//14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 1;
+        consensus.nAllClaimsInMerkleForkHeight = 2500; // TODO: pick me
         consensus.nOriginalClaimExpirationTime = 500;
         consensus.nExtendedClaimExpirationTime = 600;
         consensus.nExtendedClaimExpirationForkHeight = 800;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -58,6 +58,8 @@ struct Params {
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
+    /** blocks before the hard fork that adds non-winning claims into the merkle hash */
+    int64_t nAllClaimsInMerkleForkHeight;
     /** how long it took claims to expire before the hard fork */
     int64_t nOriginalClaimExpirationTime;
     /** how long it takes claims to expire after the hard fork */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4267,7 +4267,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     return true;
 }
 
-bool GetProofForName(const CBlockIndex* pindexProof, const std::string& name, CClaimTrieProof& proof)
+bool GetProofForName(const CBlockIndex* pindexProof, const std::string& name, CClaimTrieProof& proof, const uint160& claimId)
 {
     AssertLockHeld(cs_main);
     if (!chainActive.Contains(pindexProof))
@@ -4299,7 +4299,11 @@ bool GetProofForName(const CBlockIndex* pindexProof, const std::string& name, CC
             return false;
     }
     assert(pindexState == pindexProof);
-    proof = trieCache.getProofForName(name);
+
+    if (pindexProof->nHeight >= Params().GetConsensus().nAllClaimsInMerkleForkHeight)
+        proof = trieCache.getProofForNameBinaryTree(name, claimId);
+    else
+        proof = trieCache.getProofForName(name);
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -226,7 +226,7 @@ FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
 boost::filesystem::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
 /** Get a cryptographic proof that a name maps to a value **/
-bool GetProofForName(const CBlockIndex* pindexProof, const std::string& name, CClaimTrieProof& proof);
+bool GetProofForName(const CBlockIndex* pindexProof, const std::string& name, CClaimTrieProof& proof, const uint160& claimId);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp = NULL);
 /** Initialize a new block tree database + block data on disk */

--- a/src/test/claimtriecache_tests.cpp
+++ b/src/test/claimtriecache_tests.cpp
@@ -15,7 +15,7 @@ public:
     bool recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent,
                                     std::string sPos) const
     {
-        return CClaimTrieCache::recursiveComputeMerkleHash(tnCurrent, sPos);
+        return CClaimTrieCache::recursiveComputeMerkleHash(tnCurrent, sPos, false);
     }
 
     bool recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, std::string sName, bool* pfNullified) const

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -404,7 +404,7 @@ void CreateClaim(CScript& claimScript, CAmount nAmount, CWalletTx& wtxNew)
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
     if (!pwalletMain->CommitTransaction(wtxNew, reservekey))
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error: The transaction was rejected! This might hapen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
 }
 
 UniValue claimname(const UniValue& params, bool fHelp)


### PR DESCRIPTION
It also uses Merkle trees for hashing children and claims post-fork. This significantly reduces the output for `getnameproof`.

Notable things to look at:
1. The way the tree is verified after it is loaded form disk (now using the Cache).
2. The place in the Cache's (Dis)ConnectBlock methods where we rehash the whole tree.
3. The use of the already-included MerkleHash and MerkleBranch methods.
4. The names in the getnameproof data and the Proof structs.