### PR TITLE
fixed blocks coming in too fast on testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -135,6 +135,7 @@ public:
         consensus.nExtendedClaimExpirationTime = 2102400;
         consensus.nExtendedClaimExpirationForkHeight = 400155;
         consensus.fPowAllowMinDifficultyBlocks = false;
+        consensus.nAllowMinDiffMinHeight = consensus.nAllowMinDiffMaxHeight = -1;
         consensus.fPowNoRetargeting = false;
         consensus.nNormalizedNameForkHeight = 539940; // targeting 21 March 2019
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
@@ -223,6 +224,8 @@ public:
         consensus.nExtendedClaimExpirationTime = 2102400;
         consensus.nExtendedClaimExpirationForkHeight = 278160;
         consensus.fPowAllowMinDifficultyBlocks = true;
+        consensus.nAllowMinDiffMinHeight = 277299;
+        consensus.nAllowMinDiffMaxHeight = 1100000;
         consensus.fPowNoRetargeting = false;
         consensus.nNormalizedNameForkHeight = 993380;   // targeting, 21 Feb 2019
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
@@ -304,6 +307,7 @@ public:
         consensus.nExtendedClaimExpirationTime = 600;
         consensus.nExtendedClaimExpirationForkHeight = 800;
         consensus.fPowAllowMinDifficultyBlocks = false;
+        consensus.nAllowMinDiffMinHeight = consensus.nAllowMinDiffMaxHeight = -1;
         consensus.fPowNoRetargeting = false;
         consensus.nNormalizedNameForkHeight = 250; // SDK depends upon this number
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -55,6 +55,8 @@ struct Params {
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
+    int nAllowMinDiffMinHeight;
+    int nAllowMinDiffMaxHeight;
     bool fPowNoRetargeting;
     int nNormalizedNameForkHeight;
     int64_t nPowTargetSpacing;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -18,7 +18,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
 
-    if (params.fPowAllowMinDifficultyBlocks && pindexLast->nHeight >= 277299)
+    if (params.fPowAllowMinDifficultyBlocks && pindexLast->nHeight >= 277299 && pindexLast->nHeight < 1100000)
     {
         // Special difficulty rule for testnet:
         // If the new block's timestamp is twice the target block time
@@ -29,12 +29,15 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2){
             return nProofOfWorkLimit;
         }
+        // Well, actually, it wasn't ever implemented properly in LBRYcrd.
+        // It doesn't work without the missing "else" statement found in upstream bitcoin.
+        // And that statement doesn't work correctly with our DifficultyAdjustmentInterval == 1.
+        // Hence, we are killing it at block 1100000.
     }
 
     // Go back the full period unless it's the first retarget after genesis.
-    int blockstogoback = params.DifficultyAdjustmentInterval()-1;
-    if ((pindexLast->nHeight+1) != params.DifficultyAdjustmentInterval())
-        blockstogoback = params.DifficultyAdjustmentInterval();
+    int blockstogoback = params.DifficultyAdjustmentInterval();
+    blockstogoback = std::min(blockstogoback, pindexLast->nHeight);
 
     int nHeightFirst = pindexLast->nHeight - blockstogoback;
     assert(nHeightFirst >= 0);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -18,7 +18,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
 
-    if (params.fPowAllowMinDifficultyBlocks && pindexLast->nHeight >= 277299 && pindexLast->nHeight < 1100000)
+    if (params.fPowAllowMinDifficultyBlocks && pindexLast->nHeight >= params.nAllowMinDiffMinHeight
+                                            && pindexLast->nHeight < params.nAllowMinDiffMaxHeight)
     {
         // Special difficulty rule for testnet:
         // If the new block's timestamp is twice the target block time


### PR DESCRIPTION
When we get a delayed block, we thereafter knock the difficulty so low that it takes multiple (up to a 100) blocks to get back up to sufficient difficulty. It doesn't make sense for us to do this as we already adjust difficulty every block.