### PR TITLE
Remove unused Python modules in linearize-data.py

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -8,13 +8,10 @@
 #
 
 from __future__ import print_function, division
-import json
 import struct
 import re
 import os
 import os.path
-import base64
-import httplib
 import sys
 import hashlib
 import datetime


### PR DESCRIPTION
Hello,

In my opinion, No json, base64, httplib Python module are required.

Because it is not used.

What do you think of it?

Thanks.