### PR TITLE
CClaimTrieCache::removeClaim does not need the height parameter

### DIFF
--- a/src/claimtrie.cpp
+++ b/src/claimtrie.cpp
@@ -1678,20 +1678,20 @@ bool CClaimTrieCache::removeClaimFromQueue(const std::string& name, const COutPo
     return false;
 }
 
-bool CClaimTrieCache::undoAddClaim(const std::string& name, const COutPoint& outPoint, int nHeight) const
+bool CClaimTrieCache::undoAddClaim(const std::string& name, const COutPoint& outPoint) const
 {
     int throwaway;
-    return removeClaim(name, outPoint, nHeight, throwaway, false);
+    return removeClaim(name, outPoint, throwaway, false);
 }
 
-bool CClaimTrieCache::spendClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight) const
+bool CClaimTrieCache::spendClaim(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight) const
 {
-    return removeClaim(name, outPoint, nHeight, nValidAtHeight, true);
+    return removeClaim(name, outPoint, nValidAtHeight, true);
 }
 
-bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover) const
+bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight, bool fCheckTakeover) const
 {
-    LogPrintf("%s: name: %s, txhash: %s, nOut: %s, nHeight: %s, nCurrentHeight: %s\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nHeight, nCurrentHeight);
+    LogPrintf("%s: name: %s, txhash: %s, nOut: %s, nCurrentHeight: %s\n", __func__, name, outPoint.hash.GetHex(), outPoint.n, nCurrentHeight);
     bool removed = false;
     CClaimValue claim;
     if (removeClaimFromQueue(name, outPoint, claim))
@@ -1705,7 +1705,7 @@ bool CClaimTrieCache::removeClaim(const std::string& name, const COutPoint& outP
     if (removed == true)
     {
         nValidAtHeight = claim.nValidAtHeight;
-        int expirationHeight = nHeight + base->nExpirationTime;
+        int expirationHeight = base->nExpirationTime;
         removeFromExpirationQueue(name, outPoint, expirationHeight);
         claimsToDelete.insert(claim);
     }

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -479,10 +479,9 @@ public:
 
     bool addClaim(const std::string& name, const COutPoint& outPoint,
                   uint160 claimId, CAmount nAmount, int nHeight) const;
-    bool undoAddClaim(const std::string& name, const COutPoint& outPoint,
-                      int nHeight) const;
+    bool undoAddClaim(const std::string& name, const COutPoint& outPoint) const;
     bool spendClaim(const std::string& name, const COutPoint& outPoint,
-                    int nHeight, int& nValidAtHeight) const;
+                    int& nValidAtHeight) const;
     bool undoSpendClaim(const std::string& name, const COutPoint& outPoint,
                         uint160 claimId, CAmount nAmount, int nHeight,
                         int nValidAtHeight) const;
@@ -566,7 +565,7 @@ protected:
     bool clear() const;
 
     bool removeClaim(const std::string& name, const COutPoint& outPoint,
-                     int nHeight, int& nValidAtHeight, bool fCheckTakeover) const;
+                     int& nValidAtHeight, bool fCheckTakeover) const;
 
     bool addClaimToQueues(const std::string& name, CClaimValue& claim) const;
     bool removeClaimFromQueue(const std::string& name, const COutPoint& outPoint,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2194,7 +2194,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                     }
                     std::string name(vvchParams[0].begin(), vvchParams[0].end());
                     LogPrintf("%s: (txid: %s, nOut: %d) Trying to remove %s from the claim trie due to its block being disconnected\n", __func__, hash.ToString(), i, name.c_str());
-                    if (!trieCache.undoAddClaim(name, COutPoint(hash, i), pindex->nHeight))
+                    if (!trieCache.undoAddClaim(name, COutPoint(hash, i)))
                     {
                         LogPrintf("%s: Could not find the claim in the trie or the cache\n", __func__);
                     }
@@ -2625,7 +2625,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         std::string name(vvchParams[0].begin(), vvchParams[0].end());
                         int nValidAtHeight;
                         LogPrintf("%s: Removing %s from the claim trie. Tx: %s, nOut: %d\n", __func__, name, txin.prevout.hash.GetHex(), txin.prevout.n);
-                        if (trieCache.spendClaim(name, COutPoint(txin.prevout.hash, txin.prevout.n), coins->nHeight, nValidAtHeight))
+                        if (trieCache.spendClaim(name, COutPoint(txin.prevout.hash, txin.prevout.n), nValidAtHeight))
                         {
                             mClaimUndoHeights[i] = nValidAtHeight;
                             std::pair<std::string, uint160> entry(name, claimId);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -294,7 +294,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
                         }
                         std::string name(vvchParams[0].begin(), vvchParams[0].end());
                         int throwaway;
-                        if (trieCache.spendClaim(name, COutPoint(txin.prevout.hash, txin.prevout.n), nTxinHeight, throwaway))
+                        if (trieCache.spendClaim(name, COutPoint(txin.prevout.hash, txin.prevout.n), throwaway))
                         {
                             std::pair<std::string, uint160> entry(name, claimId);
                             spentClaims.push_back(entry);


### PR DESCRIPTION
Removed the height parameter from the removeClaim function.

Closes https://github.com/lbryio/lbrycrd/issues/226