### PR TITLE
Memory improvements, claimtrie revamp

### DIFF
--- a/contrib/devtools/generate_json_api_v1.py
+++ b/contrib/devtools/generate_json_api_v1.py
@@ -13,17 +13,22 @@ def get_type(arg_type, full_line):
     if arg_type is None:
         return 'string'
 
-    arg_type = arg_type.lower()
+    arg_type = arg_type.lower().split(',')[0].strip()
     if 'numeric' in arg_type:
         return 'number'
     if 'bool' in arg_type:
         return 'boolean'
-    if 'string' in arg_type:
-        return 'string'
+    if 'array' in arg_type:
+        return 'array'
     if 'object' in arg_type:
         return 'object'
 
-    raise Exception('Not implemented: ' + arg_type)
+    supported_types = ['number', 'string', 'object', 'array', 'optional']
+    if arg_type in supported_types:
+        return arg_type
+
+    print("get_type: WARNING", arg_type, "is not supported type", file=sys.stderr)
+    return arg_type
 
 
 def parse_params(args):
@@ -34,7 +39,7 @@ def parse_params(args):
                 continue
             arg_parsed = re_argline.fullmatch(line)
             if arg_parsed is None:
-                raise Exception("Unparsable argument: " + line)
+                continue
             arg_name, arg_type, arg_desc = arg_parsed.group('name', 'type', 'desc')
             if not arg_type:
                 raise Exception('Not implemented: ' + arg_type)

--- a/contrib/devtools/generated/api_jrgen.json
+++ b/contrib/devtools/generated/api_jrgen.json
@@ -4,7 +4,7 @@
     "jsonrpc": "1.0",
     "info": {
         "title": "lbrycrd RPC API",
-        "version": "LBRYcrd Core RPC client version v0.12.2.0-6fa9ee58-dirty",
+        "version": "LBRYcrd Core RPC client version v0.17.1.0-ab5c074ba-dirty",
         "description": []
     },
     "definitions": {},
@@ -22,19 +22,14 @@
                         "type": "string",
                         "description": "The transaction containing the unspent txout which should be spent."
                     },
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
                         "description": "The lbrycrd address to send to."
-                    },
-                    "amount": {
-                        "type": "number",
-                        "description": "The amount to send to the lbrycrd address. eg 0.1"
                     }
                 },
                 "required": [
                     "txid",
-                    "lbrycrdaddress",
-                    "amount"
+                    "address"
                 ]
             },
             "result": {
@@ -55,24 +50,42 @@
                         "type": "string",
                         "description": "The transaction containing the unspent txout which should be spent."
                     },
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
                         "description": "The lbrycrd address to send to."
-                    },
-                    "amount": {
-                        "type": "number",
-                        "description": "The amount to send to the lbrycrd address. eg 0.1"
                     }
                 },
                 "required": [
                     "txid",
-                    "lbrycrdaddress",
-                    "amount"
+                    "address"
                 ]
             },
             "result": {
                 "type": "string",
                 "description": "The new transaction id."
+            }
+        },
+        "checknormalization": {
+            "summary": "Given an unnormalized name of a claim, return normalized version of it",
+            "description": [],
+            "tags": [
+                "Claimtrie"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "the name to normalize"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "result": {
+                "type": "string",
+                "description": "fully normalized name"
             }
         },
         "claimname": {
@@ -131,11 +144,15 @@
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "the name of the claim"
+                        "description": "the original name of the claim (before normalization)"
+                    },
+                    "normalized_name": {
+                        "type": "string",
+                        "description": "the name of this claim (after normalization)"
                     },
                     "value": {
                         "type": "string",
-                        "description": "claim metadata"
+                        "description": "metadata of the claim"
                     },
                     "claimId": {
                         "type": "string",
@@ -156,14 +173,6 @@
                     "effective amount": {
                         "type": "number",
                         "description": "txout amount plus amount from all supports associated with the claim"
-                    },
-                    "height": {
-                        "type": "number",
-                        "description": "the height of the block in which this claim transaction is located"
-                    },
-                    "valid at height": {
-                        "type": "number",
-                        "description": "the height at which the claim is valid"
                     },
                     "supports": {
                         "type": "array",
@@ -189,9 +198,21 @@
                                 "amount": {
                                     "type": "number",
                                     "description": "the amount of the support"
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "description": "the metadata of the support if any"
                                 }
                             }
                         }
+                    },
+                    "height": {
+                        "type": "number",
+                        "description": "the height of the block in which this claim transaction is located"
+                    },
+                    "valid at height": {
+                        "type": "number",
+                        "description": "the height at which the claim is valid"
                     }
                 }
             }
@@ -208,6 +229,10 @@
                     "name": {
                         "type": "string",
                         "description": "the name for which to get claims and supports"
+                    },
+                    "blockhash": {
+                        "type": "string",
+                        "description": "get claims for name at the block specified by this block hash. If none is given, the latest active block will be used."
                     }
                 },
                 "required": [
@@ -217,9 +242,13 @@
             "result": {
                 "type": "object",
                 "properties": {
-                    "nLastTakeoverheight": {
+                    "nLastTakeoverHeight": {
                         "type": "number",
                         "description": "the last height at which ownership of the name changed"
+                    },
+                    "normalized_name": {
+                        "type": "string",
+                        "description": "the name of these claims after normalization"
                     },
                     "claims": {
                         "type": "array",
@@ -250,6 +279,10 @@
                                     "type": "number",
                                     "description": "the amount of the claim"
                                 },
+                                "value": {
+                                    "type": "string",
+                                    "description": "the metadata of the claim"
+                                },
                                 "nEffectiveAmount": {
                                     "type": "number",
                                     "description": "the total effective amount of the claim, taking into effect whether the claim or support has reached its nValidAtHeight"
@@ -278,14 +311,22 @@
                                             "nAmount": {
                                                 "type": "number",
                                                 "description": "the amount of the support"
+                                            },
+                                            "value": {
+                                                "type": "string",
+                                                "description": "the metadata of the support if any"
                                             }
                                         }
                                     }
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "the original name of this claim before normalization"
                                 }
                             }
                         }
                     },
-                    "unmatched supports": {
+                    "supports without claims": {
                         "type": "array",
                         "items": {
                             "type": "object",
@@ -341,7 +382,7 @@
                     "properties": {
                         "nOut": {
                             "type": "number",
-                            "description": "the index of the claim or support in the transaction's list out outputs"
+                            "description": "the index of the claim or support in the transaction's list of outputs"
                         },
                         "claim type": {
                             "type": "string",
@@ -350,6 +391,10 @@
                         "name": {
                             "type": "string",
                             "description": "the name claimed or supported"
+                        },
+                        "claimId": {
+                            "type": "string",
+                            "description": "if a claim, its ID"
                         },
                         "value": {
                             "type": "string",
@@ -392,7 +437,7 @@
             }
         },
         "getclaimsintrie": {
-            "summary": "Return all claims in the name trie.",
+            "summary": "Return all names in the trie.",
             "description": [],
             "tags": [
                 "Claimtrie"
@@ -400,104 +445,16 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "minconf": {
-                        "type": "number",
-                        "description": "the number of required confirmations",
-                        "default": 1
+                    "blockhash": {
+                        "type": "string",
+                        "description": "get claims in the trie at the block specified by this block hash. If none is given, the latest active block will be used."
                     }
                 },
                 "required": []
             },
             "result": {
                 "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "the name claimed"
-                        },
-                        "claims": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "claimId": {
-                                        "type": "string",
-                                        "description": "the claimId of the claim"
-                                    },
-                                    "txid": {
-                                        "type": "string",
-                                        "description": "the txid of the claim"
-                                    },
-                                    "n": {
-                                        "type": "number",
-                                        "description": "the vout value of the claim"
-                                    },
-                                    "amount": {
-                                        "type": "number",
-                                        "description": "txout amount"
-                                    },
-                                    "height": {
-                                        "type": "number",
-                                        "description": "the height of the block in which this transaction is located"
-                                    },
-                                    "value": {
-                                        "type": "string",
-                                        "description": "the value of this claim"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "getclaimtrie": {
-            "summary": "Return the entire name trie.",
-            "description": [],
-            "tags": [
-                "Claimtrie"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {
-                    "minconf": {
-                        "type": "number",
-                        "description": "the number of required confirmations",
-                        "default": 1
-                    }
-                },
-                "required": []
-            },
-            "result": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "the name of the node"
-                    },
-                    "hash": {
-                        "type": "string",
-                        "description": "the hash of the node"
-                    },
-                    "txid": {
-                        "type": "string",
-                        "description": "(if value exists) the hash of the transaction which has successfully claimed this name"
-                    },
-                    "n": {
-                        "type": "number",
-                        "description": "(if value exists) vout value"
-                    },
-                    "value": {
-                        "type": "number",
-                        "description": "(if value exists) txout value"
-                    },
-                    "height": {
-                        "type": "number",
-                        "description": "(if value exists) the height of the block in which this transaction is located"
-                    }
-                }
+                "description": "all names in the trie that have claims"
             }
         },
         "getnameproof": {
@@ -608,7 +565,7 @@
             }
         },
         "getvalueforname": {
-            "summary": "Return the value associated with a name, if one exists",
+            "summary": "Return the winning value associated with a name, if one exists",
             "description": [],
             "tags": [
                 "Claimtrie"
@@ -620,10 +577,9 @@
                         "type": "string",
                         "description": "the name to look up"
                     },
-                    "minconf": {
-                        "type": "number",
-                        "description": "the number of required confirmations",
-                        "default": 1
+                    "blockhash": {
+                        "type": "string",
+                        "description": "get the value associated with the name at the block specified by this block hash. If none is given, the latest active block will be used."
                     }
                 },
                 "required": [
@@ -632,7 +588,7 @@
             },
             "result": {
                 "type": "string",
-                "description": "the value of the name, if it exists \"claimId\" (string) the claimId for this name claim \"txid\" (string) the hash of the transaction which successfully claimed the name \"n\" (numeric) vout value \"amount\" (numeric) txout amount \"effective amount\" (numeric) txout amount plus amount from all supports associated with the claim \"height\" (numeric) the height of the block in which this transaction is located"
+                "description": "the value of the name, if it exists \"claimId\" (string) the claimId for this name claim \"txid\" (string) the hash of the transaction which successfully claimed the name \"n\" (numeric) vout value \"amount\" (numeric) txout amount \"effective amount\" (numeric) txout amount plus amount from all supports associated with the claim \"height\" (numeric) the height of the block in which this transaction is located \"name\" (string) the original name of this claim (before normalization)"
             }
         },
         "listnameclaims": {
@@ -654,7 +610,7 @@
                     },
                     "minconf": {
                         "type": "number",
-                        "description": "Only include transactions confirmed at least this many time.",
+                        "description": "Only include transactions confirmed at least this many times.",
                         "default": 1
                     }
                 },
@@ -742,7 +698,7 @@
             }
         },
         "supportclaim": {
-            "summary": "Increase the value of a claim. Whichever claim has the greatest value, including all support values, will be the authoritative claim, according to the rest of the rules. The name is the name which is claimed by the claim that will be supported, the txid is the txid of the claim that will be supported, nout is the transaction output which contains the claim to be supported, and amount is the amount which will be added to the value of the claim. If the claim is currently the authoritative claim, this support will go into effect immediately. Otherwise, it will go into effect after 100 blocks. The support will be in effect until it is spent, and will lose its effect when the claim is spent or expires. The amount is a real and is rounded to the nearest .00000001",
+            "summary": "Increase the value of a claim. Whichever claim has the greatest value, including all support values, will be the authoritative claim, according to the rest of the rules. The name is the name which is claimed by the claim that will be supported, the txid is the txid of the claim that will be supported, nout is the transaction output which contains the claim to be supported, and amount is the amount which will be added to the value of the claim. If the claim is currently the authoritative claim, this support will go into effect immediately . Otherwise, it will go into effect after 100 blocks. The support will be in effect until it is spent, and will lose its effect when the claim is spent or expires. The amount is a real and is rounded to the nearest .00000001",
             "description": [],
             "tags": [
                 "Claimtrie"
@@ -761,6 +717,10 @@
                     "amount": {
                         "type": "number",
                         "description": "The amount in LBC to use to support the claim."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The metadata of the support encoded in hexadecimal."
                     }
                 },
                 "required": [
@@ -808,7 +768,7 @@
             }
         },
         "getbestblockhash": {
-            "summary": "Returns the hash of the best (tip) block in the longest block chain. Result \"hex\" (string) the block hash hex encoded",
+            "summary": "Returns the hash of the best (tip) block in the longest blockchain.",
             "description": [
                 "",
                 "> lbrycrd-cli getbestblockhash ",
@@ -822,10 +782,14 @@
                 "type": "object",
                 "properties": {},
                 "required": []
+            },
+            "result": {
+                "type": "string",
+                "description": "the block hash hex encoded"
             }
         },
         "getblock": {
-            "summary": "If verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'. If verbose is true, returns an Object with information about block <hash>.",
+            "summary": "If verbosity is 0, returns a string that is serialized, hex-encoded data for block 'hash'. If verbosity is 1, returns an Object with information about block <hash>. If verbosity is 2, returns an Object with information about block <hash> and information about each transaction.",
             "description": [
                 "",
                 "> lbrycrd-cli getblock \"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"",
@@ -838,104 +802,27 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "hash": {
+                    "blockhash": {
                         "type": "string",
                         "description": "The block hash"
                     },
-                    "verbose": {
-                        "type": "boolean",
-                        "description": "true for a json object, false for the hex encoded data",
-                        "default": true
+                    "verbosity": {
+                        "type": "number",
+                        "description": "0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data",
+                        "default": 1
                     }
                 },
                 "required": [
-                    "hash"
+                    "blockhash"
                 ]
             },
             "result": {
-                "type": "object",
-                "properties": {
-                    "hash": {
-                        "type": "string",
-                        "description": "the block hash (same as provided)"
-                    },
-                    "confirmations": {
-                        "type": "number",
-                        "description": "The number of confirmations, or -1 if the block is not on the main chain"
-                    },
-                    "size": {
-                        "type": "number",
-                        "description": "The block size"
-                    },
-                    "height": {
-                        "type": "number",
-                        "description": "The block height or index"
-                    },
-                    "version": {
-                        "type": "number",
-                        "description": "The block version"
-                    },
-                    "versionHex": {
-                        "type": "string",
-                        "description": "The block version formatted in hexadecimal"
-                    },
-                    "merkleroot": {
-                        "type": "string",
-                        "description": "The merkle root"
-                    },
-                    "nameclaimroot": {
-                        "type": "string",
-                        "description": "The hash of the root of the name claim trie"
-                    },
-                    "tx": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "properties": {
-                                "transactionid": {
-                                    "type": "string",
-                                    "description": "The transaction id"
-                                }
-                            }
-                        }
-                    },
-                    "time": {
-                        "type": "number",
-                        "description": "The block time in seconds since epoch (Jan 1 1970 GMT)"
-                    },
-                    "mediantime": {
-                        "type": "number",
-                        "description": "The median block time in seconds since epoch (Jan 1 1970 GMT)"
-                    },
-                    "nonce": {
-                        "type": "number",
-                        "description": "The nonce"
-                    },
-                    "bits": {
-                        "type": "string",
-                        "description": "The bits"
-                    },
-                    "difficulty": {
-                        "type": "number",
-                        "description": "The difficulty"
-                    },
-                    "chainwork": {
-                        "type": "string",
-                        "description": "Expected number of hashes required to produce the chain up to this block (in hex)"
-                    },
-                    "previousblockhash": {
-                        "type": "string",
-                        "description": "The hash of the previous block"
-                    },
-                    "nextblockhash": {
-                        "type": "string",
-                        "description": "The hash of the next block"
-                    }
-                }
+                "type": "string",
+                "description": "A string that is serialized, hex-encoded data for block 'hash'. Result (for verbosity = 1): { \"hash\" : \"hash\", (string) the block hash (same as provided) \"confirmations\" : n, (numeric) The number of confirmations, or -1 if the block is not on the main chain \"size\" : n, (numeric) The block size \"strippedsize\" : n, (numeric) The block size excluding witness data \"weight\" : n (numeric) The block weight as defined in BIP 141 \"height\" : n, (numeric) The block height or index \"version\" : n, (numeric) The block version \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal \"merkleroot\" : \"xxxx\", (string) The merkle root \"nameclaimroot\" : \"xxxx\", (string) The hash of the root of the name claim trie \"tx\" : [ (array of string) The transaction ids \"transactionid\" (string) The transaction id ,... ], \"time\" : ttt, (numeric) The block time in seconds since epoch (Jan 1 1970 GMT) \"mediantime\" : ttt, (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT) \"nonce\" : n, (numeric) The nonce \"bits\" : \"1d00ffff\", (string) The bits \"difficulty\" : x.xxx, (numeric) The difficulty \"chainwork\" : \"xxxx\", (string) Expected number of hashes required to produce the chain up to this block (in hex) \"nTx\" : n, (numeric) The number of transactions in the block. \"previousblockhash\" : \"hash\", (string) The hash of the previous block \"nextblockhash\" : \"hash\" (string) The hash of the next block } Result (for verbosity = 2): { ..., Same output as verbosity = 1. \"tx\" : [ (array of Objects) The transactions in the format of the getrawtransaction RPC. Different from verbosity = 1 \"tx\" result. ,... ], ,... Same output as verbosity = 1. }"
             }
         },
         "getblockchaininfo": {
-            "summary": "Returns an object containing various state info regarding block chain processing.",
+            "summary": "Returns an object containing various state info regarding blockchain processing.",
             "description": [
                 "",
                 "> lbrycrd-cli getblockchaininfo ",
@@ -981,9 +868,17 @@
                         "type": "number",
                         "description": "estimate of verification progress [0..1]"
                     },
+                    "initialblockdownload": {
+                        "type": "boolean",
+                        "description": "(debug information) estimate of whether this node is in Initial Block Download mode."
+                    },
                     "chainwork": {
                         "type": "string",
                         "description": "total amount of work in active chain, in hexadecimal"
+                    },
+                    "size_on_disk": {
+                        "type": "number",
+                        "description": "the estimated size of the block and undo files on disk"
                     },
                     "pruned": {
                         "type": "boolean",
@@ -991,7 +886,15 @@
                     },
                     "pruneheight": {
                         "type": "number",
-                        "description": "heighest block available"
+                        "description": "lowest-height complete block stored (only present if pruning is enabled)"
+                    },
+                    "automatic_pruning": {
+                        "type": "boolean",
+                        "description": "whether automatic pruning is enabled (only present if pruning is enabled)"
+                    },
+                    "prune_target_size": {
+                        "type": "number",
+                        "description": "the target size used by pruning (only present if automatic pruning is enabled)"
                     },
                     "softforks": {
                         "type": "array",
@@ -1006,24 +909,12 @@
                                     "type": "number",
                                     "description": "block version"
                                 },
-                                "enforce": {
+                                "reject": {
                                     "type": "object",
                                     "properties": {
                                         "status": {
                                             "type": "boolean",
                                             "description": "true if threshold reached"
-                                        },
-                                        "found": {
-                                            "type": "number",
-                                            "description": "number of blocks with the new version found"
-                                        },
-                                        "required": {
-                                            "type": "number",
-                                            "description": "number of blocks required to trigger"
-                                        },
-                                        "window": {
-                                            "type": "number",
-                                            "description": "maximum size of examined window of recent blocks"
                                         }
                                     }
                                 }
@@ -1042,11 +933,11 @@
                                 "properties": {
                                     "status": {
                                         "type": "string",
-                                        "description": "one of \"defined\", \"started\", \"lockedin\", \"active\", \"failed\""
+                                        "description": "one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\""
                                     },
                                     "bit": {
                                         "type": "number",
-                                        "description": "the bit, 0-28, in the block version field used to signal this soft fork"
+                                        "description": "the bit (0-28) in the block version field used to signal this softfork (only for \"started\" status)"
                                     },
                                     "startTime": {
                                         "type": "number",
@@ -1055,16 +946,49 @@
                                     "timeout": {
                                         "type": "number",
                                         "description": "the median time past of a block at which the deployment is considered failed if not yet locked in"
+                                    },
+                                    "since": {
+                                        "type": "number",
+                                        "description": "height of the first block to which the status applies"
+                                    },
+                                    "statistics": {
+                                        "type": "object",
+                                        "properties": {
+                                            "period": {
+                                                "type": "number",
+                                                "description": "the length in blocks of the BIP9 signalling period"
+                                            },
+                                            "threshold": {
+                                                "type": "number",
+                                                "description": "the number of blocks with the version bit set required to activate the feature"
+                                            },
+                                            "elapsed": {
+                                                "type": "number",
+                                                "description": "the number of blocks elapsed since the beginning of the current period"
+                                            },
+                                            "count": {
+                                                "type": "number",
+                                                "description": "the number of blocks with the version bit set in the current period"
+                                            },
+                                            "possible": {
+                                                "type": "boolean",
+                                                "description": "returns false if there are not enough blocks left in this period to pass activation threshold"
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
+                    },
+                    "warnings": {
+                        "type": "string",
+                        "description": "any network and blockchain warnings."
                     }
                 }
             }
         },
         "getblockcount": {
-            "summary": "Returns the number of blocks in the longest block chain.",
+            "summary": "Returns the number of blocks in the longest blockchain.",
             "description": [
                 "",
                 "> lbrycrd-cli getblockcount ",
@@ -1085,7 +1009,7 @@
             }
         },
         "getblockhash": {
-            "summary": "Returns hash of block in best-block-chain at index provided.",
+            "summary": "Returns hash of block in best-block-chain at height provided.",
             "description": [
                 "",
                 "> lbrycrd-cli getblockhash 1000",
@@ -1098,13 +1022,13 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "index": {
+                    "height": {
                         "type": "number",
-                        "description": "The block index"
+                        "description": "The height index"
                     }
                 },
                 "required": [
-                    "index"
+                    "height"
                 ]
             },
             "result": {
@@ -1167,6 +1091,10 @@
                         "type": "string",
                         "description": "The merkle root"
                     },
+                    "nameclaimroot": {
+                        "type": "string",
+                        "description": "The hash of the root of the name claim trie"
+                    },
                     "time": {
                         "type": "number",
                         "description": "The block time in seconds since epoch (Jan 1 1970 GMT)"
@@ -1187,6 +1115,14 @@
                         "type": "number",
                         "description": "The difficulty"
                     },
+                    "chainwork": {
+                        "type": "string",
+                        "description": "Expected number of hashes required to produce the current chain (in hex)"
+                    },
+                    "nTx": {
+                        "type": "number",
+                        "description": "The number of transactions in the block."
+                    },
                     "previousblockhash": {
                         "type": "string",
                         "description": "The hash of the previous block"
@@ -1194,10 +1130,157 @@
                     "nextblockhash": {
                         "type": "string",
                         "description": "The hash of the next block"
+                    }
+                }
+            }
+        },
+        "getblockstats": {
+            "summary": "Compute per block statistics for a given window. All amounts are in satoshis. It won't work for some heights with pruning. It won't work without -txindex for utxo_size_inc, *fee or *feerate stats.",
+            "description": [
+                "",
+                "> lbrycrd-cli getblockstats 1000 '[\"minfeerate\",\"avgfeerate\"]'",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblockstats\", \"params\": [1000 '[\"minfeerate\",\"avgfeerate\"]'] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "hash_or_height": {
+                        "type": "number",
+                        "description": "The block hash or height of the target block"
                     },
-                    "chainwork": {
+                    "stats": {
+                        "type": "array",
+                        "description": "Values to plot, by default all values (see result below)\n    [\n      \"height\",         (string, optional) Selected statistic\n      \"time\",           (string, optional) Selected statistic\n      ,...\n    ]"
+                    }
+                },
+                "required": [
+                    "hash_or_height"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "avgfee": {
+                        "type": "number",
+                        "description": "Average fee in the block"
+                    },
+                    "avgfeerate": {
+                        "type": "number",
+                        "description": "Average feerate (in satoshis per virtual byte)"
+                    },
+                    "avgtxsize": {
+                        "type": "number",
+                        "description": "Average transaction size"
+                    },
+                    "blockhash": {
                         "type": "string",
-                        "description": "Expected number of hashes required to produce the current chain (in hex)"
+                        "description": "The block hash (to check for potential reorgs)"
+                    },
+                    "feerate_percentiles": {
+                        "type": "array",
+                        "items": {
+                            "type": "array"
+                        }
+                    },
+                    "height": {
+                        "type": "number",
+                        "description": "The height of the block"
+                    },
+                    "ins": {
+                        "type": "number",
+                        "description": "The number of inputs (excluding coinbase)"
+                    },
+                    "maxfee": {
+                        "type": "number",
+                        "description": "Maximum fee in the block"
+                    },
+                    "maxfeerate": {
+                        "type": "number",
+                        "description": "Maximum feerate (in satoshis per virtual byte)"
+                    },
+                    "maxtxsize": {
+                        "type": "number",
+                        "description": "Maximum transaction size"
+                    },
+                    "medianfee": {
+                        "type": "number",
+                        "description": "Truncated median fee in the block"
+                    },
+                    "mediantime": {
+                        "type": "number",
+                        "description": "The block median time past"
+                    },
+                    "mediantxsize": {
+                        "type": "number",
+                        "description": "Truncated median transaction size"
+                    },
+                    "minfee": {
+                        "type": "number",
+                        "description": "Minimum fee in the block"
+                    },
+                    "minfeerate": {
+                        "type": "number",
+                        "description": "Minimum feerate (in satoshis per virtual byte)"
+                    },
+                    "mintxsize": {
+                        "type": "number",
+                        "description": "Minimum transaction size"
+                    },
+                    "outs": {
+                        "type": "number",
+                        "description": "The number of outputs"
+                    },
+                    "subsidy": {
+                        "type": "number",
+                        "description": "The block subsidy"
+                    },
+                    "swtotal_size": {
+                        "type": "number",
+                        "description": "Total size of all segwit transactions"
+                    },
+                    "swtotal_weight": {
+                        "type": "number",
+                        "description": "Total weight of all segwit transactions divided by segwit scale factor (4)"
+                    },
+                    "swtxs": {
+                        "type": "number",
+                        "description": "The number of segwit transactions"
+                    },
+                    "time": {
+                        "type": "number",
+                        "description": "The block time"
+                    },
+                    "total_out": {
+                        "type": "number",
+                        "description": "Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])"
+                    },
+                    "total_size": {
+                        "type": "number",
+                        "description": "Total size of all non-coinbase transactions"
+                    },
+                    "total_weight": {
+                        "type": "number",
+                        "description": "Total weight of all non-coinbase transactions divided by segwit scale factor (4)"
+                    },
+                    "totalfee": {
+                        "type": "number",
+                        "description": "The fee total"
+                    },
+                    "txs": {
+                        "type": "number",
+                        "description": "The number of transactions (excluding coinbase)"
+                    },
+                    "utxo_increase": {
+                        "type": "number",
+                        "description": "The increase/decrease in the number of unspent outputs"
+                    },
+                    "utxo_size_inc": {
+                        "type": "number",
+                        "description": "The increase/decrease in size for the utxo index (not discounting op_return and similar)"
                     }
                 }
             }
@@ -1235,6 +1318,65 @@
                 }
             }
         },
+        "getchaintxstats": {
+            "summary": "Compute statistics about the total number and rate of transactions in the chain.",
+            "description": [
+                "",
+                "> lbrycrd-cli getchaintxstats ",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getchaintxstats\", \"params\": [2016] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "nblocks": {
+                        "type": "number",
+                        "description": "Size of the window in number of blocks (default: one month)."
+                    },
+                    "blockhash": {
+                        "type": "string",
+                        "description": "The hash of the block that ends the window."
+                    }
+                },
+                "required": []
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "time": {
+                        "type": "number",
+                        "description": "The timestamp for the final block in the window in UNIX format."
+                    },
+                    "txcount": {
+                        "type": "number",
+                        "description": "The total number of transactions in the chain up to that point."
+                    },
+                    "window_final_block_hash": {
+                        "type": "string",
+                        "description": "The hash of the final block in the window."
+                    },
+                    "window_block_count": {
+                        "type": "number",
+                        "description": "Size of the window in number of blocks."
+                    },
+                    "window_tx_count": {
+                        "type": "number",
+                        "description": "The number of transactions in the window. Only returned if \"window_block_count\" is > 0."
+                    },
+                    "window_interval": {
+                        "type": "number",
+                        "description": "The elapsed time in the window in seconds. Only returned if \"window_block_count\" is > 0."
+                    },
+                    "txrate": {
+                        "type": "number",
+                        "description": "The average rate of transactions per second in the window. Only returned if \"window_interval\" is > 0."
+                    }
+                }
+            }
+        },
         "getdifficulty": {
             "summary": "Returns the proof-of-work difficulty as a multiple of the minimum difficulty.",
             "description": [
@@ -1254,6 +1396,374 @@
             "result": {
                 "type": "number",
                 "description": "the proof-of-work difficulty as a multiple of the minimum difficulty."
+            }
+        },
+        "getmempoolancestors": {
+            "summary": "If txid is in the mempool, returns all in-mempool ancestors.",
+            "description": [
+                "",
+                "> lbrycrd-cli getmempoolancestors \"mytxid\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempoolancestors\", \"params\": [\"mytxid\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "txid": {
+                        "type": "string",
+                        "description": "The transaction id (must be in mempool)"
+                    },
+                    "verbose": {
+                        "type": "boolean",
+                        "description": "True for a json object, false for array of transaction ids",
+                        "default": false
+                    }
+                },
+                "required": [
+                    "txid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "transactionid": {
+                            "type": "string",
+                            "description": "The transaction id of an in-mempool ancestor transaction"
+                        }
+                    }
+                },
+                "properties": {
+                    "transactionid": {
+                        "type": "object",
+                        "properties": {
+                            "size": {
+                                "type": "number",
+                                "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."
+                            },
+                            "fee": {
+                                "type": "number",
+                                "description": "transaction fee in LBC (DEPRECATED)"
+                            },
+                            "modifiedfee": {
+                                "type": "number",
+                                "description": "transaction fee with fee deltas used for mining priority (DEPRECATED)"
+                            },
+                            "time": {
+                                "type": "number",
+                                "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT"
+                            },
+                            "height": {
+                                "type": "number",
+                                "description": "block height when transaction entered pool"
+                            },
+                            "descendantcount": {
+                                "type": "number",
+                                "description": "number of in-mempool descendant transactions (including this one)"
+                            },
+                            "descendantsize": {
+                                "type": "number",
+                                "description": "virtual transaction size of in-mempool descendants (including this one)"
+                            },
+                            "descendantfees": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)"
+                            },
+                            "ancestorcount": {
+                                "type": "number",
+                                "description": "number of in-mempool ancestor transactions (including this one)"
+                            },
+                            "ancestorsize": {
+                                "type": "number",
+                                "description": "virtual transaction size of in-mempool ancestors (including this one)"
+                            },
+                            "ancestorfees": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)"
+                            },
+                            "wtxid": {
+                                "type": "string",
+                                "description": "hash of serialized transaction, including witness data"
+                            },
+                            "fees": {
+                                "type": "object",
+                                "properties": {
+                                    "base": {
+                                        "type": "number",
+                                        "description": "transaction fee in LBC"
+                                    },
+                                    "modified": {
+                                        "type": "number",
+                                        "description": "transaction fee with fee deltas used for mining priority in LBC"
+                                    },
+                                    "ancestor": {
+                                        "type": "number",
+                                        "description": "modified fees (see above) of in-mempool ancestors (including this one) in LBC"
+                                    },
+                                    "descendant": {
+                                        "type": "number",
+                                        "description": "modified fees (see above) of in-mempool descendants (including this one) in LBC"
+                                    }
+                                }
+                            },
+                            "depends": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array"
+                                }
+                            },
+                            "spentby": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "getmempooldescendants": {
+            "summary": "If txid is in the mempool, returns all in-mempool descendants.",
+            "description": [
+                "",
+                "> lbrycrd-cli getmempooldescendants \"mytxid\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempooldescendants\", \"params\": [\"mytxid\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "txid": {
+                        "type": "string",
+                        "description": "The transaction id (must be in mempool)"
+                    },
+                    "verbose": {
+                        "type": "boolean",
+                        "description": "True for a json object, false for array of transaction ids",
+                        "default": false
+                    }
+                },
+                "required": [
+                    "txid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "transactionid": {
+                            "type": "string",
+                            "description": "The transaction id of an in-mempool descendant transaction"
+                        }
+                    }
+                },
+                "properties": {
+                    "transactionid": {
+                        "type": "object",
+                        "properties": {
+                            "size": {
+                                "type": "number",
+                                "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."
+                            },
+                            "fee": {
+                                "type": "number",
+                                "description": "transaction fee in LBC (DEPRECATED)"
+                            },
+                            "modifiedfee": {
+                                "type": "number",
+                                "description": "transaction fee with fee deltas used for mining priority (DEPRECATED)"
+                            },
+                            "time": {
+                                "type": "number",
+                                "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT"
+                            },
+                            "height": {
+                                "type": "number",
+                                "description": "block height when transaction entered pool"
+                            },
+                            "descendantcount": {
+                                "type": "number",
+                                "description": "number of in-mempool descendant transactions (including this one)"
+                            },
+                            "descendantsize": {
+                                "type": "number",
+                                "description": "virtual transaction size of in-mempool descendants (including this one)"
+                            },
+                            "descendantfees": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)"
+                            },
+                            "ancestorcount": {
+                                "type": "number",
+                                "description": "number of in-mempool ancestor transactions (including this one)"
+                            },
+                            "ancestorsize": {
+                                "type": "number",
+                                "description": "virtual transaction size of in-mempool ancestors (including this one)"
+                            },
+                            "ancestorfees": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)"
+                            },
+                            "wtxid": {
+                                "type": "string",
+                                "description": "hash of serialized transaction, including witness data"
+                            },
+                            "fees": {
+                                "type": "object",
+                                "properties": {
+                                    "base": {
+                                        "type": "number",
+                                        "description": "transaction fee in LBC"
+                                    },
+                                    "modified": {
+                                        "type": "number",
+                                        "description": "transaction fee with fee deltas used for mining priority in LBC"
+                                    },
+                                    "ancestor": {
+                                        "type": "number",
+                                        "description": "modified fees (see above) of in-mempool ancestors (including this one) in LBC"
+                                    },
+                                    "descendant": {
+                                        "type": "number",
+                                        "description": "modified fees (see above) of in-mempool descendants (including this one) in LBC"
+                                    }
+                                }
+                            },
+                            "depends": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array"
+                                }
+                            },
+                            "spentby": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "getmempoolentry": {
+            "summary": "Returns mempool data for given transaction",
+            "description": [
+                "",
+                "> lbrycrd-cli getmempoolentry \"mytxid\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempoolentry\", \"params\": [\"mytxid\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "txid": {
+                        "type": "string",
+                        "description": "The transaction id (must be in mempool)"
+                    }
+                },
+                "required": [
+                    "txid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "size": {
+                        "type": "number",
+                        "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."
+                    },
+                    "fee": {
+                        "type": "number",
+                        "description": "transaction fee in LBC (DEPRECATED)"
+                    },
+                    "modifiedfee": {
+                        "type": "number",
+                        "description": "transaction fee with fee deltas used for mining priority (DEPRECATED)"
+                    },
+                    "time": {
+                        "type": "number",
+                        "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT"
+                    },
+                    "height": {
+                        "type": "number",
+                        "description": "block height when transaction entered pool"
+                    },
+                    "descendantcount": {
+                        "type": "number",
+                        "description": "number of in-mempool descendant transactions (including this one)"
+                    },
+                    "descendantsize": {
+                        "type": "number",
+                        "description": "virtual transaction size of in-mempool descendants (including this one)"
+                    },
+                    "descendantfees": {
+                        "type": "number",
+                        "description": "modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)"
+                    },
+                    "ancestorcount": {
+                        "type": "number",
+                        "description": "number of in-mempool ancestor transactions (including this one)"
+                    },
+                    "ancestorsize": {
+                        "type": "number",
+                        "description": "virtual transaction size of in-mempool ancestors (including this one)"
+                    },
+                    "ancestorfees": {
+                        "type": "number",
+                        "description": "modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)"
+                    },
+                    "wtxid": {
+                        "type": "string",
+                        "description": "hash of serialized transaction, including witness data"
+                    },
+                    "fees": {
+                        "type": "object",
+                        "properties": {
+                            "base": {
+                                "type": "number",
+                                "description": "transaction fee in LBC"
+                            },
+                            "modified": {
+                                "type": "number",
+                                "description": "transaction fee with fee deltas used for mining priority in LBC"
+                            },
+                            "ancestor": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool ancestors (including this one) in LBC"
+                            },
+                            "descendant": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool descendants (including this one) in LBC"
+                            }
+                        }
+                    },
+                    "depends": {
+                        "type": "array",
+                        "items": {
+                            "type": "array"
+                        }
+                    },
+                    "spentby": {
+                        "type": "array",
+                        "items": {
+                            "type": "array"
+                        }
+                    }
+                }
             }
         },
         "getmempoolinfo": {
@@ -1281,7 +1791,7 @@
                     },
                     "bytes": {
                         "type": "number",
-                        "description": "Sum of all tx sizes"
+                        "description": "Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted"
                     },
                     "usage": {
                         "type": "number",
@@ -1293,13 +1803,17 @@
                     },
                     "mempoolminfee": {
                         "type": "number",
-                        "description": "Minimum fee for tx to be accepted"
+                        "description": "Minimum fee rate in LBC/kB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee"
+                    },
+                    "minrelaytxfee": {
+                        "type": "number",
+                        "description": "Current minimum relay fee for transactions"
                     }
                 }
             }
         },
         "getrawmempool": {
-            "summary": "Returns all transaction ids in memory pool as a json array of string transaction ids.",
+            "summary": "Returns all transaction ids in memory pool as a json array of string transaction ids. Hint: use getmempoolentry to fetch a specific transaction from the mempool.",
             "description": [
                 "",
                 "> lbrycrd-cli getrawmempool true",
@@ -1314,20 +1828,108 @@
                 "properties": {
                     "verbose": {
                         "type": "boolean",
-                        "description": "true for a json object, false for array of transaction ids",
+                        "description": "True for a json object, false for array of transaction ids",
                         "default": false
                     }
                 },
                 "required": []
             },
             "result": {
-                "type": "array",
+                "type": "object",
                 "items": {
                     "type": "object",
                     "properties": {
                         "transactionid": {
                             "type": "string",
                             "description": "The transaction id"
+                        }
+                    }
+                },
+                "properties": {
+                    "transactionid": {
+                        "type": "object",
+                        "properties": {
+                            "size": {
+                                "type": "number",
+                                "description": "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."
+                            },
+                            "fee": {
+                                "type": "number",
+                                "description": "transaction fee in LBC (DEPRECATED)"
+                            },
+                            "modifiedfee": {
+                                "type": "number",
+                                "description": "transaction fee with fee deltas used for mining priority (DEPRECATED)"
+                            },
+                            "time": {
+                                "type": "number",
+                                "description": "local time transaction entered pool in seconds since 1 Jan 1970 GMT"
+                            },
+                            "height": {
+                                "type": "number",
+                                "description": "block height when transaction entered pool"
+                            },
+                            "descendantcount": {
+                                "type": "number",
+                                "description": "number of in-mempool descendant transactions (including this one)"
+                            },
+                            "descendantsize": {
+                                "type": "number",
+                                "description": "virtual transaction size of in-mempool descendants (including this one)"
+                            },
+                            "descendantfees": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)"
+                            },
+                            "ancestorcount": {
+                                "type": "number",
+                                "description": "number of in-mempool ancestor transactions (including this one)"
+                            },
+                            "ancestorsize": {
+                                "type": "number",
+                                "description": "virtual transaction size of in-mempool ancestors (including this one)"
+                            },
+                            "ancestorfees": {
+                                "type": "number",
+                                "description": "modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)"
+                            },
+                            "wtxid": {
+                                "type": "string",
+                                "description": "hash of serialized transaction, including witness data"
+                            },
+                            "fees": {
+                                "type": "object",
+                                "properties": {
+                                    "base": {
+                                        "type": "number",
+                                        "description": "transaction fee in LBC"
+                                    },
+                                    "modified": {
+                                        "type": "number",
+                                        "description": "transaction fee with fee deltas used for mining priority in LBC"
+                                    },
+                                    "ancestor": {
+                                        "type": "number",
+                                        "description": "modified fees (see above) of in-mempool ancestors (including this one) in LBC"
+                                    },
+                                    "descendant": {
+                                        "type": "number",
+                                        "description": "modified fees (see above) of in-mempool descendants (including this one) in LBC"
+                                    }
+                                }
+                            },
+                            "depends": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array"
+                                }
+                            },
+                            "spentby": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array"
+                                }
+                            }
                         }
                     }
                 }
@@ -1362,9 +1964,9 @@
                         "type": "number",
                         "description": "vout number"
                     },
-                    "includemempool": {
+                    "include_mempool": {
                         "type": "boolean",
-                        "description": "Whether to include the mem pool"
+                        "description": "Whether to include the mempool. Default: true. Note that an unspent output that is spent in the mempool won't appear."
                     }
                 },
                 "required": [
@@ -1377,7 +1979,7 @@
                 "properties": {
                     "bestblock": {
                         "type": "string",
-                        "description": "the block hash"
+                        "description": "The hash of the block at the tip of the chain"
                     },
                     "confirmations": {
                         "type": "number",
@@ -1411,7 +2013,7 @@
                                 "items": {
                                     "type": "array",
                                     "properties": {
-                                        "lbrycrdaddress": {
+                                        "address": {
                                             "type": "string",
                                             "description": "lbrycrd address"
                                         }
@@ -1419,10 +2021,6 @@
                                 }
                             }
                         }
-                    },
-                    "version": {
-                        "type": "number",
-                        "description": "The version"
                     },
                     "coinbase": {
                         "type": "boolean",
@@ -1432,7 +2030,7 @@
             }
         },
         "gettxoutproof": {
-            "summary": "Returns a hex-encoded proof that \"txid\" was included in a block. NOTE: By default this function only works sometimes. This is when there is an unspent output in the utxo for this transaction. To make it always work, you need to maintain a transaction index, using the -txindex command line option or specify the block in which the transaction is included in manually (by blockhash). Return the raw transaction data.",
+            "summary": "Returns a hex-encoded proof that \"txid\" was included in a block. NOTE: By default this function only works sometimes. This is when there is an unspent output in the utxo for this transaction. To make it always work, you need to maintain a transaction index, using the -txindex command line option or specify the block in which the transaction is included manually (by blockhash).",
             "description": [],
             "tags": [
                 "Blockchain"
@@ -1444,7 +2042,7 @@
                         "type": "string",
                         "description": "A json array of txids to filter [ \"txid\" (string) A transaction hash ,... ]"
                     },
-                    "block hash": {
+                    "blockhash": {
                         "type": "string",
                         "description": "If specified, looks for txid in the block with this hash"
                     }
@@ -1483,29 +2081,157 @@
                     },
                     "bestblock": {
                         "type": "string",
-                        "description": "the best block hash hex"
+                        "description": "The hash of the block at the tip of the chain"
                     },
                     "transactions": {
                         "type": "number",
-                        "description": "The number of transactions"
+                        "description": "The number of transactions with unspent outputs"
                     },
                     "txouts": {
                         "type": "number",
-                        "description": "The number of output transactions"
+                        "description": "The number of unspent transaction outputs"
                     },
-                    "bytes_serialized": {
+                    "bogosize": {
                         "type": "number",
-                        "description": "The serialized size"
+                        "description": "A meaningless metric for UTXO set size"
                     },
-                    "hash_serialized": {
+                    "hash_serialized_2": {
                         "type": "string",
                         "description": "The serialized hash"
+                    },
+                    "disk_size": {
+                        "type": "number",
+                        "description": "The estimated size of the chainstate on disk"
                     },
                     "total_amount": {
                         "type": "number",
                         "description": "The total amount"
                     }
                 }
+            }
+        },
+        "preciousblock": {
+            "summary": "Treats a block as if it were received before others with the same work. A later preciousblock call can override the effect of an earlier one. The effects of preciousblock are not retained across restarts.",
+            "description": [
+                "",
+                "> lbrycrd-cli preciousblock \"blockhash\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"preciousblock\", \"params\": [\"blockhash\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "blockhash": {
+                        "type": "string",
+                        "description": "the hash of the block to mark as precious"
+                    }
+                },
+                "required": [
+                    "blockhash"
+                ]
+            }
+        },
+        "pruneblockchain": {
+            "summary": "",
+            "description": [
+                "",
+                "> lbrycrd-cli pruneblockchain 1000",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"pruneblockchain\", \"params\": [1000] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "height": {
+                        "type": "number",
+                        "description": "The block height to prune up to. May be set to a discrete height, or a unix timestamp to prune blocks whose block time is at least 2 hours older than the provided timestamp."
+                    }
+                },
+                "required": [
+                    "height"
+                ]
+            },
+            "result": {
+                "type": "number",
+                "description": "Height of the last block pruned."
+            }
+        },
+        "savemempool": {
+            "summary": "Dumps the mempool to disk. It will fail until the previous dump is fully loaded.",
+            "description": [
+                "",
+                "> lbrycrd-cli savemempool ",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"savemempool\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        },
+        "scantxoutset": {
+            "summary": "EXPERIMENTAL warning: this call may be removed or changed in future releases. Scans the unspent transaction output set for entries that match certain output descriptors.",
+            "description": [
+                "",
+                "    addr(<address>)                      Outputs whose scriptPubKey corresponds to the specified address (does not include P2PK)",
+                "    raw(<hex script>)                    Outputs whose scriptPubKey equals the specified hex scripts",
+                "    combo(<pubkey>)                      P2PK, P2PKH, P2WPKH, and P2SH-P2WPKH outputs for the given pubkey",
+                "    pkh(<pubkey>)                        P2PKH outputs for the given pubkey",
+                "    sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys",
+                "",
+                "In the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one",
+                "or more path elements separated by \"/\", and optionally ending in \"/*\" (unhardened), or \"/*'\" or \"/*h\" (hardened) to specify all",
+                "unhardened or hardened child keys.",
+                "In the latter case, a range needs to be specified by below if different from 1000.",
+                "For more information on output descriptors, see the documentation in the doc/descriptors.md file.",
+                "",
+                "Arguments:",
+                "1. \"action\"                       (string, required) The action to execute",
+                "                                      \"start\" for starting a scan",
+                "                                      \"abort\" for aborting the current scan (returns true when abort was successful)",
+                "                                      \"status\" for progress report (in %) of the current scan",
+                "2. \"scanobjects\"                  (array, required) Array of scan objects",
+                "    [                             Every scan object is either a string descriptor or an object:",
+                "        \"descriptor\",             (string, optional) An output descriptor",
+                "        {                         (object, optional) An object with output descriptor and metadata",
+                "          \"desc\": \"descriptor\",   (string, required) An output descriptor",
+                "          \"range\": n,             (numeric, optional) Up to what child index HD chains should be explored (default: 1000)",
+                "        },",
+                "        ...",
+                "    ]",
+                "",
+                "Result:",
+                "{",
+                "  \"unspents\": [",
+                "    {",
+                "    \"txid\" : \"transactionid\",     (string) The transaction id",
+                "    \"vout\": n,                    (numeric) the vout value",
+                "    \"scriptPubKey\" : \"script\",    (string) the script key",
+                "    \"amount\" : x.xxx,             (numeric) The total amount in LBC of the unspent output",
+                "    \"height\" : n,                 (numeric) Height of the unspent transaction output",
+                "   }",
+                "   ,...], ",
+                " \"total_amount\" : x.xxx,          (numeric) The total amount of all found unspent outputs in LBC",
+                "]",
+                ""
+            ],
+            "tags": [
+                "Blockchain"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
             }
         },
         "verifychain": {
@@ -1527,10 +2253,10 @@
                         "description": "How thorough the block verification is.",
                         "default": 3
                     },
-                    "numblocks": {
+                    "nblocks": {
                         "type": "number",
                         "description": "The number of blocks to check.",
-                        "default": 288
+                        "default": 24
                     }
                 },
                 "required": []
@@ -1559,12 +2285,12 @@
                 ]
             }
         },
-        "getinfo": {
-            "summary": "Returns an object containing various state info.",
+        "getmemoryinfo": {
+            "summary": "Returns an object containing information about memory usage.",
             "description": [
                 "",
-                "> lbrycrd-cli getinfo ",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli getmemoryinfo ",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmemoryinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -1572,75 +2298,47 @@
             ],
             "params": {
                 "type": "object",
-                "properties": {},
-                "required": []
+                "properties": {
+                    "null": {
+                        "type": "object",
+                        "description": "\"mode\" determines what kind of information is returned. This argument is optional, the default mode is \"stats\".\n  - \"stats\" returns general statistics about memory usage in the daemon.\n  - \"mallocinfo\" returns an XML string describing low-level heap state (only available if compiled with glibc 2.10+)."
+                    }
+                },
+                "required": [
+                    null
+                ]
             },
             "result": {
                 "type": "object",
                 "properties": {
-                    "version": {
-                        "type": "number",
-                        "description": "the server version"
-                    },
-                    "protocolversion": {
-                        "type": "number",
-                        "description": "the protocol version"
-                    },
-                    "walletversion": {
-                        "type": "number",
-                        "description": "the wallet version"
-                    },
-                    "balance": {
-                        "type": "number",
-                        "description": "the total lbrycrd balance of the wallet"
-                    },
-                    "blocks": {
-                        "type": "number",
-                        "description": "the current number of blocks processed in the server"
-                    },
-                    "timeoffset": {
-                        "type": "number",
-                        "description": "the time offset"
-                    },
-                    "connections": {
-                        "type": "number",
-                        "description": "the number of connections"
-                    },
-                    "proxy": {
-                        "type": "string",
-                        "description": "the proxy used by the server"
-                    },
-                    "difficulty": {
-                        "type": "number",
-                        "description": "the current difficulty"
-                    },
-                    "testnet": {
-                        "type": "boolean",
-                        "description": "if the server is using testnet or not"
-                    },
-                    "keypoololdest": {
-                        "type": "number",
-                        "description": "the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool"
-                    },
-                    "keypoolsize": {
-                        "type": "number",
-                        "description": "how many new keys are pre-generated"
-                    },
-                    "unlocked_until": {
-                        "type": "number",
-                        "description": "the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked"
-                    },
-                    "paytxfee": {
-                        "type": "number",
-                        "description": "the transaction fee set in LBC/kB"
-                    },
-                    "relayfee": {
-                        "type": "number",
-                        "description": "minimum relay fee for non-free transactions in LBC/kB"
-                    },
-                    "errors": {
-                        "type": "string",
-                        "description": "any error messages"
+                    "locked": {
+                        "type": "object",
+                        "properties": {
+                            "used": {
+                                "type": "number",
+                                "description": "Number of bytes used"
+                            },
+                            "free": {
+                                "type": "number",
+                                "description": "Number of bytes available in current arenas"
+                            },
+                            "total": {
+                                "type": "number",
+                                "description": "Total number of bytes managed"
+                            },
+                            "locked": {
+                                "type": "number",
+                                "description": "Amount of bytes that succeeded locking. If this number is smaller than total, locking pages failed at some point and key data could be swapped to disk."
+                            },
+                            "chunks_used": {
+                                "type": "number",
+                                "description": "Number allocated chunks"
+                            },
+                            "chunks_free": {
+                                "type": "number",
+                                "description": "Number unused chunks"
+                            }
+                        }
                     }
                 }
             }
@@ -1666,8 +2364,43 @@
                 "description": "The help text"
             }
         },
+        "logging": {
+            "summary": "Gets and sets the logging configuration. When called without an argument, returns the list of categories with status that are currently being debug logged or not. When called with arguments, adds or removes categories from debug logging and return the lists above. The arguments are evaluated in order \"include\", \"exclude\". If an item is both included and excluded, it will thus end up being excluded. The valid logging categories are: net, tor, mempool, http, bench, zmq, db, rpc, estimatefee, addrman, selectcoins, reindex, cmpctblock, rand, prune, proxy, mempoolrej, libevent, coindb, qt, leveldb In addition, the following are available as category names with special meanings: - \"all\", \"1\" : represent all logging categories. - \"none\", \"0\" : even if other logging categories are specified, ignore all of them.",
+            "description": [
+                "",
+                "> lbrycrd-cli logging \"[\\\"all\\\"]\" \"[\\\"http\\\"]\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"logging\", \"params\": [[\"all\"], \"[libevent]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Control"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "include": {
+                        "type": "array",
+                        "description": "A json array of categories to add debug logging\n     [\n       \"category\"   (string) the valid logging category\n       ,...\n     ]"
+                    },
+                    "exclude": {
+                        "type": "array",
+                        "description": "A json array of categories to remove debug logging\n     [\n       \"category\"   (string) the valid logging category\n       ,...\n     ]"
+                    }
+                },
+                "required": []
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "number",
+                        "description": "if being debug logged or not. 0:inactive, 1:active"
+                    }
+                }
+            }
+        },
         "stop": {
-            "summary": "Stop LBRYcrd server.",
+            "summary": "Stop lbrycrd server.",
             "description": [],
             "tags": [
                 "Control"
@@ -1678,8 +2411,29 @@
                 "required": []
             }
         },
+        "uptime": {
+            "summary": "Returns the total uptime of the server.",
+            "description": [
+                "",
+                "> lbrycrd-cli uptime ",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"uptime\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Control"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            },
+            "result": {
+                "type": "number",
+                "description": "The number of seconds that the server has been running"
+            }
+        },
         "generate": {
-            "summary": "Mine up to numblocks blocks immediately (before the RPC call returns)",
+            "summary": "Mine up to nblocks blocks immediately (before the RPC call returns) to an address in the wallet.",
             "description": [
                 "",
                 "",
@@ -1693,17 +2447,17 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "numblocks": {
+                    "nblocks": {
                         "type": "number",
                         "description": "How many blocks are generated immediately."
                     },
                     "maxtries": {
                         "type": "number",
-                        "description": "How many iterations to try (default = 1000000). Result [ blockhashes ] (array) hashes of blocks generated"
+                        "description": "How many iterations to try (default = 1000000)."
                     }
                 },
                 "required": [
-                    "numblocks"
+                    "nblocks"
                 ]
             }
         },
@@ -1722,31 +2476,31 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "numblocks": {
+                    "nblocks": {
                         "type": "number",
                         "description": "How many blocks are generated immediately."
                     },
                     "address": {
                         "type": "string",
-                        "description": "The address to send the newly generated bitcoin to."
+                        "description": "The address to send the newly generated lbry to."
                     },
                     "maxtries": {
                         "type": "number",
-                        "description": "How many iterations to try (default = 1000000). Result [ blockhashes ] (array) hashes of blocks generated"
+                        "description": "How many iterations to try (default = 1000000)."
                     }
                 },
                 "required": [
-                    "numblocks",
+                    "nblocks",
                     "address"
                 ]
             }
         },
         "getblocktemplate": {
-            "summary": "If the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'. It returns data needed to construct a block to work on. See https://en.bitcoin.it/wiki/BIP_0022 for full specification.",
+            "summary": "If the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'. It returns data needed to construct a block to work on. For full specification, see BIPs 22, 23, 9, and 145: https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki#getblocktemplate_changes https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki",
             "description": [
                 "",
-                "> lbrycrd-cli getblocktemplate ",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblocktemplate\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli getblocktemplate {\"rules\": [\"segwit\"]}",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblocktemplate\", \"params\": [{\"rules\": [\"segwit\"]}] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -1755,9 +2509,38 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "jsonrequestobject": {
-                        "type": "string",
-                        "description": "A json object in the following spec { \"mode\":\"template\" (string, optional) This must be set to \"template\" or omitted \"capabilities\":[ (array, optional) A list of strings \"support\" (string) client side supported feature, 'longpoll', 'coinbasetxn', 'coinbasevalue', 'proposal', 'serverlist', 'workid' ,... ] }"
+                    "template_request": {
+                        "type": "object",
+                        "properties": {
+                            "mode": {
+                                "type": "string",
+                                "description": "This must be set to \"template\", \"proposal\" (see BIP 23), or omitted"
+                            },
+                            "capabilities": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "properties": {
+                                        "support": {
+                                            "type": "string",
+                                            "description": "client side supported feature, 'longpoll', 'coinbasetxn', 'coinbasevalue', 'proposal', 'serverlist', 'workid'"
+                                        }
+                                    }
+                                }
+                            },
+                            "rules": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "properties": {
+                                        "support": {
+                                            "type": "string",
+                                            "description": "client side supported softfork deployment"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 "required": []
@@ -1767,7 +2550,20 @@
                 "properties": {
                     "version": {
                         "type": "number",
-                        "description": "The block version"
+                        "description": "The preferred block version"
+                    },
+                    "vbavailable": {
+                        "type": "object",
+                        "properties": {
+                            "rulename": {
+                                "type": "number",
+                                "description": "identifies the bit number as indicating acceptance and readiness for the named softfork rule"
+                            }
+                        }
+                    },
+                    "vbrequired": {
+                        "type": "number",
+                        "description": "bit mask of versionbits the server requires set in submissions"
                     },
                     "previousblockhash": {
                         "type": "string",
@@ -1782,9 +2578,13 @@
                                     "type": "string",
                                     "description": "transaction data encoded in hexadecimal (byte-for-byte)"
                                 },
+                                "txid": {
+                                    "type": "string",
+                                    "description": "transaction id encoded in little-endian hexadecimal"
+                                },
                                 "hash": {
                                     "type": "string",
-                                    "description": "hash/id encoded in little-endian hexadecimal"
+                                    "description": "hash encoded in little-endian hexadecimal (including witness data)"
                                 },
                                 "depends": {
                                     "type": "array",
@@ -1800,15 +2600,15 @@
                                 },
                                 "fee": {
                                     "type": "number",
-                                    "description": "difference in value between transaction inputs and outputs (in Satoshis); for coinbase transactions, this is a negative Number of the total collected block fees (ie, not including the block subsidy); if key is not present, fee is unknown and clients MUST NOT assume there isn't one"
+                                    "description": "difference in value between transaction inputs and outputs (in satoshis); for coinbase transactions, this is a negative Number of the total collected block fees (ie, not including the block subsidy); if key is not present, fee is unknown and clients MUST NOT assume there isn't one"
                                 },
                                 "sigops": {
                                     "type": "number",
-                                    "description": "total number of SigOps, as counted for purposes of block limits; if key is not present, sigop count is unknown and clients MUST NOT assume there aren't any"
+                                    "description": "total SigOps cost, as counted for purposes of block limits; if key is not present, sigop cost is unknown and clients MUST NOT assume it is zero"
                                 },
-                                "required": {
-                                    "type": "boolean",
-                                    "description": "if provided and true, this transaction must be in the final block"
+                                "weight": {
+                                    "type": "number",
+                                    "description": "total transaction weight, as counted for purposes of block limits"
                                 }
                             }
                         }
@@ -1818,13 +2618,13 @@
                         "properties": {
                             "flags": {
                                 "type": "string",
-                                "description": ""
+                                "description": "key name is to be ignored, and value included in scriptSig"
                             }
                         }
                     },
                     "coinbasevalue": {
                         "type": "number",
-                        "description": "maximum allowable input to coinbase transaction, including the generation award and transaction fees (in Satoshis)"
+                        "description": "maximum allowable input to coinbase transaction, including the generation award and transaction fees (in satoshis)"
                     },
                     "target": {
                         "type": "string",
@@ -1858,6 +2658,10 @@
                         "type": "number",
                         "description": "limit of block size"
                     },
+                    "weightlimit": {
+                        "type": "number",
+                        "description": "limit of block weight"
+                    },
                     "curtime": {
                         "type": "number",
                         "description": "current timestamp in seconds since epoch (Jan 1 1970 GMT)"
@@ -1869,46 +2673,12 @@
                     "height": {
                         "type": "number",
                         "description": "The height of the next block"
+                    },
+                    "claimtrie": {
+                        "type": "string",
+                        "description": "The root hash of the claim trie in hex"
                     }
                 }
-            }
-        },
-        "getgenerate": {
-            "summary": "Return if the server is set to generate coins or not. The default is false. It is set with the command line argument -gen (or lbrycrd.conf setting gen) It can also be set with the setgenerate call. Result true|false (boolean) If the server is set to generate coins or not",
-            "description": [
-                "",
-                "> lbrycrd-cli getgenerate ",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getgenerate\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
-                ""
-            ],
-            "tags": [
-                "Mining"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
-        },
-        "gethashespersec": {
-            "summary": "Returns a recent hashes per second performance measurement while generating. See the getgenerate and setgenerate calls to turn generation on and off.",
-            "description": [
-                "",
-                "> lbrycrd-cli gethashespersec ",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"gethashespersec\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
-                ""
-            ],
-            "tags": [
-                "Mining"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {},
-                "required": []
-            },
-            "result": {
-                "type": "number",
-                "description": "The recent hashes per second when generation is on (will return 0 if generation is off)"
             }
         },
         "getmininginfo": {
@@ -1934,9 +2704,9 @@
                         "type": "number",
                         "description": "The current block"
                     },
-                    "currentblocksize": {
+                    "currentblockweight": {
                         "type": "number",
-                        "description": "The last block size"
+                        "description": "The last block weight"
                     },
                     "currentblocktx": {
                         "type": "number",
@@ -1946,33 +2716,21 @@
                         "type": "number",
                         "description": "The current difficulty"
                     },
-                    "errors": {
-                        "type": "string",
-                        "description": "Current errors"
-                    },
-                    "generate": {
-                        "type": "boolean",
-                        "description": "If the generation is on or off (see getgenerate or setgenerate calls)"
-                    },
-                    "genproclimit": {
+                    "networkhashps": {
                         "type": "number",
-                        "description": "The processor limit for generation. -1 if no generation. (see getgenerate or setgenerate calls)"
-                    },
-                    "hashespersec": {
-                        "type": "number",
-                        "description": "The hashes per second of the generation, or 0 if no generation."
+                        "description": "The network hashes per second"
                     },
                     "pooledtx": {
                         "type": "number",
-                        "description": "The size of the mem pool"
-                    },
-                    "testnet": {
-                        "type": "boolean",
-                        "description": "If using testnet or not"
+                        "description": "The size of the mempool"
                     },
                     "chain": {
                         "type": "string",
                         "description": "current network name as defined in BIP70 (main, test, regtest)"
+                    },
+                    "warnings": {
+                        "type": "string",
+                        "description": "any network and blockchain warnings"
                     }
                 }
             }
@@ -1991,7 +2749,7 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "blocks": {
+                    "nblocks": {
                         "type": "number",
                         "description": "The number of blocks, or -1 for blocks since last difficulty change.",
                         "default": 120
@@ -2027,62 +2785,27 @@
                         "type": "string",
                         "description": "The transaction id."
                     },
-                    "priority delta": {
+                    "dummy": {
                         "type": "number",
-                        "description": "The priority to add or subtract. The transaction selection algorithm considers the tx as it would have a higher priority. (priority of a transaction is calculated: coinage * value_in_satoshis / txsize)"
+                        "description": "API-Compatibility for previous API. Must be zero or null. DEPRECATED. For forward compatibility use named arguments and omit this parameter."
                     },
-                    "fee delta": {
+                    "fee_delta": {
                         "type": "number",
-                        "description": "The fee value (in satoshis) to add (or subtract, if negative). The fee is not actually paid, only the algorithm for selecting transactions into a block considers the transaction as it would have paid a higher (or lower) fee. Result true (boolean) Returns true"
+                        "description": "The fee value (in satoshis) to add (or subtract, if negative). Note, that this value is not a fee rate. It is a value to modify absolute fee of the TX. The fee is not actually paid, only the algorithm for selecting transactions into a block considers the transaction as it would have paid a higher (or lower) fee."
                     }
                 },
                 "required": [
                     "txid",
-                    "priority delta",
-                    "fee delta"
+                    "fee_delta"
                 ]
-            }
-        },
-        "setgenerate": {
-            "summary": "Set 'generate' true or false to turn generation on or off. Generation is limited to 'genproclimit' processors, -1 is unlimited. See the getgenerate call for the current setting.",
-            "description": [
-                "",
-                "",
-                "Set the generation on with a limit of one processor",
-                "> lbrycrd-cli setgenerate true 1",
-                "",
-                "Check the setting",
-                "> lbrycrd-cli getgenerate ",
-                "",
-                "Turn off generation",
-                "> lbrycrd-cli setgenerate false",
-                "",
-                "Using json rpc",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setgenerate\", \"params\": [true, 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
-                ""
-            ],
-            "tags": [
-                "Mining"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {
-                    "generate": {
-                        "type": "boolean",
-                        "description": "Set to true to turn on generation, off to turn off."
-                    },
-                    "genproclimit": {
-                        "type": "number",
-                        "description": "Set the processor limit for when generation is on. Can be -1 for unlimited."
-                    }
-                },
-                "required": [
-                    "generate"
-                ]
+            },
+            "result": {
+                "type": "boolean",
+                "description": "Returns true"
             }
         },
         "submitblock": {
-            "summary": "Attempts to submit new block to network. The 'jsonparametersobject' parameter is currently ignored. See https://en.bitcoin.it/wiki/BIP_0022 for full specification.",
+            "summary": "Attempts to submit new block to network. See https://en.bitcoin.it/wiki/BIP_0022 for full specification.",
             "description": [
                 "",
                 "> lbrycrd-cli submitblock \"mydata\"",
@@ -2099,18 +2822,23 @@
                         "type": "string",
                         "description": "the hex-encoded block data to submit"
                     },
-                    "jsonparametersobject": {
-                        "type": "string",
-                        "description": "object of optional parameters { \"workid\" : \"id\" (string, optional) if the server provided a workid, it MUST be included with submissions }"
+                    "dummy": {
+                        "type": "optional",
+                        "description": "dummy value, for compatibility with BIP"
+                    },
+                    "null": {
+                        "type": "object",
+                        "description": "This value is ignored."
                     }
                 },
                 "required": [
-                    "hexdata"
+                    "hexdata",
+                    null
                 ]
             }
         },
         "addnode": {
-            "summary": "Attempts add or remove a node from the addnode list. Or try a connection to a node once.",
+            "summary": "Attempts to add or remove a node from the addnode list. Or try a connection to a node once. Nodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be full nodes/support SegWit as other outbound peers are (though such peers will not be synced from).",
             "description": [
                 "",
                 "> lbrycrd-cli addnode \"192.168.0.6:8333\" \"onetry\"",
@@ -2156,11 +2884,13 @@
             }
         },
         "disconnectnode": {
-            "summary": "Immediately disconnects from the specified node.",
+            "summary": "Immediately disconnects from the specified peer node. Strictly one out of 'address' and 'nodeid' can be provided to identify the node. To disconnect by nodeid, either set 'address' to the empty string, or call using the named 'nodeid' argument only.",
             "description": [
                 "",
                 "> lbrycrd-cli disconnectnode \"192.168.0.6:8333\"",
+                "> lbrycrd-cli disconnectnode \"\" 1",
                 "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"disconnectnode\", \"params\": [\"192.168.0.6:8333\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"disconnectnode\", \"params\": [\"\", 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -2169,23 +2899,24 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "node": {
+                    "address": {
                         "type": "string",
-                        "description": "The node (see getpeerinfo for nodes)"
+                        "description": "The IP address/port of the node"
+                    },
+                    "nodeid": {
+                        "type": "number",
+                        "description": "The node ID (see getpeerinfo for node IDs)"
                     }
                 },
-                "required": [
-                    "node"
-                ]
+                "required": []
             }
         },
         "getaddednodeinfo": {
-            "summary": "Returns information about the given added node, or all added nodes (note that onetry addnodes are not listed here) If dns is false, only a list of added nodes will be provided, otherwise connected information will also be available.",
+            "summary": "Returns information about the given added node, or all added nodes (note that onetry addnodes are not listed here)",
             "description": [
                 "",
-                "> lbrycrd-cli getaddednodeinfo true",
-                "> lbrycrd-cli getaddednodeinfo true \"192.168.0.201\"",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddednodeinfo\", \"params\": [true, \"192.168.0.201\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli getaddednodeinfo \"192.168.0.201\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddednodeinfo\", \"params\": [\"192.168.0.201\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -2194,18 +2925,12 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "dns": {
-                        "type": "boolean",
-                        "description": "If false, only a list of added nodes will be provided, otherwise connected information will also be available."
-                    },
                     "node": {
                         "type": "string",
                         "description": "If provided, return information about this specific node, otherwise all nodes are returned."
                     }
                 },
-                "required": [
-                    "dns"
-                ]
+                "required": []
             },
             "result": {
                 "type": "array",
@@ -2214,7 +2939,7 @@
                     "properties": {
                         "addednode": {
                             "type": "string",
-                            "description": "The node ip address"
+                            "description": "The node IP address or name (as provided to addnode)"
                         },
                         "connected": {
                             "type": "boolean",
@@ -2227,7 +2952,7 @@
                                 "properties": {
                                     "address": {
                                         "type": "string",
-                                        "description": "The lbrycrd server host and port"
+                                        "description": "The lbrycrd server IP and port we're connected to"
                                     },
                                     "connected": {
                                         "type": "string",
@@ -2290,7 +3015,7 @@
                     },
                     "timemillis": {
                         "type": "number",
-                        "description": "Total cpu time"
+                        "description": "Current UNIX time in milliseconds"
                     },
                     "uploadtarget": {
                         "type": "object",
@@ -2359,6 +3084,10 @@
                         "type": "string",
                         "description": "the services we offer to the network"
                     },
+                    "localrelay": {
+                        "type": "boolean",
+                        "description": "true if transaction relay is requested from peers"
+                    },
                     "timeoffset": {
                         "type": "number",
                         "description": "the time offset"
@@ -2366,6 +3095,10 @@
                     "connections": {
                         "type": "number",
                         "description": "the number of connections"
+                    },
+                    "networkactive": {
+                        "type": "boolean",
+                        "description": "whether p2p networking is enabled"
                     },
                     "networks": {
                         "type": "array",
@@ -2387,13 +3120,21 @@
                                 "proxy": {
                                     "type": "string",
                                     "description": "the proxy that is used for this network, or empty if none"
+                                },
+                                "proxy_randomize_credentials": {
+                                    "type": "string",
+                                    "description": "Whether randomized credentials are used"
                                 }
                             }
                         }
                     },
                     "relayfee": {
                         "type": "number",
-                        "description": "minimum relay fee for non-free transactions in LBC/kB"
+                        "description": "minimum relay fee for transactions in LBC/kB"
+                    },
+                    "incrementalfee": {
+                        "type": "number",
+                        "description": "minimum fee increment for mempool limiting or BIP 125 replacement in LBC/kB"
                     },
                     "localaddresses": {
                         "type": "array",
@@ -2417,7 +3158,7 @@
                     },
                     "warnings": {
                         "type": "string",
-                        "description": "any network warnings (such as alert messages)"
+                        "description": "any network and blockchain warnings"
                     }
                 }
             }
@@ -2449,11 +3190,15 @@
                         },
                         "addr": {
                             "type": "string",
-                            "description": "The ip address and port of the peer"
+                            "description": "The IP address and port of the peer"
+                        },
+                        "addrbind": {
+                            "type": "string",
+                            "description": "Bind address of the connection to the peer"
                         },
                         "addrlocal": {
                             "type": "string",
-                            "description": "local address"
+                            "description": "Local address as reported by the peer"
                         },
                         "services": {
                             "type": "string",
@@ -2501,7 +3246,7 @@
                         },
                         "version": {
                             "type": "number",
-                            "description": "The peer version, such as 7001"
+                            "description": "The peer version, such as 70001"
                         },
                         "subver": {
                             "type": "string",
@@ -2510,6 +3255,10 @@
                         "inbound": {
                             "type": "boolean",
                             "description": "Inbound (true) or Outbound (false)"
+                        },
+                        "addnode": {
+                            "type": "boolean",
+                            "description": "Whether connection was due to addnode/-connect or if it was an automatic/inbound connection"
                         },
                         "startingheight": {
                             "type": "number",
@@ -2538,6 +3287,10 @@
                                     }
                                 }
                             }
+                        },
+                        "whitelisted": {
+                            "type": "boolean",
+                            "description": "Whether the peer is whitelisted"
                         },
                         "bytessent_per_msg": {
                             "type": "object",
@@ -2596,12 +3349,12 @@
             }
         },
         "setban": {
-            "summary": "Attempts add or remove a IP/Subnet from the banned list.",
+            "summary": "Attempts to add or remove an IP/Subnet from the banned list.",
             "description": [
                 "",
                 "> lbrycrd-cli setban \"192.168.0.6\" \"add\" 86400",
                 "> lbrycrd-cli setban \"192.168.0.0/24\" \"add\"",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setban\", \"params\": [\"192.168.0.6\", \"add\" 86400] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setban\", \"params\": [\"192.168.0.6\", \"add\", 86400] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -2610,37 +3363,53 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "ip(/netmask)": {
+                    "subnet": {
                         "type": "string",
-                        "description": "The IP/Subnet (see getpeerinfo for nodes ip) with a optional netmask (default is /32 = single ip)"
+                        "description": "The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP)"
                     },
                     "command": {
                         "type": "string",
-                        "description": "'add' to add a IP/Subnet to the list, 'remove' to remove a IP/Subnet from the list"
+                        "description": "'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list"
                     },
                     "bantime": {
                         "type": "number",
-                        "description": "time in seconds how long (or until when if [absolute] is set) the ip is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)"
+                        "description": "time in seconds how long (or until when if [absolute] is set) the IP is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)"
                     },
                     "absolute": {
                         "type": "boolean",
-                        "description": "If set, the bantime must be a absolute timestamp in seconds since epoch (Jan 1 1970 GMT)"
+                        "description": "If set, the bantime must be an absolute timestamp in seconds since epoch (Jan 1 1970 GMT)"
                     }
                 },
                 "required": [
-                    "ip(/netmask)",
+                    "subnet",
                     "command"
                 ]
             }
         },
-        "createrawtransaction": {
-            "summary": "Create a transaction spending the given inputs and creating new outputs. Outputs can be addresses or data. Returns hex-encoded raw transaction. Note that the transaction's inputs are not signed, and it is not stored in the wallet or transmitted to the network.",
+        "setnetworkactive": {
+            "summary": "Disable/enable all p2p network activity.",
+            "description": [],
+            "tags": [
+                "Network"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "type": "boolean",
+                        "description": "true to enable networking, false to disable"
+                    }
+                },
+                "required": [
+                    "state"
+                ]
+            }
+        },
+        "combinepsbt": {
+            "summary": "Combine multiple partially signed LBRY transactions into one transaction. Implements the Combiner role.",
             "description": [
                 "",
-                "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"address\\\":0.01}\"",
-                "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"data\\\":\\\"00010203\\\"}\"",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"address\\\":0.01}\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"data\\\":\\\"00010203\\\"}\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli combinepsbt [\"mybase64_1\", \"mybase64_2\", \"mybase64_3\"]",
                 ""
             ],
             "tags": [
@@ -2649,28 +3418,353 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "transactions": {
+                    "txs": {
                         "type": "string",
-                        "description": "A json array of json objects [ { \"txid\":\"id\", (string, required) The transaction id \"vout\":n (numeric, required) The output number } ,... ]"
+                        "description": "A json array of base64 strings of partially signed transactions [ \"psbt\" (string) A base64 string of a PSBT ,... ]"
+                    }
+                },
+                "required": [
+                    "txs"
+                ]
+            },
+            "result": {
+                "type": "string",
+                "description": "The base64-encoded partially signed transaction"
+            }
+        },
+        "combinerawtransaction": {
+            "summary": "Combine multiple partially signed transactions into one transaction. The combined transaction may be another partially signed transaction or a fully signed transaction.",
+            "description": [
+                "",
+                "> lbrycrd-cli combinerawtransaction [\"myhex1\", \"myhex2\", \"myhex3\"]",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "txs": {
+                        "type": "string",
+                        "description": "A json array of hex strings of partially signed transactions [ \"hexstring\" (string) A transaction hash ,... ]"
+                    }
+                },
+                "required": [
+                    "txs"
+                ]
+            },
+            "result": {
+                "type": "string",
+                "description": "The hex-encoded raw transaction with signature(s)"
+            }
+        },
+        "converttopsbt": {
+            "summary": "Converts a network serialized transaction to a PSBT. This should be used only with createrawtransaction and fundrawtransaction createpsbt and walletcreatefundedpsbt should be used for new applications.",
+            "description": [
+                "",
+                "",
+                "Create a transaction",
+                "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"",
+                "",
+                "Convert the transaction to a PSBT",
+                "> lbrycrd-cli converttopsbt \"rawtransaction\"",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "hexstring": {
+                        "type": "string",
+                        "description": "The hex string of a raw transaction"
+                    },
+                    "permitsigdata": {
+                        "type": "boolean",
+                        "description": "If true, any signatures in the input will be discarded and conversion. will continue. If false, RPC will fail if any signatures are present.",
+                        "default": false
+                    },
+                    "iswitness": {
+                        "type": "boolean",
+                        "description": "Whether the transaction hex is a serialized witness transaction. If iswitness is not present, heuristic tests will be used in decoding. If true, only witness deserializaion will be tried. If false, only non-witness deserialization wil be tried. Only has an effect if permitsigdata is true."
+                    }
+                },
+                "required": [
+                    "hexstring"
+                ]
+            },
+            "result": {
+                "type": "string",
+                "description": "The resulting raw transaction (base64-encoded string)"
+            }
+        },
+        "createpsbt": {
+            "summary": "Creates a transaction in the Partially Signed Transaction format. Implements the Creator role.",
+            "description": [
+                "",
+                "> lbrycrd-cli createpsbt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "description": "A json array of json objects\n     [\n       {\n         \"txid\":\"id\",      (string, required) The transaction id\n         \"vout\":n,         (numeric, required) The output number\n         \"sequence\":n      (numeric, optional) The sequence number\n       } \n       ,...\n     ]"
                     },
                     "outputs": {
-                        "type": "string",
-                        "description": "a json object with outputs { \"address\": x.xxx (numeric or string, required) The key is the lbrycrd address, the numeric value (can be string) is the LBC amount \"data\": \"hex\", (string, required) The key is \"data\", the value is hex encoded data ... }"
+                        "type": "array",
+                        "description": "a json array with outputs (key-value pairs), where none of the keys are duplicated.\nThat is, each address can only appear once and there can only be one 'data' object.\n   [\n    {\n      \"address\": x.xxx,    (obj, optional) A key-value pair. The key (string) is the lbry address, the value (float or string) is the amount in LBC\n    },\n    {\n      \"data\": \"hex\"        (obj, optional) A key-value pair. The key must be \"data\", the value is hex encoded data\n    }\n    ,...                     More key-value pairs of the above form. For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\n                             accepted as second parameter.\n   ]"
                     },
                     "locktime": {
                         "type": "number",
                         "description": "Raw locktime. Non-0 value also locktime-activates inputs",
                         "default": 0
+                    },
+                    "replaceable": {
+                        "type": "boolean",
+                        "description": "Marks this transaction as BIP125 replaceable. Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.",
+                        "default": false
                     }
                 },
                 "required": [
-                    "transactions",
+                    "inputs",
+                    "outputs"
+                ]
+            },
+            "result": {
+                "type": "string",
+                "description": "The resulting raw transaction (base64-encoded string)"
+            }
+        },
+        "createrawtransaction": {
+            "summary": "Create a transaction spending the given inputs and creating new outputs. Outputs can be addresses or data. Returns hex-encoded raw transaction. Note that the transaction's inputs are not signed, and it is not stored in the wallet or transmitted to the network.",
+            "description": [
+                "",
+                "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"address\\\":0.01}]\"",
+                "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"address\\\":0.01}]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"data\\\":\\\"00010203\\\"}]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "description": "A json array of json objects\n     [\n       {\n         \"txid\":\"id\",      (string, required) The transaction id\n         \"vout\":n,         (numeric, required) The output number\n         \"sequence\":n      (numeric, optional) The sequence number\n       } \n       ,...\n     ]"
+                    },
+                    "outputs": {
+                        "type": "array",
+                        "description": "a json array with outputs (key-value pairs), where none of the keys are duplicated.\nThat is, each address can only appear once and there can only be one 'data' object.\n   [\n    {\n      \"address\": x.xxx,    (obj, optional) A key-value pair. The key (string) is the lbry address, the value (float or string) is the amount in LBC\n    },\n    {\n      \"data\": \"hex\"        (obj, optional) A key-value pair. The key must be \"data\", the value is hex encoded data\n    }\n    ,...                     More key-value pairs of the above form. For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\n                             accepted as second parameter.\n   ]"
+                    },
+                    "locktime": {
+                        "type": "number",
+                        "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+                        "default": 0
+                    },
+                    "replaceable": {
+                        "type": "boolean",
+                        "description": "Marks this transaction as BIP125 replaceable. Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.",
+                        "default": false
+                    }
+                },
+                "required": [
+                    "inputs",
                     "outputs"
                 ]
             },
             "result": {
                 "type": "string",
                 "description": "hex string of the transaction"
+            }
+        },
+        "decodepsbt": {
+            "summary": "Return a JSON object representing the serialized, base64-encoded partially signed LBRY transaction.",
+            "description": [
+                "",
+                "> lbrycrd-cli decodepsbt \"psbt\"",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "psbt": {
+                        "type": "string",
+                        "description": "The PSBT base64 string"
+                    }
+                },
+                "required": [
+                    "psbt"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "tx": {
+                        "type": "object"
+                    },
+                    "unknown": {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": null,
+                                "description": "An unknown key-value pair"
+                            }
+                        }
+                    },
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "non_witness_utxo": {
+                                    "type": "object"
+                                },
+                                "witness_utxo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "amount": {
+                                            "type": "number",
+                                            "description": "The value in LBC"
+                                        },
+                                        "scriptPubKey": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string",
+                                                    "description": "The asm"
+                                                },
+                                                "hex": {
+                                                    "type": "string",
+                                                    "description": "The hex"
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "description": "The type, eg 'pubkeyhash'"
+                                                },
+                                                "address": {
+                                                    "type": "string",
+                                                    "description": "LBRY address if there is one"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "partial_signatures": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pubkey": {
+                                            "type": "string",
+                                            "description": "The public key and signature that corresponds to it."
+                                        }
+                                    }
+                                },
+                                "sighash": {
+                                    "type": "string",
+                                    "description": "The sighash type to be used"
+                                },
+                                "redeem_script": {
+                                    "type": "object",
+                                    "properties": {
+                                        "asm": {
+                                            "type": "string",
+                                            "description": "The asm"
+                                        },
+                                        "hex": {
+                                            "type": "string",
+                                            "description": "The hex"
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "description": "The type, eg 'pubkeyhash'"
+                                        }
+                                    }
+                                },
+                                "witness_script": {
+                                    "type": "object",
+                                    "properties": {
+                                        "asm": {
+                                            "type": "string",
+                                            "description": "The asm"
+                                        },
+                                        "hex": {
+                                            "type": "string",
+                                            "description": "The hex"
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "description": "The type, eg 'pubkeyhash'"
+                                        }
+                                    }
+                                },
+                                "bip32_derivs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pubkey": {
+                                            "type": "object",
+                                            "properties": {
+                                                "master_fingerprint": {
+                                                    "type": "string",
+                                                    "description": "The fingerprint of the master key"
+                                                },
+                                                "path": {
+                                                    "type": "string",
+                                                    "description": "The path"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "final_scriptsig": {
+                                    "type": "object",
+                                    "properties": {
+                                        "asm": {
+                                            "type": "string",
+                                            "description": "The asm"
+                                        },
+                                        "hex": {
+                                            "type": "string",
+                                            "description": "The hex"
+                                        }
+                                    }
+                                },
+                                "unknown": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {
+                                            "type": null,
+                                            "description": "An unknown key-value pair"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "outputs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "key": {
+                                    "type": null,
+                                    "description": "An unknown key-value pair"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "decoderawtransaction": {
@@ -2687,13 +3781,17 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "hex": {
+                    "hexstring": {
                         "type": "string",
                         "description": "The transaction hex string"
+                    },
+                    "iswitness": {
+                        "type": "boolean",
+                        "description": "Whether the transaction hex is a serialized witness transaction If iswitness is not present, heuristic tests will be used in decoding"
                     }
                 },
                 "required": [
-                    "hex"
+                    "hexstring"
                 ]
             },
             "result": {
@@ -2703,9 +3801,21 @@
                         "type": "string",
                         "description": "The transaction id"
                     },
+                    "hash": {
+                        "type": "string",
+                        "description": "The transaction hash (differs from txid for witness transactions)"
+                    },
                     "size": {
                         "type": "number",
                         "description": "The transaction size"
+                    },
+                    "vsize": {
+                        "type": "number",
+                        "description": "The virtual transaction size (differs from size for witness transactions)"
+                    },
+                    "weight": {
+                        "type": "number",
+                        "description": "The transaction's weight (between vsize*4 - 3 and vsize*4)"
                     },
                     "version": {
                         "type": "number",
@@ -2787,7 +3897,7 @@
                                                 "properties": {
                                                     "12tvKAXCxZjSmdNbao16dKXC8tRWfcF5oc": {
                                                         "type": "string",
-                                                        "description": "lbrycrd address"
+                                                        "description": "lbry address"
                                                     }
                                                 }
                                             }
@@ -2814,13 +3924,13 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "hex": {
+                    "hexstring": {
                         "type": "string",
                         "description": "the hex encoded script"
                     }
                 },
                 "required": [
-                    "hex"
+                    "hexstring"
                 ]
             },
             "result": {
@@ -2849,20 +3959,65 @@
                             "properties": {
                                 "address": {
                                     "type": "string",
-                                    "description": "lbrycrd address"
+                                    "description": "lbry address"
                                 }
                             }
                         }
                     },
                     "p2sh\",\"address": {
                         "type": "string",
-                        "description": "script address"
+                        "description": "address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH)."
+                    }
+                }
+            }
+        },
+        "finalizepsbt": {
+            "summary": "Finalize the inputs of a PSBT. If the transaction is fully signed, it will produce a network serialized transaction which can be broadcast with sendrawtransaction. Otherwise a PSBT will be created which has the final_scriptSig and final_scriptWitness fields filled for inputs that are complete. Implements the Finalizer and Extractor roles.",
+            "description": [
+                "",
+                "> lbrycrd-cli finalizepsbt \"psbt\"",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "psbt": {
+                        "type": "string",
+                        "description": "A base64 string of a PSBT"
+                    },
+                    "extract": {
+                        "type": "boolean",
+                        "description": "If true and the transaction is complete, extract and return the complete transaction in normal network serialization instead of the PSBT.",
+                        "default": true
+                    }
+                },
+                "required": [
+                    "psbt"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "psbt": {
+                        "type": "string",
+                        "description": "The base64-encoded partially signed transaction if not extracted"
+                    },
+                    "hex": {
+                        "type": "string",
+                        "description": "The hex-encoded network transaction if extracted"
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "description": "If the transaction has a complete set of signatures"
                     }
                 }
             }
         },
         "fundrawtransaction": {
-            "summary": "Add inputs to a transaction until it has enough in value to meet its out value. This will not modify existing inputs, and will add one change output to the outputs. Note that inputs which were signed may need to be resigned after completion since in/outputs have been added. The inputs added will not be signed, use signrawtransaction for that. Note that all existing inputs must have their previous output transaction be in the wallet. Note that all inputs selected must be of standard form and P2SH scripts must be in the wallet using importaddress or addmultisigaddress (to calculate fees). Only pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only",
+            "summary": "Add inputs to a transaction until it has enough in value to meet its out value. This will not modify existing inputs, and will add at most one change output to the outputs. No existing outputs will be modified unless \"subtractFeeFromOutputs\" is specified. Note that inputs which were signed may need to be resigned after completion since in/outputs have been added. The inputs added will not be signed, use signrawtransaction for that. Note that all existing inputs must have their previous output transaction be in the wallet. Note that all inputs selected must be of standard form and P2SH scripts must be in the wallet using importaddress or addmultisigaddress (to calculate fees). You can see whether this is the case by checking the \"solvable\" field in the listunspent output. Only pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only",
             "description": [
                 "",
                 "",
@@ -2900,6 +4055,10 @@
                                 "type": "number",
                                 "description": "The index of the change output"
                             },
+                            "change_type": {
+                                "type": "string",
+                                "description": "The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype."
+                            },
                             "includeWatching": {
                                 "type": "boolean",
                                 "description": "Also select inputs which are watch only"
@@ -2907,8 +4066,28 @@
                             "lockUnspents": {
                                 "type": "boolean",
                                 "description": "Lock selected unspent outputs"
+                            },
+                            "feeRate": {
+                                "type": "number",
+                                "description": "Set a specific fee rate in LBC/kB"
+                            },
+                            "replaceable": {
+                                "type": "boolean",
+                                "description": "Marks this transaction as BIP125 replaceable."
+                            },
+                            "conf_target": {
+                                "type": "number",
+                                "description": "Confirmation target (in blocks)"
+                            },
+                            "estimate_mode": {
+                                "type": "string",
+                                "description": "The fee estimate mode, must be one of:"
                             }
                         }
+                    },
+                    "iswitness": {
+                        "type": "boolean",
+                        "description": "Whether the transaction hex is a serialized witness transaction If iswitness is not present, heuristic tests will be used in decoding"
                     }
                 },
                 "required": [
@@ -2924,7 +4103,7 @@
                     },
                     "fee": {
                         "type": "number",
-                        "description": "Fee the resulting transaction pays"
+                        "description": "Fee in LBC the resulting transaction pays"
                     },
                     "changepos": {
                         "type": "number",
@@ -2934,12 +4113,14 @@
             }
         },
         "getrawtransaction": {
-            "summary": "NOTE: By default this function only works sometimes. This is when the tx is in the mempool or there is an unspent output in the utxo for this transaction. To make it always work, you need to maintain a transaction index, using the -txindex command line option. Return the raw transaction data. If verbose=0, returns a string that is serialized, hex-encoded data for 'txid'. If verbose is non-zero, returns an Object with information about 'txid'.",
+            "summary": "NOTE: By default this function only works for mempool transactions. If the -txindex option is enabled, it also works for blockchain transactions. If the block which contains the transaction is known, its hash can be provided even for nodes without -txindex. Note that if a blockhash is provided, only that block will be searched and if the transaction is in the mempool or other blocks, or if this node does not have the given block available, the transaction will not be found. DEPRECATED: for now, it also works for transactions with unspent outputs. Return the raw transaction data. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
             "description": [
                 "",
                 "> lbrycrd-cli getrawtransaction \"mytxid\"",
-                "> lbrycrd-cli getrawtransaction \"mytxid\" 1",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getrawtransaction\", \"params\": [\"mytxid\", 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli getrawtransaction \"mytxid\" true",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getrawtransaction\", \"params\": [\"mytxid\", true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli getrawtransaction \"mytxid\" false \"myblockhash\"",
+                "> lbrycrd-cli getrawtransaction \"mytxid\" true \"myblockhash\"",
                 ""
             ],
             "tags": [
@@ -2953,9 +4134,13 @@
                         "description": "The transaction id"
                     },
                     "verbose": {
-                        "type": "number",
-                        "description": "If 0, return a string, other return a json object",
-                        "default": 0
+                        "type": "boolean",
+                        "description": "If false, return a string, otherwise return a json object",
+                        "default": false
+                    },
+                    "blockhash": {
+                        "type": "string",
+                        "description": "The block in which to look for the transaction"
                     }
                 },
                 "required": [
@@ -2964,7 +4149,7 @@
             },
             "result": {
                 "type": "string",
-                "description": "The serialized, hex-encoded data for 'txid' Result (if verbose > 0): { \"hex\" : \"data\", (string) The serialized, hex-encoded data for 'txid' \"txid\" : \"id\", (string) The transaction id (same as provided) \"size\" : n, (numeric) The transaction size \"version\" : n, (numeric) The version \"locktime\" : ttt, (numeric) The lock time \"vin\" : [ (array of json objects) { \"txid\": \"id\", (string) The transaction id \"vout\": n, (numeric) \"scriptSig\": { (json object) The script \"asm\": \"asm\", (string) asm \"hex\": \"hex\" (string) hex }, \"sequence\": n (numeric) The script sequence number } ,... ], \"vout\" : [ (array of json objects) { \"value\" : x.xxx, (numeric) The value in LBC \"n\" : n, (numeric) index \"scriptPubKey\" : { (json object) \"asm\" : \"asm\", (string) the asm \"hex\" : \"hex\", (string) the hex \"reqSigs\" : n, (numeric) The required sigs \"type\" : \"pubkeyhash\", (string) The type, eg 'pubkeyhash' \"addresses\" : [ (json array of string) \"lbrycrdaddress\" (string) lbrycrd address ,... ] } } ,... ], \"blockhash\" : \"hash\", (string) the block hash \"confirmations\" : n, (numeric) The confirmations \"time\" : ttt, (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT) \"blocktime\" : ttt (numeric) The block time in seconds since epoch (Jan 1 1970 GMT) }"
+                "description": "The serialized, hex-encoded data for 'txid' Result (if verbose is set to true): { \"in_active_chain\": b, (bool) Whether specified block is in the active chain or not (only present with explicit \"blockhash\" argument) \"hex\" : \"data\", (string) The serialized, hex-encoded data for 'txid' \"txid\" : \"id\", (string) The transaction id (same as provided) \"hash\" : \"id\", (string) The transaction hash (differs from txid for witness transactions) \"size\" : n, (numeric) The serialized transaction size \"vsize\" : n, (numeric) The virtual transaction size (differs from size for witness transactions) \"weight\" : n, (numeric) The transaction's weight (between vsize*4-3 and vsize*4) \"version\" : n, (numeric) The version \"locktime\" : ttt, (numeric) The lock time \"vin\" : [ (array of json objects) { \"txid\": \"id\", (string) The transaction id \"vout\": n, (numeric) \"scriptSig\": { (json object) The script \"asm\": \"asm\", (string) asm \"hex\": \"hex\" (string) hex }, \"sequence\": n (numeric) The script sequence number \"txinwitness\": [\"hex\", ...] (array of string) hex-encoded witness data (if any) } ,... ], \"vout\" : [ (array of json objects) { \"value\" : x.xxx, (numeric) The value in LBC \"n\" : n, (numeric) index \"scriptPubKey\" : { (json object) \"asm\" : \"asm\", (string) the asm \"hex\" : \"hex\", (string) the hex \"reqSigs\" : n, (numeric) The required sigs \"type\" : \"pubkeyhash\", (string) The type, eg 'pubkeyhash' \"addresses\" : [ (json array of string) \"address\" (string) lbry address ,... ] } } ,... ], \"blockhash\" : \"hash\", (string) the block hash \"confirmations\" : n, (numeric) The confirmations \"time\" : ttt, (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT) \"blocktime\" : ttt (numeric) The block time in seconds since epoch (Jan 1 1970 GMT) }"
             }
         },
         "sendrawtransaction": {
@@ -3010,7 +4195,7 @@
             }
         },
         "signrawtransaction": {
-            "summary": "Sign inputs for raw transaction (serialized, hex-encoded). The second optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain. The third optional argument (may be null) is an array of base58-encoded private keys that, if given, will be the only keys used to sign the transaction.",
+            "summary": "DEPRECATED. Sign inputs for raw transaction (serialized, hex-encoded). The second optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain. The third optional argument (may be null) is an array of base58-encoded private keys that, if given, will be the only keys used to sign the transaction.",
             "description": [
                 "",
                 "> lbrycrd-cli signrawtransaction \"myhex\"",
@@ -3029,9 +4214,9 @@
                     },
                     "prevtxs": {
                         "type": "string",
-                        "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\" (string, required for P2SH) redeem script } ,... ]"
+                        "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\", (string, required for P2SH or P2WSH) redeem script \"amount\": value (numeric, required) The amount spent } ,... ]"
                     },
-                    "privatekeys": {
+                    "privkeys": {
                         "type": "string",
                         "description": "A json array of base58-encoded private keys for signing [ (json array of strings, or 'null' if none provided) \"privatekey\" (string) private key in base58-encoding ,... ]"
                     },
@@ -3087,16 +4272,147 @@
                 }
             }
         },
+        "signrawtransactionwithkey": {
+            "summary": "Sign inputs for raw transaction (serialized, hex-encoded). The second argument is an array of base58-encoded private keys that will be the only keys used to sign the transaction. The third optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain.",
+            "description": [
+                "",
+                "> lbrycrd-cli signrawtransactionwithkey \"myhex\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signrawtransactionwithkey\", \"params\": [\"myhex\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "hexstring": {
+                        "type": "string",
+                        "description": "The transaction hex string"
+                    },
+                    "privkeys": {
+                        "type": "string",
+                        "description": "A json array of base58-encoded private keys for signing [ (json array of strings) \"privatekey\" (string) private key in base58-encoding ,... ]"
+                    },
+                    "prevtxs": {
+                        "type": "string",
+                        "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\", (string, required for P2SH or P2WSH) redeem script \"amount\": value (numeric, required) The amount spent } ,... ]"
+                    },
+                    "sighashtype": {
+                        "type": "string",
+                        "description": "The signature hash type. Must be one of \"ALL\" \"NONE\" \"SINGLE\" \"ALL|ANYONECANPAY\" \"NONE|ANYONECANPAY\" \"SINGLE|ANYONECANPAY\"",
+                        "default": "ALL"
+                    }
+                },
+                "required": [
+                    "hexstring",
+                    "privkeys"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "hex": {
+                        "type": "string",
+                        "description": "The hex-encoded raw transaction with signature(s)"
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "description": "If the transaction has a complete set of signatures"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "txid": {
+                                    "type": "string",
+                                    "description": "The hash of the referenced, previous transaction"
+                                },
+                                "vout": {
+                                    "type": "number",
+                                    "description": "The index of the output to spent and used as input"
+                                },
+                                "scriptSig": {
+                                    "type": "string",
+                                    "description": "The hex-encoded signature script"
+                                },
+                                "sequence": {
+                                    "type": "number",
+                                    "description": "Script sequence number"
+                                },
+                                "error": {
+                                    "type": "string",
+                                    "description": "Verification or signing error related to the input"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "testmempoolaccept": {
+            "summary": "Returns if raw transaction (serialized, hex-encoded) would be accepted by mempool. This checks if the transaction violates the consensus or policy rules. See sendrawtransaction call.",
+            "description": [
+                "",
+                "",
+                "Create a transaction",
+                "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\" : \\\"mytxid\\\",\\\"vout\\\":0}]\" \"{\\\"myaddress\\\":0.01}\"",
+                "Sign the transaction, and get back the hex",
+                "> lbrycrd-cli signrawtransaction \"myhex\"",
+                "",
+                "Test acceptance of the transaction (signed hex)",
+                "> lbrycrd-cli testmempoolaccept [\"signedhex\"]",
+                "",
+                "As a json rpc call",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"testmempoolaccept\", \"params\": [[\"signedhex\"]] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Rawtransactions"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "allowhighfees": {
+                        "type": "boolean",
+                        "description": "Allow high fees",
+                        "default": false
+                    }
+                },
+                "required": []
+            },
+            "result": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "txid": {
+                            "type": "string",
+                            "description": "The transaction hash in hex"
+                        },
+                        "allowed": {
+                            "type": "boolean",
+                            "description": "If the mempool allows this tx to be inserted"
+                        },
+                        "reject-reason": {
+                            "type": "string",
+                            "description": "Rejection string (only present when 'allowed' is false)"
+                        }
+                    }
+                }
+            }
+        },
         "createmultisig": {
             "summary": "Creates a multi-signature address with n signature of m keys required. It returns a json object with the address and redeemScript.",
             "description": [
                 "",
                 "",
-                "Create a multisig address from 2 addresses",
-                "> lbrycrd-cli createmultisig 2 \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"",
+                "Create a multisig address from 2 public keys",
+                "> lbrycrd-cli createmultisig 2 \"[\\\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\\\",\\\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\\\"]\"",
                 "",
                 "As a json rpc call",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createmultisig\", \"params\": [2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createmultisig\", \"params\": [2, \"[\\\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\\\",\\\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -3107,11 +4423,15 @@
                 "properties": {
                     "nrequired": {
                         "type": "number",
-                        "description": "The number of required signatures out of the n keys or addresses."
+                        "description": "The number of required signatures out of the n keys."
                     },
                     "keys": {
                         "type": "string",
-                        "description": "A json array of keys which are lbrycrd addresses or hex-encoded public keys [ \"key\" (string) lbrycrd address or hex-encoded public key ,... ]"
+                        "description": "A json array of hex-encoded public keys [ \"key\" (string) The hex-encoded public key ,... ]"
+                    },
+                    "address_type": {
+                        "type": "string",
+                        "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is legacy."
                     }
                 },
                 "required": [
@@ -3133,62 +4453,8 @@
                 }
             }
         },
-        "estimatefee": {
-            "summary": "Estimates the approximate fee per kilobyte needed for a transaction to begin confirmation within nblocks blocks.",
-            "description": [
-                "",
-                "> lbrycrd-cli estimatefee 6",
-                ""
-            ],
-            "tags": [
-                "Util"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {
-                    "nblocks": {
-                        "type": "number",
-                        "description": ""
-                    }
-                },
-                "required": [
-                    "nblocks"
-                ]
-            },
-            "result": {
-                "type": "number",
-                "description": "estimated fee-per-kilobyte A negative value is returned if not enough transactions and blocks have been observed to make an estimate."
-            }
-        },
-        "estimatepriority": {
-            "summary": "Estimates the approximate priority a zero-fee transaction needs to begin confirmation within nblocks blocks.",
-            "description": [
-                "",
-                "> lbrycrd-cli estimatepriority 6",
-                ""
-            ],
-            "tags": [
-                "Util"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {
-                    "nblocks": {
-                        "type": "number",
-                        "description": ""
-                    }
-                },
-                "required": [
-                    "nblocks"
-                ]
-            },
-            "result": {
-                "type": "number",
-                "description": "estimated priority A negative value is returned if not enough transactions and blocks have been observed to make an estimate."
-            }
-        },
         "estimatesmartfee": {
-            "summary": "WARNING: This interface is unstable and may disappear or change! Estimates the approximate fee per kilobyte needed for a transaction to begin confirmation within nblocks blocks if possible and return the number of blocks for which the estimate is valid.",
+            "summary": "Estimates the approximate fee per kilobyte needed for a transaction to begin confirmation within conf_target blocks if possible and return the number of blocks for which the estimate is valid. Uses virtual transaction size as defined in BIP 141 (witness data is discounted).",
             "description": [
                 "",
                 "> lbrycrd-cli estimatesmartfee 6",
@@ -3200,13 +4466,18 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "nblocks": {
+                    "conf_target": {
                         "type": "number",
-                        "description": ""
+                        "description": "Confirmation target in blocks (1 - 1008)"
+                    },
+                    "estimate_mode": {
+                        "type": "string",
+                        "description": "The fee estimate mode. Whether to return a more conservative estimate which also satisfies a longer history. A conservative estimate potentially returns a higher feerate and is more likely to be sufficient for the desired target, but is not as responsive to short term drops in the prevailing fee market. Must be one of: \"UNSET\" (defaults to CONSERVATIVE) \"ECONOMICAL\" \"CONSERVATIVE\"",
+                        "default": "CONSERVATIVE"
                     }
                 },
                 "required": [
-                    "nblocks"
+                    "conf_target"
                 ]
             },
             "result": {
@@ -3214,7 +4485,7 @@
                 "properties": {
                     "feerate": {
                         "type": "number",
-                        "description": "estimate fee-per-kilobyte (in BTC)"
+                        "description": "estimate fee rate in LBC/kB"
                     },
                     "blocks": {
                         "type": "number",
@@ -3223,11 +4494,19 @@
                 }
             }
         },
-        "estimatesmartpriority": {
-            "summary": "WARNING: This interface is unstable and may disappear or change! Estimates the approximate priority a zero-fee transaction needs to begin confirmation within nblocks blocks if possible and return the number of blocks for which the estimate is valid.",
+        "signmessagewithprivkey": {
+            "summary": "Sign a message with the private key of an address",
             "description": [
                 "",
-                "> lbrycrd-cli estimatesmartpriority 6",
+                "",
+                "Create the signature",
+                "> lbrycrd-cli signmessagewithprivkey \"privkey\" \"my message\"",
+                "",
+                "Verify the signature",
+                "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"",
+                "",
+                "As json rpc",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signmessagewithprivkey\", \"params\": [\"privkey\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -3236,31 +4515,27 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "nblocks": {
-                        "type": "number",
-                        "description": ""
+                    "privkey": {
+                        "type": "string",
+                        "description": "The private key to sign the message with."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The message to create a signature of."
                     }
                 },
                 "required": [
-                    "nblocks"
+                    "privkey",
+                    "message"
                 ]
             },
             "result": {
-                "type": "object",
-                "properties": {
-                    "priority": {
-                        "type": "number",
-                        "description": "estimated priority"
-                    },
-                    "blocks": {
-                        "type": "number",
-                        "description": "block number where estimate was found"
-                    }
-                }
+                "type": "string",
+                "description": "The signature of the message encoded in base 64"
             }
         },
         "validateaddress": {
-            "summary": "Return information about the given lbrycrd address.",
+            "summary": "Return information about the given lbry address. DEPRECATION WARNING: Parts of this command have been deprecated and moved to getaddressinfo. Clients must transition to using getaddressinfo to access this information before upgrading to v0.18. The following deprecated fields have moved to getaddressinfo and will only be shown here with -deprecatedrpc=validateaddress: ismine, iswatchonly, script, hex, pubkeys, sigsrequired, pubkey, addresses, embedded, iscompressed, account, timestamp, hdkeypath, kdmasterkeyid.",
             "description": [
                 "",
                 "> lbrycrd-cli validateaddress \"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"",
@@ -3273,13 +4548,13 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address to validate"
+                        "description": "The lbry address to validate"
                     }
                 },
                 "required": [
-                    "lbrycrdaddress"
+                    "address"
                 ]
             },
             "result": {
@@ -3291,35 +4566,27 @@
                     },
                     "address": {
                         "type": "string",
-                        "description": "The lbrycrd address validated"
+                        "description": "The lbry address validated"
                     },
                     "scriptPubKey": {
                         "type": "string",
                         "description": "The hex encoded scriptPubKey generated by the address"
                     },
-                    "ismine": {
-                        "type": "boolean",
-                        "description": "If the address is yours or not"
-                    },
-                    "iswatchonly": {
-                        "type": "boolean",
-                        "description": "If the address is watchonly"
-                    },
                     "isscript": {
                         "type": "boolean",
                         "description": "If the key is a script"
                     },
-                    "pubkey": {
-                        "type": "string",
-                        "description": "The hex value of the raw public key"
-                    },
-                    "iscompressed": {
+                    "iswitness": {
                         "type": "boolean",
-                        "description": "If the address is compressed"
+                        "description": "If the address is a witness address"
                     },
-                    "account": {
+                    "witness_version": {
+                        "type": "number",
+                        "description": "The version number of the witness program"
+                    },
+                    "witness_program": {
                         "type": "string",
-                        "description": "DEPRECATED. The account associated with the address, \"\" is the default account"
+                        "description": "The hex value of the witness program"
                     }
                 }
             }
@@ -3333,13 +4600,13 @@
                 "> lbrycrd-cli walletpassphrase \"mypassphrase\" 30",
                 "",
                 "Create the signature",
-                "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"my message\"",
+                "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\"",
                 "",
                 "Verify the signature",
-                "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"signature\" \"my message\"",
+                "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"",
                 "",
                 "As json rpc",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"verifymessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", \"signature\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"verifymessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"signature\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -3348,9 +4615,9 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address to use for the signature."
+                        "description": "The lbry address to use for the signature."
                     },
                     "signature": {
                         "type": "string",
@@ -3362,7 +4629,7 @@
                     }
                 },
                 "required": [
-                    "lbrycrdaddress",
+                    "address",
                     "signature",
                     "message"
                 ]
@@ -3373,7 +4640,7 @@
             }
         },
         "abandontransaction": {
-            "summary": "Mark in-wallet transaction <txid> as abandoned This will mark this transaction and all its in-wallet descendants as abandoned which will allow for their inputs to be respent. It can be used to replace \"stuck\" or evicted transactions. It only works on transactions which are not included in a block and are not currently in the mempool. It has no effect on transactions which are already conflicted or abandoned.",
+            "summary": "Mark in-wallet transaction <txid> as abandoned This will mark this transaction and all its in-wallet descendants as abandoned which will allow for their inputs to be respent. It can be used to replace \"stuck\" or evicted transactions. It only works on transactions which are not included in a block and are not currently in the mempool. It has no effect on transactions which are already abandoned.",
             "description": [
                 "",
                 "> lbrycrd-cli abandontransaction \"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"",
@@ -3396,8 +4663,32 @@
                 ]
             }
         },
+        "abortrescan": {
+            "summary": "Stops current wallet rescan triggered by an RPC call, e.g. by an importprivkey call.",
+            "description": [
+                "",
+                "",
+                "Import a private key",
+                "> lbrycrd-cli importprivkey \"mykey\"",
+                "",
+                "Abort the running wallet rescan",
+                "> lbrycrd-cli abortrescan ",
+                "",
+                "As a JSON-RPC call",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"abortrescan\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        },
         "addmultisigaddress": {
-            "summary": "Add a nrequired-to-sign multisignature address to the wallet. Each key is a Bitcoin address or hex-encoded public key. If 'account' is specified (DEPRECATED), assign address to that account.",
+            "summary": "Add a nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup. Each key is a Bitcoin address or hex-encoded public key. This functionality is only intended for use with non-watchonly addresses. See `importaddress` for watchonly p2sh address support. If 'label' is specified, assign address to that label.",
             "description": [
                 "",
                 "",
@@ -3418,23 +4709,36 @@
                         "type": "number",
                         "description": "The number of required signatures out of the n keys or addresses."
                     },
-                    "keysobject": {
+                    "keys": {
                         "type": "string",
-                        "description": "A json array of lbrycrd addresses or hex-encoded public keys [ \"address\" (string) lbrycrd address or hex-encoded public key ..., ]"
+                        "description": "A json array of bitcoin addresses or hex-encoded public keys [ \"address\" (string) bitcoin address or hex-encoded public key ..., ]"
                     },
-                    "account": {
+                    "label": {
                         "type": "string",
-                        "description": "DEPRECATED. An account to assign the addresses to."
+                        "description": "A label to assign the addresses to."
+                    },
+                    "address_type": {
+                        "type": "string",
+                        "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -addresstype."
                     }
                 },
                 "required": [
                     "nrequired",
-                    "keysobject"
+                    "keys"
                 ]
             },
             "result": {
-                "type": "string",
-                "description": "A lbrycrd address associated with the keys."
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "string",
+                        "description": "The value of the new multisig address."
+                    },
+                    "redeemScript": {
+                        "type": "string",
+                        "description": "The string value of the hex-encoded redemption script."
+                    }
+                }
             }
         },
         "backupwallet": {
@@ -3461,8 +4765,112 @@
                 ]
             }
         },
+        "bumpfee": {
+            "summary": "Bumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B. An opt-in RBF transaction with the given txid must be in the wallet. The command will pay the additional fee by decreasing (or perhaps removing) its change output. If the change output is not big enough to cover the increased fee, the command will currently fail instead of adding new inputs to compensate. (A future implementation could improve this.) The command will fail if the wallet or mempool contains a transaction that spends one of T's outputs. By default, the new fee will be calculated automatically using estimatesmartfee. The user can specify a confirmation target for estimatesmartfee. Alternatively, the user can specify totalFee, or use RPC settxfee to set a higher fee rate. At a minimum, the new fee rate must be high enough to pay an additional new relay fee (incrementalfee returned by getnetworkinfo) to enter the node's mempool.",
+            "description": [
+                "",
+                "",
+                "Bump the fee, get the new transaction's txid",
+                "> lbrycrd-cli bumpfee <txid>",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "txid": {
+                        "type": "string",
+                        "description": "The txid to be bumped"
+                    },
+                    "options": {
+                        "type": "object",
+                        "properties": {
+                            "confTarget": {
+                                "type": "number",
+                                "description": "Confirmation target (in blocks)"
+                            },
+                            "totalFee": {
+                                "type": "number",
+                                "description": "Total fee (NOT feerate) to pay, in satoshis."
+                            },
+                            "replaceable": {
+                                "type": "boolean",
+                                "description": "Whether the new transaction should still be"
+                            },
+                            "estimate_mode": {
+                                "type": "string",
+                                "description": "The fee estimate mode, must be one of:"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "txid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "txid": {
+                        "type": "string",
+                        "description": "The id of the new transaction"
+                    },
+                    "origfee": {
+                        "type": "number",
+                        "description": "Fee of the replaced transaction"
+                    },
+                    "fee": {
+                        "type": "number",
+                        "description": "Fee of the new transaction"
+                    }
+                }
+            }
+        },
+        "createwallet": {
+            "summary": "Creates and loads a new wallet.",
+            "description": [
+                "",
+                "> lbrycrd-cli createwallet \"testwallet\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createwallet\", \"params\": [\"testwallet\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "wallet_name": {
+                        "type": "string",
+                        "description": "The name for the new wallet. If this is a path, the wallet will be created at the path location."
+                    },
+                    "disable_private_keys": {
+                        "type": "boolean",
+                        "description": "Disable the possibility of private keys (only watchonlys are possible in this mode)."
+                    }
+                },
+                "required": [
+                    "wallet_name"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The wallet name if created successfully. If the wallet was created using a full path, the wallet_name will be the full path."
+                    },
+                    "warning": {
+                        "type": "string",
+                        "description": "Warning message if wallet was not loaded cleanly."
+                    }
+                }
+            }
+        },
         "dumpprivkey": {
-            "summary": "Reveals the private key corresponding to 'lbrycrdaddress'. Then the importprivkey can be used with this output",
+            "summary": "Reveals the private key corresponding to 'address'. Then the importprivkey can be used with this output",
             "description": [
                 "",
                 "> lbrycrd-cli dumpprivkey \"myaddress\"",
@@ -3476,13 +4884,13 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address for the private key"
+                        "description": "The bitcoin address for the private key"
                     }
                 },
                 "required": [
-                    "lbrycrdaddress"
+                    "address"
                 ]
             },
             "result": {
@@ -3491,7 +4899,7 @@
             }
         },
         "dumpwallet": {
-            "summary": "Dumps all wallet keys in a human-readable format.",
+            "summary": "Dumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files. Imported scripts are included in the dumpfile, but corresponding BIP173 addresses, etc. may not be added automatically by importwallet. Note that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by only backing up the seed itself, and must be backed up too (e.g. ensure you back up the whole dumpfile).",
             "description": [
                 "",
                 "> lbrycrd-cli dumpwallet \"test\"",
@@ -3506,7 +4914,7 @@
                 "properties": {
                     "filename": {
                         "type": "string",
-                        "description": "The filename"
+                        "description": "The filename with path (either absolute or relative to bitcoind)"
                     }
                 },
                 "required": [
@@ -3515,18 +4923,18 @@
             }
         },
         "encryptwallet": {
-            "summary": "Encrypts the wallet with 'passphrase'. This is for first time encryption. After this, any calls that interact with private keys such as sending or signing will require the passphrase to be set prior the making these calls. Use the walletpassphrase call for this, and then walletlock call. If the wallet is already encrypted, use the walletpassphrasechange call. Note that this will shutdown the server.",
+            "summary": "Encrypts the wallet with 'passphrase'. This is for first time encryption. After this, any calls that interact with private keys such as sending or signing will require the passphrase to be set prior the making these calls. Use the walletpassphrase call for this, and then walletlock call. If the wallet is already encrypted, use the walletpassphrasechange call.",
             "description": [
                 "",
                 "",
-                "Encrypt you wallet",
+                "Encrypt your wallet",
                 "> lbrycrd-cli encryptwallet \"my pass phrase\"",
                 "",
-                "Now set the passphrase to use the wallet, such as for signing or sending LBC",
+                "Now set the passphrase to use the wallet, such as for signing or sending bitcoin",
                 "> lbrycrd-cli walletpassphrase \"my pass phrase\"",
                 "",
-                "Now we can so something like sign",
-                "> lbrycrd-cli signmessage \"lbrycrdaddress\" \"test message\"",
+                "Now we can do something like sign",
+                "> lbrycrd-cli signmessage \"address\" \"test message\"",
                 "",
                 "Now lock the wallet again by removing the passphrase",
                 "> lbrycrd-cli walletlock ",
@@ -3555,8 +4963,8 @@
             "summary": "DEPRECATED. Returns the account associated with the given address.",
             "description": [
                 "",
-                "> lbrycrd-cli getaccount \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\"",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaccount\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli getaccount \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaccount\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -3565,13 +4973,13 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address for account lookup."
+                        "description": "The bitcoin address for account lookup."
                     }
                 },
                 "required": [
-                    "lbrycrdaddress"
+                    "address"
                 ]
             },
             "result": {
@@ -3597,7 +5005,7 @@
                 "properties": {
                     "account": {
                         "type": "string",
-                        "description": "The account name for the address. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created and a new address created if there is no account by the given name."
+                        "description": "The account for the address. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created and a new address created if there is no account by the given name."
                     }
                 },
                 "required": [
@@ -3606,7 +5014,7 @@
             },
             "result": {
                 "type": "string",
-                "description": "The account lbrycrd address"
+                "description": "The account bitcoin address"
             }
         },
         "getaddressesbyaccount": {
@@ -3637,23 +5045,85 @@
                 "items": {
                     "type": "object",
                     "properties": {
-                        "lbrycrdaddress": {
+                        "address": {
                             "type": "string",
-                            "description": "a lbrycrd address associated with the given account"
+                            "description": "a bitcoin address associated with the given account"
                         }
                     }
                 }
             }
         },
+        "getaddressesbylabel": {
+            "summary": "Returns the list of addresses assigned the specified label.",
+            "description": [
+                "",
+                "> lbrycrd-cli getaddressesbylabel \"tabby\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddressesbylabel\", \"params\": [\"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "The label."
+                    }
+                },
+                "required": [
+                    "label"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "object",
+                        "properties": {
+                            "purpose": {
+                                "type": "string",
+                                "description": "Purpose of address (\"send\" for sending address, \"receive\" for receiving address)"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "getaddressinfo": {
+            "summary": "Return information about the given bitcoin address. Some information requires the address to be in the wallet.",
+            "description": [
+                "",
+                "> lbrycrd-cli getaddressinfo \"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddressinfo\", \"params\": [\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "string",
+                        "description": "The bitcoin address to get the information of."
+                    }
+                },
+                "required": [
+                    "address"
+                ]
+            }
+        },
         "getbalance": {
-            "summary": "If account is not specified, returns the server's total available balance. If account is specified (DEPRECATED), returns the balance in the account. Note that the account \"\" is not the same as leaving the parameter out. The server total may be different to the balance in the default \"\" account.",
+            "summary": "If account is not specified, returns the server's total available balance. The available balance is what the wallet considers currently spendable, and is thus affected by options which limit spendability such as -spendzeroconfchange. If account is specified (DEPRECATED), returns the balance in the account. Note that the account \"\" is not the same as leaving the parameter out. The server total may be different to the balance in the default \"\" account.",
             "description": [
                 "",
                 "",
-                "The total amount in the wallet",
+                "The total amount in the wallet with 1 or more confirmations",
                 "> lbrycrd-cli getbalance ",
                 "",
-                "The total amount in the wallet at least 5 blocks confirmed",
+                "The total amount in the wallet at least 6 blocks confirmed",
                 "> lbrycrd-cli getbalance \"*\" 6",
                 "",
                 "As a json rpc call",
@@ -3668,16 +5138,19 @@
                 "properties": {
                     "account": {
                         "type": "string",
-                        "description": "DEPRECATED. The selected account, or \"*\" for entire wallet. It may be the default account using \"\"."
+                        "description": "DEPRECATED. This argument will be removed in V0."
+                    },
+                    "To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. The account string may be given as a\n                     specific account name to find the balance associated with wallet keys in\n                     a named account, or as the empty string": {
+                        "type": null,
+                        "description": "to find the balance associated with wallet keys not in any named account, or as \"*\" to find the balance associated with all wallet keys regardless of account. When this option is specified, it calculates the balance in a different way than when it is not specified, and which can count spends twice when there are conflicting pending transactions (such as those created by the bumpfee command), temporarily resulting in low or even negative balances. In general, account balance calculation is not considered reliable and has resulted in confusing outcomes, so it is recommended to avoid passing this argument."
                     },
                     "minconf": {
                         "type": "number",
-                        "description": "Only include transactions confirmed at least this many times.",
-                        "default": 1
+                        "description": "Only include transactions confirmed at least this many times. The default is 1 if an account is provided or 0 if no account is provided"
                     },
-                    "includeWatchonly": {
+                    "include_watchonly": {
                         "type": "boolean",
-                        "description": "Also include balance in watchonly addresses (see 'importaddress')",
+                        "description": "Also include balance in watch-only addresses (see 'importaddress')",
                         "default": false
                     }
                 },
@@ -3689,7 +5162,7 @@
             }
         },
         "getnewaddress": {
-            "summary": "Returns a new Bitcoin address for receiving payments. If 'account' is specified (DEPRECATED), it is added to the address book so payments received with the address will be credited to 'account'.",
+            "summary": "Returns a new Bitcoin address for receiving payments. If 'label' is specified, it is added to the address book so payments received with the address will be associated with 'label'.",
             "description": [
                 "",
                 "> lbrycrd-cli getnewaddress ",
@@ -3702,16 +5175,20 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "account": {
+                    "label": {
                         "type": "string",
-                        "description": "DEPRECATED. The account name for the address to be linked to. If not provided, the default account \"\" is used. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created if there is no account by the given name."
+                        "description": "The label name for the address to be linked to. If not provided, the default label \"\" is used. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name."
+                    },
+                    "address_type": {
+                        "type": "string",
+                        "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -addresstype."
                     }
                 },
                 "required": []
             },
             "result": {
                 "type": "string",
-                "description": "The new lbrycrd address"
+                "description": "The new bitcoin address"
             }
         },
         "getrawchangeaddress": {
@@ -3727,7 +5204,12 @@
             ],
             "params": {
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "address_type": {
+                        "type": "string",
+                        "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype."
+                    }
+                },
                 "required": []
             },
             "result": {
@@ -3735,65 +5217,22 @@
                 "description": "The address"
             }
         },
-        "getreceivedbyaccount": {
-            "summary": "DEPRECATED. Returns the total amount received by addresses with <account> in transactions with at least [minconf] confirmations.",
-            "description": [
-                "",
-                "",
-                "Amount received by the default account with at least 1 confirmation",
-                "> lbrycrd-cli getreceivedbyaccount \"\"",
-                "",
-                "Amount received at the tabby account including unconfirmed amounts with zero confirmations",
-                "> lbrycrd-cli getreceivedbyaccount \"tabby\" 0",
-                "",
-                "The amount with at least 6 confirmation, very safe",
-                "> lbrycrd-cli getreceivedbyaccount \"tabby\" 6",
-                "",
-                "As a json rpc call",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbyaccount\", \"params\": [\"tabby\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
-                ""
-            ],
-            "tags": [
-                "Wallet"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {
-                    "account": {
-                        "type": "string",
-                        "description": "The selected account, may be the default account using \"\"."
-                    },
-                    "minconf": {
-                        "type": "number",
-                        "description": "Only include transactions confirmed at least this many times.",
-                        "default": 1
-                    }
-                },
-                "required": [
-                    "account"
-                ]
-            },
-            "result": {
-                "type": "number",
-                "description": "The total amount in LBC received for this account."
-            }
-        },
         "getreceivedbyaddress": {
-            "summary": "Returns the total amount received by the given lbrycrdaddress in transactions with at least minconf confirmations.",
+            "summary": "Returns the total amount received by the given address in transactions with at least minconf confirmations.",
             "description": [
                 "",
                 "",
                 "The amount from transactions with at least 1 confirmation",
-                "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\"",
+                "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"",
                 "",
                 "The amount including unconfirmed transactions, zero confirmations",
-                "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" 0",
+                "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 0",
                 "",
-                "The amount with at least 6 confirmation, very safe",
-                "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" 6",
+                "The amount with at least 6 confirmations",
+                "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 6",
                 "",
                 "As a json rpc call",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbyaddress\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbyaddress\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -3802,9 +5241,9 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address for transactions."
+                        "description": "The bitcoin address for transactions."
                     },
                     "minconf": {
                         "type": "number",
@@ -3813,12 +5252,55 @@
                     }
                 },
                 "required": [
-                    "lbrycrdaddress"
+                    "address"
                 ]
             },
             "result": {
                 "type": "number",
                 "description": "The total amount in LBC received at this address."
+            }
+        },
+        "getreceivedbylabel": {
+            "summary": "Returns the total amount received by addresses with <label> in transactions with at least [minconf] confirmations.",
+            "description": [
+                "",
+                "",
+                "Amount received by the default label with at least 1 confirmation",
+                "> lbrycrd-cli getreceivedbylabel \"\"",
+                "",
+                "Amount received at the tabby label including unconfirmed amounts with zero confirmations",
+                "> lbrycrd-cli getreceivedbylabel \"tabby\" 0",
+                "",
+                "The amount with at least 6 confirmations",
+                "> lbrycrd-cli getreceivedbylabel \"tabby\" 6",
+                "",
+                "As a json rpc call",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbylabel\", \"params\": [\"tabby\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "The selected label, may be the default label using \"\"."
+                    },
+                    "minconf": {
+                        "type": "number",
+                        "description": "Only include transactions confirmed at least this many times.",
+                        "default": 1
+                    }
+                },
+                "required": [
+                    "label"
+                ]
+            },
+            "result": {
+                "type": "number",
+                "description": "The total amount in LBC received for this label."
             }
         },
         "gettransaction": {
@@ -3840,9 +5322,9 @@
                         "type": "string",
                         "description": "The transaction id"
                     },
-                    "includeWatchonly": {
+                    "include_watchonly": {
                         "type": "boolean",
-                        "description": "Whether to include watchonly addresses in balance calculation and details[]",
+                        "description": "Whether to include watch-only addresses in balance calculation and details[]",
                         "default": false
                     }
                 },
@@ -3856,6 +5338,10 @@
                     "amount": {
                         "type": "number",
                         "description": "The transaction amount in LBC"
+                    },
+                    "fee": {
+                        "type": "number",
+                        "description": "The amount of the fee in LBC. This is negative and only available for the  'send' category of transactions."
                     },
                     "confirmations": {
                         "type": "number",
@@ -3896,11 +5382,11 @@
                             "properties": {
                                 "account": {
                                     "type": "string",
-                                    "description": "DEPRECATED. The account name involved in the transaction, can be \"\" for the default account."
+                                    "description": "DEPRECATED. This field will be removed in a V0.18. To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The account name involved in the transaction, can be \"\" for the default account."
                                 },
                                 "address": {
                                     "type": "string",
-                                    "description": "The lbrycrd address involved in the transaction"
+                                    "description": "The bitcoin address involved in the transaction"
                                 },
                                 "category": {
                                     "type": "string",
@@ -3917,6 +5403,14 @@
                                 "vout": {
                                     "type": "number",
                                     "description": "the vout value"
+                                },
+                                "fee": {
+                                    "type": "number",
+                                    "description": "The amount of the fee in LBC. This is negative and only available for the  'send' category of transactions."
+                                },
+                                "abandoned": {
+                                    "type": "boolean",
+                                    "description": "'true' if the transaction has been abandoned (inputs are respendable). Only available for the  'send' category of transactions."
                                 }
                             }
                         }
@@ -3959,6 +5453,10 @@
             "result": {
                 "type": "object",
                 "properties": {
+                    "walletname": {
+                        "type": "string",
+                        "description": "the wallet name"
+                    },
                     "walletversion": {
                         "type": "number",
                         "description": "the wallet version"
@@ -3981,11 +5479,15 @@
                     },
                     "keypoololdest": {
                         "type": "number",
-                        "description": "the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool"
+                        "description": "the timestamp (seconds since Unix epoch) of the oldest pre-generated key in the key pool"
                     },
                     "keypoolsize": {
                         "type": "number",
-                        "description": "how many new keys are pre-generated"
+                        "description": "how many new keys are pre-generated (only counts external keys)"
+                    },
+                    "keypoolsize_hd_internal": {
+                        "type": "number",
+                        "description": "how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)"
                     },
                     "unlocked_until": {
                         "type": "number",
@@ -3994,23 +5496,35 @@
                     "paytxfee": {
                         "type": "number",
                         "description": "the transaction fee configuration, set in LBC/kB"
+                    },
+                    "hdseedid": {
+                        "type": "string",
+                        "description": "the Hash160 of the HD seed (only present when HD is enabled)"
+                    },
+                    "hdmasterkeyid": {
+                        "type": "string",
+                        "description": "alias for hdseedid retained for backwards-compatibility. Will be removed in V0.18."
+                    },
+                    "private_keys_enabled": {
+                        "type": "boolean",
+                        "description": "false if privatekeys are disabled for this wallet (enforced watch-only wallet)"
                     }
                 }
             }
         },
         "importaddress": {
-            "summary": "Adds a script (in hex) or address that can be watched as if it were in your wallet but cannot be used to spend.",
+            "summary": "Adds an address or script (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.",
             "description": [
                 "",
                 "",
-                "Import a script with rescan",
-                "> lbrycrd-cli importaddress \"myscript\"",
+                "Import an address with rescan",
+                "> lbrycrd-cli importaddress \"myaddress\"",
                 "",
                 "Import using a label without rescan",
-                "> lbrycrd-cli importaddress \"myscript\" \"testing\" false",
+                "> lbrycrd-cli importaddress \"myaddress\" \"testing\" false",
                 "",
                 "As a JSON-RPC call",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"importaddress\", \"params\": [\"myscript\", \"testing\", false] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"importaddress\", \"params\": [\"myaddress\", \"testing\", false] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -4019,9 +5533,9 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "script": {
+                    "address": {
                         "type": "string",
-                        "description": "The hex-encoded script (or address)"
+                        "description": "The Bitcoin address (or hex-encoded script)"
                     },
                     "label": {
                         "type": "string",
@@ -4035,17 +5549,48 @@
                     },
                     "p2sh": {
                         "type": "boolean",
-                        "description": "Add the P2SH version of the script as well Note: This call can take minutes to complete if rescan is true. If you have the full public key, you should call importpubkey instead of this.",
+                        "description": "Add the P2SH version of the script as well Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported address exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes. If you have the full public key, you should call importpubkey instead of this. Note: If you import a non-standard raw script in hex form, outputs sending to it will be treated as change, and not show up in many RPCs.",
                         "default": false
                     }
                 },
                 "required": [
-                    "script"
+                    "address"
+                ]
+            }
+        },
+        "importmulti": {
+            "summary": "Import addresses/scripts (with private or public keys, redeem script (P2SH)), rescanning all addresses in one-shot-only (rescan can be disabled via options). Requires a new wallet backup.",
+            "description": [
+                "",
+                "> lbrycrd-cli importmulti '[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }, { \"scriptPubKey\": { \"address\": \"<my 2nd address>\" }, \"label\": \"example 2\", \"timestamp\": 1455191480 }]'",
+                "> lbrycrd-cli importmulti '[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }]' '{ \"rescan\": false}'",
+                "",
+                "Response is an array with the same size as the input that has the execution result :",
+                "  [{ \"success\": true } , { \"success\": false, \"error\": { \"code\": -1, \"message\": \"Internal Server Error\"} }, ... ]",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "requests": {
+                        "type": "array",
+                        "description": "Data to be imported\n  [     (array of json objects)\n    {\n      \"scriptPubKey\": \"<script>\" | { \"address\":\"<address>\" }, (string / json, required) Type of scriptPubKey (string for script, json for address)\n      \"timestamp\": timestamp | \"now\"                        , (integer / string, required) Creation time of the key in seconds since epoch (Jan 1 1970 GMT),\n                                                              or the string \"now\" to substitute the current synced blockchain time. The timestamp of the oldest\n                                                              key will determine how far back blockchain rescans need to begin for missing wallet transactions.\n                                                              \"now\" can be specified to bypass scanning, for keys which are known to never have been used, and\n                                                              0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest key\n                                                              creation time of all keys being imported by the importmulti call will be scanned.\n      \"redeemscript\": \"<script>\"                            , (string, optional) Allowed only if the scriptPubKey is a P2SH address or a P2SH scriptPubKey\n      \"pubkeys\": [\"<pubKey>\", ... ]                         , (array, optional) Array of strings giving pubkeys that must occur in the output or redeemscript\n      \"keys\": [\"<key>\", ... ]                               , (array, optional) Array of strings giving private keys whose corresponding public keys must occur in the output or redeemscript\n      \"internal\": <true>                                    , (boolean, optional, default: false) Stating whether matching outputs should be treated as not incoming payments aka change\n      \"watchonly\": <true>                                   , (boolean, optional, default: false) Stating whether matching outputs should be considered watched even when they're not spendable, only allowed if keys are empty\n      \"label\": <label>                                      , (string, optional, default: '') Label to assign to the address (aka account name, for now), only allowed with internal=false\n    }\n  ,...\n  ]"
+                    },
+                    "options": {
+                        "type": "json",
+                        "description": "{ \"rescan\": <false>, (boolean, optional, default: true) Stating if should rescan the blockchain after all imports } Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported keys, addresses or scripts exists but related transactions are still missing."
+                    }
+                },
+                "required": [
+                    "requests"
                 ]
             }
         },
         "importprivkey": {
-            "summary": "Adds a private key (as returned by dumpprivkey) to your wallet.",
+            "summary": "Adds a private key (as returned by dumpprivkey) to your wallet. Requires a new wallet backup. Hint: use importmulti to import more than one private key.",
             "description": [
                 "",
                 "",
@@ -4058,6 +5603,9 @@
                 "Import using a label and without rescan",
                 "> lbrycrd-cli importprivkey \"mykey\" \"testing\" false",
                 "",
+                "Import using default blank label and without rescan",
+                "> lbrycrd-cli importprivkey \"mykey\" \"\" false",
+                "",
                 "As a JSON-RPC call",
                 "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"importprivkey\", \"params\": [\"mykey\", \"testing\", false] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
@@ -4068,7 +5616,7 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdprivkey": {
+                    "privkey": {
                         "type": "string",
                         "description": "The private key (see dumpprivkey)"
                     },
@@ -4079,12 +5627,12 @@
                     },
                     "rescan": {
                         "type": "boolean",
-                        "description": "Rescan the wallet for transactions Note: This call can take minutes to complete if rescan is true.",
+                        "description": "Rescan the wallet for transactions Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported key exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.",
                         "default": true
                     }
                 },
                 "required": [
-                    "lbrycrdprivkey"
+                    "privkey"
                 ]
             }
         },
@@ -4104,10 +5652,6 @@
                     "txoutproof": {
                         "type": "string",
                         "description": "The hex output from gettxoutproof that contains the transaction"
-                    },
-                    "label": {
-                        "type": "string",
-                        "description": "An optional label"
                     }
                 },
                 "required": [
@@ -4117,7 +5661,7 @@
             }
         },
         "importpubkey": {
-            "summary": "Adds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend.",
+            "summary": "Adds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.",
             "description": [
                 "",
                 "",
@@ -4148,7 +5692,7 @@
                     },
                     "rescan": {
                         "type": "boolean",
-                        "description": "Rescan the wallet for transactions Note: This call can take minutes to complete if rescan is true.",
+                        "description": "Rescan the wallet for transactions Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported pubkey exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.",
                         "default": true
                     }
                 },
@@ -4158,7 +5702,7 @@
             }
         },
         "importwallet": {
-            "summary": "Imports keys from a wallet dump file (see dumpwallet).",
+            "summary": "Imports keys from a wallet dump file (see dumpwallet). Requires a new wallet backup to include imported keys.",
             "description": [
                 "",
                 "",
@@ -4240,9 +5784,9 @@
                         "description": "Only include transactions with at least this many confirmations",
                         "default": 1
                     },
-                    "includeWatchonly": {
+                    "include_watchonly": {
                         "type": "boolean",
-                        "description": "Include balances in watchonly addresses (see 'importaddress')",
+                        "description": "Include balances in watch-only addresses (see 'importaddress')",
                         "default": false
                     }
                 },
@@ -4278,6 +5822,44 @@
                 "type": "array",
                 "items": {
                     "type": "array"
+                }
+            }
+        },
+        "listlabels": {
+            "summary": "Returns the list of all labels, or labels that are assigned to addresses with a specific purpose.",
+            "description": [
+                "",
+                "",
+                "List all labels",
+                "> lbrycrd-cli listlabels ",
+                "",
+                "List labels that have receiving addresses",
+                "> lbrycrd-cli listlabels receive",
+                "",
+                "List labels that have sending addresses",
+                "> lbrycrd-cli listlabels send",
+                "",
+                "As json rpc call",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listlabels\", \"params\": [receive] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "purpose": {
+                        "type": "string",
+                        "description": "Address purpose to list labels for ('send','receive'). An empty string is the same as not providing this argument."
+                    }
+                },
+                "required": []
+            },
+            "result": {
+                "type": "array",
+                "items": {
+                    "type": "object"
                 }
             }
         },
@@ -4327,68 +5909,6 @@
                 }
             }
         },
-        "listreceivedbyaccount": {
-            "summary": "DEPRECATED. List balances by account.",
-            "description": [
-                "",
-                "> lbrycrd-cli listreceivedbyaccount ",
-                "> lbrycrd-cli listreceivedbyaccount 6 true",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbyaccount\", \"params\": [6, true, true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
-                ""
-            ],
-            "tags": [
-                "Wallet"
-            ],
-            "params": {
-                "type": "object",
-                "properties": {
-                    "minconf": {
-                        "type": "number",
-                        "description": "The minimum number of confirmations before payments are included.",
-                        "default": 1
-                    },
-                    "includeempty": {
-                        "type": "boolean",
-                        "description": "Whether to include accounts that haven't received any payments.",
-                        "default": false
-                    },
-                    "includeWatchonly": {
-                        "type": "boolean",
-                        "description": "Whether to include watchonly addresses (see 'importaddress').",
-                        "default": false
-                    }
-                },
-                "required": []
-            },
-            "result": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "involvesWatchonly": {
-                            "type": "boolean",
-                            "description": "Only returned if imported addresses were involved in transaction"
-                        },
-                        "account": {
-                            "type": "string",
-                            "description": "The account name of the receiving account"
-                        },
-                        "amount": {
-                            "type": "number",
-                            "description": "The total amount received by addresses with this account"
-                        },
-                        "confirmations": {
-                            "type": "number",
-                            "description": "The number of confirmations of the most recent transaction included"
-                        },
-                        "label": {
-                            "type": "string",
-                            "description": "A comment for the address/transaction, if any"
-                        }
-                    }
-                }
-            }
-        },
         "listreceivedbyaddress": {
             "summary": "List balances by receiving address.",
             "description": [
@@ -4396,6 +5916,7 @@
                 "> lbrycrd-cli listreceivedbyaddress ",
                 "> lbrycrd-cli listreceivedbyaddress 6 true",
                 "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbyaddress\", \"params\": [6, true, true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbyaddress\", \"params\": [6, true, true, \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -4409,15 +5930,19 @@
                         "description": "The minimum number of confirmations before payments are included.",
                         "default": 1
                     },
-                    "includeempty": {
+                    "include_empty": {
                         "type": "boolean",
                         "description": "Whether to include addresses that haven't received any payments.",
                         "default": false
                     },
-                    "includeWatchonly": {
+                    "include_watchonly": {
                         "type": "boolean",
-                        "description": "Whether to include watchonly addresses (see 'importaddress').",
+                        "description": "Whether to include watch-only addresses (see 'importaddress').",
                         "default": false
+                    },
+                    "address_filter": {
+                        "type": "string",
+                        "description": "If present, only return information on this address."
                     }
                 },
                 "required": []
@@ -4437,7 +5962,7 @@
                         },
                         "account": {
                             "type": "string",
-                            "description": "DEPRECATED. The account of the receiving address. The default account is \"\"."
+                            "description": "DEPRECATED. Backwards compatible alias for label."
                         },
                         "amount": {
                             "type": "number",
@@ -4449,14 +5974,82 @@
                         },
                         "label": {
                             "type": "string",
-                            "description": "A comment for the address/transaction, if any"
+                            "description": "The label of the receiving address. The default label is \"\"."
+                        },
+                        "txids": {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "listreceivedbylabel": {
+            "summary": "List received transactions by label.",
+            "description": [
+                "",
+                "> lbrycrd-cli listreceivedbylabel ",
+                "> lbrycrd-cli listreceivedbylabel 6 true",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbylabel\", \"params\": [6, true, true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "minconf": {
+                        "type": "number",
+                        "description": "The minimum number of confirmations before payments are included.",
+                        "default": 1
+                    },
+                    "include_empty": {
+                        "type": "boolean",
+                        "description": "Whether to include labels that haven't received any payments.",
+                        "default": false
+                    },
+                    "include_watchonly": {
+                        "type": "boolean",
+                        "description": "Whether to include watch-only addresses (see 'importaddress').",
+                        "default": false
+                    }
+                },
+                "required": []
+            },
+            "result": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "involvesWatchonly": {
+                            "type": "boolean",
+                            "description": "Only returned if imported addresses were involved in transaction"
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": "DEPRECATED. Backwards compatible alias for label."
+                        },
+                        "amount": {
+                            "type": "number",
+                            "description": "The total amount received by addresses with this label"
+                        },
+                        "confirmations": {
+                            "type": "number",
+                            "description": "The number of confirmations of the most recent transaction included"
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "The label of the receiving address. The default label is \"\"."
                         }
                     }
                 }
             }
         },
         "listsinceblock": {
-            "summary": "Get all transactions in blocks since block [blockhash], or all transactions if omitted",
+            "summary": "Get all transactions in blocks since block [blockhash], or all transactions if omitted. If \"blockhash\" is no longer a part of the main chain, transactions from the fork point onward are included. Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.",
             "description": [
                 "",
                 "> lbrycrd-cli listsinceblock ",
@@ -4474,14 +6067,20 @@
                         "type": "string",
                         "description": "The block hash to list transactions since"
                     },
-                    "target-confirmations": {
+                    "target_confirmations": {
                         "type": "number",
-                        "description": "The confirmations required, must be 1 or more"
+                        "description": "Return the nth block hash from the main chain. e.g. 1 would mean the best block hash. Note: this is not used as a filter, but only affects [lastblock] in the return value",
+                        "default": 1
                     },
-                    "includeWatchonly": {
+                    "include_watchonly": {
                         "type": "boolean",
-                        "description": "Include transactions to watchonly addresses (see 'importaddress')",
+                        "description": "Include transactions to watch-only addresses (see 'importaddress')",
                         "default": false
+                    },
+                    "include_removed": {
+                        "type": "boolean",
+                        "description": "Show transactions that were removed due to a reorg in the \"removed\" array (not guaranteed to work on pruned nodes)",
+                        "default": true
                     }
                 },
                 "required": []
@@ -4496,11 +6095,11 @@
                             "properties": {
                                 "account": {
                                     "type": "string",
-                                    "description": "DEPRECATED. The account name associated with the transaction. Will be \"\" for the default account."
+                                    "description": "DEPRECATED. This field will be removed in V0.18. To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The account name associated with the transaction. Will be \"\" for the default account."
                                 },
                                 "address": {
                                     "type": "string",
-                                    "description": "The lbrycrd address of the transaction. Not present for move transactions (category = move)."
+                                    "description": "The bitcoin address of the transaction. Not present for move transactions (category = move)."
                                 },
                                 "category": {
                                     "type": "string",
@@ -4520,7 +6119,7 @@
                                 },
                                 "confirmations": {
                                     "type": "number",
-                                    "description": "The number of confirmations for the transaction. Available for 'send' and 'receive' category of transactions."
+                                    "description": "The number of confirmations for the transaction. Available for 'send' and 'receive' category of transactions. When it's < 0, it means the transaction conflicted that many blocks ago."
                                 },
                                 "blockhash": {
                                     "type": "string",
@@ -4546,6 +6145,14 @@
                                     "type": "number",
                                     "description": "The time received in seconds since epoch (Jan 1 1970 GMT). Available for 'send' and 'receive' category of transactions."
                                 },
+                                "bip125-replaceable": {
+                                    "type": "string",
+                                    "description": "Whether this transaction could be replaced due to BIP125 (replace-by-fee); may be unknown for unconfirmed transactions not in the mempool"
+                                },
+                                "abandoned": {
+                                    "type": "boolean",
+                                    "description": "'true' if the transaction has been abandoned (inputs are respendable). Only available for the 'send' category of transactions."
+                                },
                                 "comment": {
                                     "type": "string",
                                     "description": "If a comment is associated with the transaction."
@@ -4561,9 +6168,15 @@
                             }
                         }
                     },
+                    "removed": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
                     "lastblock": {
                         "type": "string",
-                        "description": "The hash of the last block"
+                        "description": "The hash of the block (target_confirmations-1) from the best block on the main chain. This is typically used to feed back into listsinceblock the next time you call it. So you would generally use a target_confirmations of say 6, so you will be continually re-notified of transactions until they've reached 6 confirmations plus any new ones"
                     }
                 }
             }
@@ -4591,25 +6204,31 @@
                 "properties": {
                     "account": {
                         "type": "string",
-                        "description": "DEPRECATED. The account name. Should be \"*\"."
+                        "description": "DEPRECATED. This argument will be removed in V0."
+                    },
+                    "null": {
+                        "type": "object",
+                        "description": "The account name. Should be \"*\"."
                     },
                     "count": {
                         "type": "number",
                         "description": "The number of transactions to return",
                         "default": 10
                     },
-                    "from": {
+                    "skip": {
                         "type": "number",
                         "description": "The number of transactions to skip",
                         "default": 0
                     },
-                    "includeWatchonly": {
+                    "include_watchonly": {
                         "type": "boolean",
-                        "description": "Include transactions to watchonly addresses (see 'importaddress')",
+                        "description": "Include transactions to watch-only addresses (see 'importaddress')",
                         "default": false
                     }
                 },
-                "required": []
+                "required": [
+                    null
+                ]
             },
             "result": {
                 "type": "array",
@@ -4618,11 +6237,11 @@
                     "properties": {
                         "account": {
                             "type": "string",
-                            "description": "DEPRECATED. The account name associated with the transaction.  It will be \"\" for the default account."
+                            "description": "DEPRECATED. This field will be removed in V0.18. The account name associated with the transaction.  It will be \"\" for the default account."
                         },
                         "address": {
                             "type": "string",
-                            "description": "The lbrycrd address of the transaction. Not present for  move transactions (category = move)."
+                            "description": "The bitcoin address of the transaction. Not present for  move transactions (category = move)."
                         },
                         "category": {
                             "type": "string",
@@ -4632,6 +6251,10 @@
                             "type": "number",
                             "description": "The amount in LBC. This is negative for the 'send' category, and for the 'move' category for moves outbound. It is positive for the 'receive' category, and for the 'move' category for inbound funds."
                         },
+                        "label": {
+                            "type": "string",
+                            "description": "A comment for the address/transaction, if any"
+                        },
                         "vout": {
                             "type": "number",
                             "description": "the vout value"
@@ -4639,10 +6262,6 @@
                         "fee": {
                             "type": "number",
                             "description": "The amount of the fee in LBC. This is negative and only available for the  'send' category of transactions."
-                        },
-                        "abandoned": {
-                            "type": "boolean",
-                            "description": "'true' if the transaction has been abandoned (inputs are respendable)."
                         },
                         "confirmations": {
                             "type": "number",
@@ -4680,29 +6299,31 @@
                             "type": "string",
                             "description": "If a comment is associated with the transaction."
                         },
-                        "label": {
-                            "type": "string",
-                            "description": "A comment for the address/transaction, if any"
-                        },
                         "otheraccount": {
                             "type": "string",
-                            "description": "For the 'move' category of transactions, the account the funds came  from (for receiving funds, positive amounts), or went to (for sending funds, negative amounts)."
+                            "description": "DEPRECATED. This field will be removed in V0.18. For the 'move' category of transactions, the account the funds came  from (for receiving funds, positive amounts), or went to (for sending funds, negative amounts)."
                         },
                         "bip125-replaceable": {
                             "type": "string",
                             "description": "Whether this transaction could be replaced due to BIP125 (replace-by-fee); may be unknown for unconfirmed transactions not in the mempool"
+                        },
+                        "abandoned": {
+                            "type": "boolean",
+                            "description": "'true' if the transaction has been abandoned (inputs are respendable). Only available for the  'send' category of transactions."
                         }
                     }
                 }
             }
         },
         "listunspent": {
-            "summary": "Returns array of unspent transaction outputs with between minconf and maxconf (inclusive) confirmations. Optionally filter to only include txouts paid to specified addresses. Results are an array of Objects, each of which has: {txid, vout, scriptPubKey, amount, confirmations}",
+            "summary": "Returns array of unspent transaction outputs with between minconf and maxconf (inclusive) confirmations. Optionally filter to only include txouts paid to specified addresses.",
             "description": [
                 "",
                 "> lbrycrd-cli listunspent ",
                 "> lbrycrd-cli listunspent 6 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"",
                 "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listunspent\", \"params\": [6, 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli listunspent 6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listunspent\", \"params\": [6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -4723,16 +6344,96 @@
                     },
                     "addresses": {
                         "type": "string",
-                        "description": "A json array of lbrycrd addresses to filter [ \"address\" (string) lbrycrd address ,... ] Result [ (array of json object) { \"txid\" : \"txid\", (string) the transaction id \"vout\" : n, (numeric) the vout value \"address\" : \"address\", (string) the lbrycrd address \"account\" : \"account\", (string) DEPRECATED. The associated account, or \"\" for the default account \"scriptPubKey\" : \"key\", (string) the script key \"amount\" : x.xxx, (numeric) the transaction amount in LBC \"confirmations\" : n (numeric) The number of confirmations } ,... ]"
+                        "description": "A json array of bitcoin addresses to filter [ \"address\" (string) bitcoin address ,... ]"
+                    },
+                    "include_unsafe": {
+                        "type": "boolean",
+                        "description": "Include outputs that are not safe to spend See description of \"safe\" attribute below.",
+                        "default": true
+                    },
+                    "query_options": {
+                        "type": "json",
+                        "description": "JSON with query options { \"minimumAmount\" (numeric or string, default=0) Minimum value of each UTXO in LBC \"maximumAmount\" (numeric or string, default=unlimited) Maximum value of each UTXO in LBC \"maximumCount\" (numeric or string, default=unlimited) Maximum number of UTXOs \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in LBC } Result [ (array of json object) { \"txid\" : \"txid\", (string) the transaction id \"vout\" : n, (numeric) the vout value \"address\" : \"address\", (string) the bitcoin address \"label\" : \"label\", (string) The associated label, or \"\" for the default label \"account\" : \"account\", (string) DEPRECATED. This field will be removed in V0."
+                    },
+                    "To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The associated account, or \"\" for the default account\n    \"scriptPubKey\"": {
+                        "type": "string",
+                        "description": "the script key \"amount\" : x.xxx, (numeric) the transaction output amount in LBC \"confirmations\" : n, (numeric) The number of confirmations \"redeemScript\" : n (string) The redeemScript if scriptPubKey is P2SH \"spendable\" : xxx, (bool) Whether we have the private keys to spend this output \"solvable\" : xxx, (bool) Whether we know how to spend this output, ignoring the lack of keys \"safe\" : xxx (bool) Whether this output is considered safe to spend. Unconfirmed transactions from outside keys and unconfirmed replacement transactions are considered unsafe and are not eligible for spending by fundrawtransaction and sendtoaddress. } ,... ]"
                     }
                 },
                 "required": [
-                    "addresses"
+                    "addresses",
+                    "To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The associated account, or \"\" for the default account\n    \"scriptPubKey\""
                 ]
             }
         },
+        "listwallets": {
+            "summary": "Returns a list of currently loaded wallets. For full information on the wallet, use \"getwalletinfo\"",
+            "description": [
+                "",
+                "> lbrycrd-cli listwallets ",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listwallets\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            },
+            "result": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "walletname": {
+                            "type": "string",
+                            "description": "the wallet name"
+                        }
+                    }
+                }
+            }
+        },
+        "loadwallet": {
+            "summary": "Loads a wallet from a wallet file or directory. Note that all wallet command-line options used when starting bitcoind will be applied to the new wallet (eg -zapwallettxes, upgradewallet, rescan, etc).",
+            "description": [
+                "",
+                "> lbrycrd-cli loadwallet \"test.dat\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"loadwallet\", \"params\": [\"test.dat\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "The wallet directory or .dat file."
+                    }
+                },
+                "required": [
+                    "filename"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The wallet name if loaded successfully."
+                    },
+                    "warning": {
+                        "type": "string",
+                        "description": "Warning message if wallet was not loaded cleanly."
+                    }
+                }
+            }
+        },
         "lockunspent": {
-            "summary": "Updates list of temporarily unspendable outputs. Temporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs. If no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked. A locked transaction output will not be chosen by automatic coin selection, when spending LBC. Locks are stored in memory only. Nodes start with zero locked outputs, and the locked output list is always cleared (by virtue of process exit) when a node stops or fails. Also see the listunspent call",
+            "summary": "Updates list of temporarily unspendable outputs. Temporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs. If no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked. A locked transaction output will not be chosen by automatic coin selection, when spending bitcoins. Locks are stored in memory only. Nodes start with zero locked outputs, and the locked output list is always cleared (by virtue of process exit) when a node stops or fails. Also see the listunspent call",
             "description": [
                 "",
                 "",
@@ -4809,10 +6510,9 @@
                         "type": "number",
                         "description": "Quantity of LBC to move between accounts."
                     },
-                    "minconf": {
-                        "type": "number",
-                        "description": "Only use funds with at least this many confirmations.",
-                        "default": 1
+                    "null": {
+                        "type": "object",
+                        "description": "(dummy)           (numeric, optional) Ignored. Remains for backward compatibility."
                     },
                     "comment": {
                         "type": "string",
@@ -4822,7 +6522,8 @@
                 "required": [
                     "fromaccount",
                     "toaccount",
-                    "amount"
+                    "amount",
+                    null
                 ]
             },
             "result": {
@@ -4831,13 +6532,13 @@
             }
         },
         "removeprunedfunds": {
-            "summary": "Deletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will effect wallet balances.",
+            "summary": "Deletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.",
             "description": [
                 "",
                 "> lbrycrd-cli removeprunedfunds \"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"",
                 "",
                 "As a JSON-RPC call",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"removprunedfunds\", \"params\": [\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"removeprunedfunds\", \"params\": [\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -4856,8 +6557,47 @@
                 ]
             }
         },
+        "rescanblockchain": {
+            "summary": "Rescan the local blockchain for wallet related transactions.",
+            "description": [
+                "",
+                "> lbrycrd-cli rescanblockchain 100000 120000",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"rescanblockchain\", \"params\": [100000, 120000] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "start_height": {
+                        "type": "number",
+                        "description": "block height where the rescan should start"
+                    },
+                    "stop_height": {
+                        "type": "number",
+                        "description": "the last block height that should be scanned"
+                    }
+                },
+                "required": []
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "start_height": {
+                        "type": "number",
+                        "description": "The block height where the rescan has started. If omitted, rescan started from the genesis block."
+                    },
+                    "stop_height": {
+                        "type": "number",
+                        "description": "The height of the last rescanned block. If omitted, rescan stopped at the chain tip."
+                    }
+                }
+            }
+        },
         "sendfrom": {
-            "summary": "DEPRECATED (use sendtoaddress). Sent an amount from an account to a lbrycrd address.",
+            "summary": "DEPRECATED (use sendtoaddress). Sent an amount from an account to a bitcoin address.",
             "description": [
                 "",
                 "",
@@ -4879,11 +6619,11 @@
                 "properties": {
                     "fromaccount": {
                         "type": "string",
-                        "description": "The name of the account to send funds from. May be the default account using \"\"."
+                        "description": "The name of the account to send funds from. May be the default account using \"\". Specifying an account does not influence coin selection, but it does associate the newly created transaction with the account, so the account's balance computation and transaction history can reflect the spend."
                     },
-                    "tolbrycrdaddress": {
+                    "toaddress": {
                         "type": "string",
-                        "description": "The lbrycrd address to send funds to."
+                        "description": "The bitcoin address to send funds to."
                     },
                     "amount": {
                         "type": "number",
@@ -4898,14 +6638,14 @@
                         "type": "string",
                         "description": "A comment used to store what the transaction is for. This is not part of the transaction, just kept in your wallet."
                     },
-                    "comment-to": {
+                    "comment_to": {
                         "type": "string",
                         "description": "An optional comment to store the name of the person or organization to which you're sending the transaction. This is not part of the transaction, it is just kept in your wallet."
                     }
                 },
                 "required": [
                     "fromaccount",
-                    "tolbrycrdaddress",
+                    "toaddress",
                     "amount"
                 ]
             },
@@ -4920,16 +6660,16 @@
                 "",
                 "",
                 "Send two amounts to two different addresses:",
-                "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\"",
+                "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\"",
                 "",
                 "Send two amounts to two different addresses setting the confirmation and comment:",
-                "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 6 \"testing\"",
+                "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 6 \"testing\"",
                 "",
                 "Send two amounts to two different addresses, subtract fee from amount:",
-                "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 1 \"\" \"[\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\",\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\"]\"",
+                "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 1 \"\" \"[\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\",\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\"]\"",
                 "",
                 "As a json rpc call",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendmany\", \"params\": [\"\", \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\", 6, \"testing\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendmany\", \"params\": [\"\", {\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\":0.01,\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\":0.02}, 6, \"testing\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -4944,7 +6684,7 @@
                     },
                     "amounts": {
                         "type": "string",
-                        "description": "A json object with addresses and amounts { \"address\":amount (numeric or string) The lbrycrd address is the key, the numeric amount (can be string) in LBC is the value ,... }"
+                        "description": "A json object with addresses and amounts { \"address\":amount (numeric or string) The bitcoin address is the key, the numeric amount (can be string) in LBC is the value ,... }"
                     },
                     "minconf": {
                         "type": "number",
@@ -4955,9 +6695,22 @@
                         "type": "string",
                         "description": "A comment"
                     },
-                    "subtractfeefromamount": {
+                    "subtractfeefrom": {
+                        "type": "array",
+                        "description": "A json array with addresses.\n                           The fee will be equally deducted from the amount of each selected address.\n                           Those recipients will receive less bitcoins than you enter in their corresponding amount field.\n                           If no addresses are specified here, the sender pays the fee.\n    [\n      \"address\"          (string) Subtract fee from this address\n      ,...\n    ]"
+                    },
+                    "replaceable": {
+                        "type": "boolean",
+                        "description": "Allow this transaction to be replaced by a transaction with higher fees via BIP 125"
+                    },
+                    "conf_target": {
+                        "type": "number",
+                        "description": "Confirmation target (in blocks)"
+                    },
+                    "estimate_mode": {
                         "type": "string",
-                        "description": "A json array with addresses. The fee will be equally deducted from the amount of each selected address. Those recipients will receive less LBC than you enter in their corresponding amount field. If no addresses are specified here, the sender pays the fee. [ \"address\" (string) Subtract fee from this address ,... ]"
+                        "description": "The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\"",
+                        "default": "UNSET"
                     }
                 },
                 "required": [
@@ -4986,9 +6739,9 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address to send to."
+                        "description": "The bitcoin address to send to."
                     },
                     "amount": {
                         "type": "number",
@@ -4998,18 +6751,31 @@
                         "type": "string",
                         "description": "A comment used to store what the transaction is for. This is not part of the transaction, just kept in your wallet."
                     },
-                    "comment-to": {
+                    "comment_to": {
                         "type": "string",
                         "description": "A comment to store the name of the person or organization to which you're sending the transaction. This is not part of the transaction, just kept in your wallet."
                     },
                     "subtractfeefromamount": {
                         "type": "boolean",
-                        "description": "The fee will be deducted from the amount being sent. The recipient will receive less LBC than you enter in the amount field.",
+                        "description": "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field.",
                         "default": false
+                    },
+                    "replaceable": {
+                        "type": "boolean",
+                        "description": "Allow this transaction to be replaced by a transaction with higher fees via BIP 125"
+                    },
+                    "conf_target": {
+                        "type": "number",
+                        "description": "Confirmation target (in blocks)"
+                    },
+                    "estimate_mode": {
+                        "type": "string",
+                        "description": "The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\"",
+                        "default": "UNSET"
                     }
                 },
                 "required": [
-                    "lbrycrdaddress",
+                    "address",
                     "amount"
                 ]
             },
@@ -5018,12 +6784,14 @@
                 "description": "The transaction id."
             }
         },
-        "setaccount": {
-            "summary": "DEPRECATED. Sets the account associated with the given address.",
+        "sethdseed": {
+            "summary": "Set or generate a new HD wallet seed. Non-HD wallets will not be upgraded to being a HD wallet. Wallets that are already HD will have a new HD seed set so that new keys added to the keypool will be derived from this new seed. Note that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet seed.",
             "description": [
                 "",
-                "> lbrycrd-cli setaccount \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"tabby\"",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setaccount\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", \"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> lbrycrd-cli sethdseed ",
+                "> lbrycrd-cli sethdseed false",
+                "> lbrycrd-cli sethdseed true \"wifkey\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sethdseed\", \"params\": [true, \"wifkey\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -5032,23 +6800,50 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
-                        "type": "string",
-                        "description": "The lbrycrd address to be associated with an account."
+                    "newkeypool": {
+                        "type": "boolean",
+                        "description": "Whether to flush old unused addresses, including change addresses, from the keypool and regenerate it. If true, the next address from getnewaddress and change address from getrawchangeaddress will be from this new seed. If false, addresses (including change addresses if the wallet already had HD Chain Split enabled) from the existing keypool will be used until it has been depleted.",
+                        "default": true
                     },
-                    "account": {
+                    "seed": {
                         "type": "string",
-                        "description": "The account to assign the address to."
+                        "description": "The WIF private key to use as the new HD seed; if not provided a random seed will be used. The seed value can be retrieved using the dumpwallet command. It is the private key marked hdseed=1"
+                    }
+                },
+                "required": []
+            }
+        },
+        "setlabel": {
+            "summary": "Sets the label associated with the given address.",
+            "description": [
+                "",
+                "> lbrycrd-cli setlabel \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"tabby\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setlabel\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "string",
+                        "description": "The bitcoin address to be associated with a label."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "The label to assign to the address."
                     }
                 },
                 "required": [
-                    "lbrycrdaddress",
-                    "account"
+                    "address",
+                    "label"
                 ]
             }
         },
         "settxfee": {
-            "summary": "Set the transaction fee per kB. Overwrites the paytxfee parameter.",
+            "summary": "Set the transaction fee per kB for this wallet. Overrides the global -paytxfee command line parameter.",
             "description": [
                 "",
                 "> lbrycrd-cli settxfee 0.00001",
@@ -5080,13 +6875,13 @@
                 "> lbrycrd-cli walletpassphrase \"mypassphrase\" 30",
                 "",
                 "Create the signature",
-                "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"my message\"",
+                "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\"",
                 "",
                 "Verify the signature",
-                "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"signature\" \"my message\"",
+                "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"",
                 "",
                 "As json rpc",
-                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signmessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signmessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
                 ""
             ],
             "tags": [
@@ -5095,9 +6890,9 @@
             "params": {
                 "type": "object",
                 "properties": {
-                    "lbrycrdaddress": {
+                    "address": {
                         "type": "string",
-                        "description": "The lbrycrd address to use for the private key."
+                        "description": "The bitcoin address to use for the private key."
                     },
                     "message": {
                         "type": "string",
@@ -5105,13 +6900,383 @@
                     }
                 },
                 "required": [
-                    "lbrycrdaddress",
+                    "address",
                     "message"
                 ]
             },
             "result": {
                 "type": "string",
                 "description": "The signature of the message encoded in base 64"
+            }
+        },
+        "signrawtransactionwithwallet": {
+            "summary": "Sign inputs for raw transaction (serialized, hex-encoded). The second optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain.",
+            "description": [
+                "",
+                "> lbrycrd-cli signrawtransactionwithwallet \"myhex\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signrawtransactionwithwallet\", \"params\": [\"myhex\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "hexstring": {
+                        "type": "string",
+                        "description": "The transaction hex string"
+                    },
+                    "prevtxs": {
+                        "type": "string",
+                        "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\", (string, required for P2SH or P2WSH) redeem script \"amount\": value (numeric, required) The amount spent } ,... ]"
+                    },
+                    "sighashtype": {
+                        "type": "string",
+                        "description": "The signature hash type. Must be one of \"ALL\" \"NONE\" \"SINGLE\" \"ALL|ANYONECANPAY\" \"NONE|ANYONECANPAY\" \"SINGLE|ANYONECANPAY\"",
+                        "default": "ALL"
+                    }
+                },
+                "required": [
+                    "hexstring"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "hex": {
+                        "type": "string",
+                        "description": "The hex-encoded raw transaction with signature(s)"
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "description": "If the transaction has a complete set of signatures"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "txid": {
+                                    "type": "string",
+                                    "description": "The hash of the referenced, previous transaction"
+                                },
+                                "vout": {
+                                    "type": "number",
+                                    "description": "The index of the output to spent and used as input"
+                                },
+                                "scriptSig": {
+                                    "type": "string",
+                                    "description": "The hex-encoded signature script"
+                                },
+                                "sequence": {
+                                    "type": "number",
+                                    "description": "Script sequence number"
+                                },
+                                "error": {
+                                    "type": "string",
+                                    "description": "Verification or signing error related to the input"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "unloadwallet": {
+            "summary": "Unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument. Specifying the wallet name on a wallet endpoint is invalid.",
+            "description": [
+                "",
+                "> lbrycrd-cli unloadwallet wallet_name",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"unloadwallet\", \"params\": [wallet_name] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "wallet_name": {
+                        "type": "string",
+                        "description": "The name of the wallet to unload."
+                    }
+                },
+                "required": []
+            }
+        },
+        "walletcreatefundedpsbt": {
+            "summary": "Creates and funds a transaction in the Partially Signed Transaction format. Inputs will be added if supplied inputs are not enough Implements the Creator and Updater roles.",
+            "description": [
+                "",
+                "",
+                "Create a transaction with no inputs",
+                "> lbrycrd-cli walletcreatefundedpsbt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "description": "A json array of json objects\n     [\n       {\n         \"txid\":\"id\",      (string, required) The transaction id\n         \"vout\":n,         (numeric, required) The output number\n         \"sequence\":n      (numeric, optional) The sequence number\n       } \n       ,...\n     ]"
+                    },
+                    "outputs": {
+                        "type": "array",
+                        "description": "a json array with outputs (key-value pairs), where none of the keys are duplicated.\nThat is, each address can only appear once and there can only be one 'data' object.\n   [\n    {\n      \"address\": x.xxx,    (obj, optional) A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in LBC\n    },\n    {\n      \"data\": \"hex\"        (obj, optional) A key-value pair. The key must be \"data\", the value is hex encoded data\n    }\n    ,...                     More key-value pairs of the above form. For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also\n                             accepted as second parameter.\n   ]"
+                    },
+                    "locktime": {
+                        "type": "number",
+                        "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+                        "default": 0
+                    },
+                    "options": {
+                        "type": "object",
+                        "properties": {
+                            "changeAddress": {
+                                "type": "string",
+                                "description": "The bitcoin address to receive the change"
+                            },
+                            "changePosition": {
+                                "type": "number",
+                                "description": "The index of the change output"
+                            },
+                            "change_type": {
+                                "type": "string",
+                                "description": "The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype."
+                            },
+                            "includeWatching": {
+                                "type": "boolean",
+                                "description": "Also select inputs which are watch only"
+                            },
+                            "lockUnspents": {
+                                "type": "boolean",
+                                "description": "Lock selected unspent outputs"
+                            },
+                            "feeRate": {
+                                "type": "number",
+                                "description": "Set a specific fee rate in LBC/kB"
+                            },
+                            "replaceable": {
+                                "type": "boolean",
+                                "description": "Marks this transaction as BIP125 replaceable."
+                            },
+                            "conf_target": {
+                                "type": "number",
+                                "description": "Confirmation target (in blocks)"
+                            },
+                            "estimate_mode": {
+                                "type": "string",
+                                "description": "The fee estimate mode, must be one of:"
+                            }
+                        }
+                    },
+                    "bip32derivs": {
+                        "type": "boolean",
+                        "description": "If true, includes the BIP 32 derivation paths for public keys if we know them",
+                        "default": false
+                    }
+                },
+                "required": [
+                    "inputs",
+                    "outputs"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "psbt": {
+                        "type": "string",
+                        "description": "The resulting raw transaction (base64-encoded string)"
+                    },
+                    "fee": {
+                        "type": "number",
+                        "description": "Fee in LBC the resulting transaction pays"
+                    },
+                    "changepos": {
+                        "type": "number",
+                        "description": "The position of the added change output, or -1"
+                    }
+                }
+            }
+        },
+        "walletlock": {
+            "summary": "Removes the wallet encryption key from memory, locking the wallet. After calling this method, you will need to call walletpassphrase again before being able to call any methods which require the wallet to be unlocked.",
+            "description": [
+                "",
+                "",
+                "Set the passphrase for 2 minutes to perform a transaction",
+                "> lbrycrd-cli walletpassphrase \"my pass phrase\" 120",
+                "",
+                "Perform a send (requires passphrase set)",
+                "> lbrycrd-cli sendtoaddress \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 1.0",
+                "",
+                "Clear the passphrase since we are done before 2 minutes is up",
+                "> lbrycrd-cli walletlock ",
+                "",
+                "As json rpc call",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"walletlock\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        },
+        "walletpassphrase": {
+            "summary": "Stores the wallet decryption key in memory for 'timeout' seconds. This is needed prior to performing transactions related to private keys such as sending bitcoins",
+            "description": [
+                "",
+                "",
+                "Unlock the wallet for 60 seconds",
+                "> lbrycrd-cli walletpassphrase \"my pass phrase\" 60",
+                "",
+                "Lock the wallet again (before 60 seconds)",
+                "> lbrycrd-cli walletlock ",
+                "",
+                "As json rpc call",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"walletpassphrase\", \"params\": [\"my pass phrase\", 60] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "passphrase": {
+                        "type": "string",
+                        "description": "The wallet passphrase"
+                    },
+                    "timeout": {
+                        "type": "number",
+                        "description": "The time to keep the decryption key in seconds; capped at 100000000 (~3 years). Note: Issuing the walletpassphrase command while the wallet is already unlocked will set a new unlock time that overrides the old one."
+                    }
+                },
+                "required": [
+                    "passphrase",
+                    "timeout"
+                ]
+            }
+        },
+        "walletpassphrasechange": {
+            "summary": "Changes the wallet passphrase from 'oldpassphrase' to 'newpassphrase'.",
+            "description": [
+                "",
+                "> lbrycrd-cli walletpassphrasechange \"old one\" \"new one\"",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"walletpassphrasechange\", \"params\": [\"old one\", \"new one\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "oldpassphrase": {
+                        "type": "string",
+                        "description": "The current passphrase"
+                    },
+                    "newpassphrase": {
+                        "type": "string",
+                        "description": "The new passphrase"
+                    }
+                },
+                "required": [
+                    "oldpassphrase",
+                    "newpassphrase"
+                ]
+            }
+        },
+        "walletprocesspsbt": {
+            "summary": "Update a PSBT with input information from our wallet and then sign inputs that we can sign for.",
+            "description": [
+                "",
+                "> lbrycrd-cli walletprocesspsbt \"psbt\"",
+                ""
+            ],
+            "tags": [
+                "Wallet"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {
+                    "psbt": {
+                        "type": "string",
+                        "description": "The transaction base64 string"
+                    },
+                    "sign": {
+                        "type": "boolean",
+                        "description": "Also sign the transaction when updating",
+                        "default": true
+                    },
+                    "sighashtype": {
+                        "type": "string",
+                        "description": "The signature hash type to sign with if not specified by the PSBT. Must be one of \"ALL\" \"NONE\" \"SINGLE\" \"ALL|ANYONECANPAY\" \"NONE|ANYONECANPAY\" \"SINGLE|ANYONECANPAY\"",
+                        "default": "ALL"
+                    },
+                    "bip32derivs": {
+                        "type": "boolean",
+                        "description": "If true, includes the BIP 32 derivation paths for public keys if we know them",
+                        "default": false
+                    }
+                },
+                "required": [
+                    "psbt"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "psbt": {
+                        "type": "string",
+                        "description": "The base64-encoded partially signed transaction"
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "description": "If the transaction has a complete set of signatures"
+                    }
+                }
+            }
+        },
+        "getzmqnotifications": {
+            "summary": "Returns information about the active ZeroMQ notifications.",
+            "description": [
+                "",
+                "> lbrycrd-cli getzmqnotifications ",
+                "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getzmqnotifications\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/",
+                ""
+            ],
+            "tags": [
+                "Zmq"
+            ],
+            "params": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            },
+            "result": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Type of notification"
+                        },
+                        "address": {
+                            "type": "string",
+                            "description": "Address of the publisher"
+                        }
+                    }
+                }
             }
         }
     }

--- a/contrib/devtools/generated/api_v1.json
+++ b/contrib/devtools/generated/api_v1.json
@@ -11,15 +11,9 @@
                 "is_required": true
             },
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
                 "description": "The lbrycrd address to send to.",
-                "is_required": true
-            },
-            {
-                "name": "amount",
-                "type": "number",
-                "description": "The amount to send to the lbrycrd address. eg 0.1",
                 "is_required": true
             }
         ],
@@ -38,15 +32,9 @@
                 "is_required": true
             },
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
                 "description": "The lbrycrd address to send to.",
-                "is_required": true
-            },
-            {
-                "name": "amount",
-                "type": "number",
-                "description": "The amount to send to the lbrycrd address. eg 0.1",
                 "is_required": true
             }
         ],
@@ -108,7 +96,7 @@
             }
         ],
         "examples": [],
-        "returns": "{\n  \"name\"                (string) the original name of the claim (before normalization)\n  \"normalized_name\"      (string) the name of this claim (after normalization)\n  \"value\"               (string) claim metadata\n  \"claimId\"             (string) the claimId of this claim\n  \"txid\"                (string) the hash of the transaction which has successfully claimed this name\n  \"n\"                   (numeric) vout value\n  \"amount\"              (numeric) txout value\n  \"effective amount\"    (numeric) txout amount plus amount from all supports associated with the claim\n  \"supports\"            (array of object) supports for this claim\n  [\n    \"txid\"              (string) the txid of the support\n    \"n\"                 (numeric) the index of the support in the transaction's list of outputs\n    \"height\"            (numeric) the height at which the support was included in the blockchain\n    \"valid at height\"   (numeric) the height at which the support is valid\n    \"amount\"            (numeric) the amount of the support\n  ]\n  \"height\"              (numeric) the height of the block in which this claim transaction is located\n  \"valid at height\"     (numeric) the height at which the claim is valid\n}"
+        "returns": "{\n  \"name\"                (string) the original name of the claim (before normalization)\n  \"normalized_name\"     (string) the name of this claim (after normalization)\n  \"value\"               (string) metadata of the claim\n  \"claimId\"             (string) the claimId of this claim\n  \"txid\"                (string) the hash of the transaction which has successfully claimed this name\n  \"n\"                   (numeric) vout value\n  \"amount\"              (numeric) txout value\n  \"effective amount\"    (numeric) txout amount plus amount from all supports associated with the claim\n  \"supports\"            (array of object) supports for this claim\n  [\n    \"txid\"              (string) the txid of the support\n    \"n\"                 (numeric) the index of the support in the transaction's list of outputs\n    \"height\"            (numeric) the height at which the support was included in the blockchain\n    \"valid at height\"   (numeric) the height at which the support is valid\n    \"amount\"            (numeric) the amount of the support\n    \"value\"             (string) the metadata of the support if any\n  ]\n  \"height\"              (numeric) the height of the block in which this claim transaction is located\n  \"valid at height\"     (numeric) the height at which the claim is valid\n}"
     },
     {
         "name": "getclaimsforname",
@@ -129,7 +117,7 @@
             }
         ],
         "examples": [],
-        "returns": "{\n  \"nLastTakeoverHeight\" (numeric) the last height at which ownership of the name changed\n  \"normalized_name\"      (string) the name of these claims after normalization\n  \"claims\": [      (array of object) claims for this name\n    {\n      \"claimId\"    (string) the claimId of this claim\n      \"txid\"       (string) the txid of this claim\n      \"n\"          (numeric) the index of the claim in the transaction's list of outputs\n      \"nHeight\"    (numeric) the height at which the claim was included in the blockchain\n      \"nValidAtHeight\" (numeric) the height at which the claim became/becomes valid\n      \"nAmount\"    (numeric) the amount of the claim\n      \"value\"      (string) the value of the name, if it exists\n      \"nEffectiveAmount\" (numeric) the total effective amount of the claim, taking into effect whether the claim or support has reached its nValidAtHeight\n      \"supports\" : [ (array of object) supports for this claim\n        \"txid\"     (string) the txid of the support\n        \"n\"        (numeric) the index of the support in the transaction's list of outputs\n        \"nHeight\"  (numeric) the height at which the support was included in the blockchain\n        \"nValidAtHeight\" (numeric) the height at which the support became/becomes valid\n        \"nAmount\"  (numeric) the amount of the support\n      ]\n      \"name\"       (string) the original name of this claim before normalization\n    }\n  ],\n  \"supports without claims\": [ (array of object) supports that did not match a claim for this name\n    {\n      \"txid\"     (string) the txid of the support\n      \"n\"        (numeric) the index of the support in the transaction's list of outputs\n      \"nHeight\"  (numeric) the height at which the support was included in the blockchain\n      \"nValidAtHeight\" (numeric) the height at which the support became/becomes valid\n      \"nAmount\"  (numeric) the amount of the support\n    }\n  ]\n}"
+        "returns": "{\n  \"nLastTakeoverHeight\" (numeric) the last height at which ownership of the name changed\n  \"normalized_name\"     (string) the name of these claims after normalization\n  \"claims\": [      (array of object) claims for this name\n    {\n      \"claimId\"    (string) the claimId of this claim\n      \"txid\"       (string) the txid of this claim\n      \"n\"          (numeric) the index of the claim in the transaction's list of outputs\n      \"nHeight\"    (numeric) the height at which the claim was included in the blockchain\n      \"nValidAtHeight\" (numeric) the height at which the claim became/becomes valid\n      \"nAmount\"    (numeric) the amount of the claim\n      \"value\"      (string) the metadata of the claim\n      \"nEffectiveAmount\" (numeric) the total effective amount of the claim, taking into effect whether the claim or support has reached its nValidAtHeight\n      \"supports\" : [ (array of object) supports for this claim\n        \"txid\"     (string) the txid of the support\n        \"n\"        (numeric) the index of the support in the transaction's list of outputs\n        \"nHeight\"  (numeric) the height at which the support was included in the blockchain\n        \"nValidAtHeight\" (numeric) the height at which the support became/becomes valid\n        \"nAmount\"  (numeric) the amount of the support\n        \"value\"    (string) the metadata of the support if any\n      ]\n      \"name\"       (string) the original name of this claim before normalization\n    }\n  ],\n  \"supports without claims\": [ (array of object) supports that did not match a claim for this name\n    {\n      \"txid\"     (string) the txid of the support\n      \"n\"        (numeric) the index of the support in the transaction's list of outputs\n      \"nHeight\"  (numeric) the height at which the support was included in the blockchain\n      \"nValidAtHeight\" (numeric) the height at which the support became/becomes valid\n      \"nAmount\"  (numeric) the amount of the support\n    }\n  ]\n}"
     },
     {
         "name": "getclaimsfortx",
@@ -144,12 +132,12 @@
             }
         ],
         "examples": [],
-        "returns": "[\n  {\n    \"nOut\"                   (numeric) the index of the claim or support in the transaction's list out outputs\n    \"claim type\"             (string) 'claim' or 'support'\n    \"name\"                   (string) the name claimed or supported\n    \"claimId\"                (string) if a claim, its ID\n    \"value\"                  (string) if a name claim, the value of the claim\n    \"supported txid\"         (string) if a support, the txid of the supported claim\n    \"supported nout\"         (numeric) if a support, the index of the supported claim in its transaction\n    \"depth\"                  (numeric) the depth of the transaction in the main chain\n    \"in claim trie\"          (boolean) if a name claim, whether the claim is active, i.e. has made it into the trie\n    \"is controlling\"         (boolean) if a name claim, whether the claim is the current controlling claim for the name\n    \"in support map\"         (boolean) if a support, whether the support is active, i.e. has made it into the support map\n    \"in queue\"               (boolean) whether the claim is in a queue waiting to be inserted into the trie or support map\n    \"blocks to valid\"        (numeric) if in a queue, the number of blocks until it's inserted into the trie or support map\n  }\n]"
+        "returns": "[\n  {\n    \"nOut\"                   (numeric) the index of the claim or support in the transaction's list of outputs\n    \"claim type\"             (string) 'claim' or 'support'\n    \"name\"                   (string) the name claimed or supported\n    \"claimId\"                (string) if a claim, its ID\n    \"value\"                  (string) if a name claim, the value of the claim\n    \"supported txid\"         (string) if a support, the txid of the supported claim\n    \"supported nout\"         (numeric) if a support, the index of the supported claim in its transaction\n    \"depth\"                  (numeric) the depth of the transaction in the main chain\n    \"in claim trie\"          (boolean) if a name claim, whether the claim is active, i.e. has made it into the trie\n    \"is controlling\"         (boolean) if a name claim, whether the claim is the current controlling claim for the name\n    \"in support map\"         (boolean) if a support, whether the support is active, i.e. has made it into the support map\n    \"in queue\"               (boolean) whether the claim is in a queue waiting to be inserted into the trie or support map\n    \"blocks to valid\"        (numeric) if in a queue, the number of blocks until it's inserted into the trie or support map\n  }\n]"
     },
     {
         "name": "getclaimsintrie",
         "namespace": "Claimtrie",
-        "description": "Return all claims in the name trie.",
+        "description": "Return all names in the trie.",
         "arguments": [
             {
                 "name": "blockhash",
@@ -159,22 +147,7 @@
             }
         ],
         "examples": [],
-        "returns": "[\n  {\n    \"normalized_name\"     (string) the name of these claims (after normalization)\n    \"claims\": [          (array of object) the claims for this name\n      {\n        \"claimId\"        (string) the claimId of the claim\n        \"txid\"           (string) the txid of the claim\n        \"n\"              (numeric) the vout value of the claim\n        \"amount\"         (numeric) txout amount\n        \"height\"         (numeric) the height of the block in which this transaction is located\n        \"value\"          (string) the value of this claim\n        \"name\"           (string) the original name of this claim (before normalization)\n      }\n    ]\n  }\n]"
-    },
-    {
-        "name": "getclaimtrie",
-        "namespace": "Claimtrie",
-        "description": "DEPRECATED. Return the entire name trie.",
-        "arguments": [
-            {
-                "name": "blockhash",
-                "type": "string",
-                "description": "get claim in the trie at the block specified by this block hash. If none is given, the latest active block will be used.",
-                "is_required": false
-            }
-        ],
-        "examples": [],
-        "returns": "[\n {\n  \"name\"           (string) the name of the node\n  \"hash\"           (string) the hash of the node\n  \"txid\"           (string) (if value exists) the hash of the transaction which has successfully claimed this name\n  \"n\"              (numeric) (if value exists) vout value\n  \"value\"          (numeric) (if value exists) txout value\n  \"height\"         (numeric) (if value exists) the height of the block in which this transaction is located\n }\n]"
+        "returns": "\"names\"             (array) all names in the trie that have claims"
     },
     {
         "name": "getnameproof",
@@ -269,7 +242,7 @@
             {
                 "name": "minconf",
                 "type": "number",
-                "description": "Only include transactions confirmed at least this many time.",
+                "description": "Only include transactions confirmed at least this many times.",
                 "is_required": false
             }
         ],
@@ -279,7 +252,7 @@
     {
         "name": "supportclaim",
         "namespace": "Claimtrie",
-        "description": "Increase the value of a claim. Whichever claim has the greatest value, including all support values, will be the authoritative claim, according to the rest of the rules. The name is the name which is claimed by the claim that will be supported, the txid is the txid of the claim that will be supported, nout is the transaction output which contains the claim to be supported, and amount is the amount which will be added to the value of the claim. If the claim is currently the authoritative claim, this support will go into effect immediately. Otherwise, it will go into effect after 100 blocks. The support will be in effect until it is spent, and will lose its effect when the claim is spent or expires. The amount is a real and is rounded to the nearest .00000001",
+        "description": "Increase the value of a claim. Whichever claim has the greatest value, including all support values, will be the authoritative claim, according to the rest of the rules. The name is the name which is claimed by the claim that will be supported, the txid is the txid of the claim that will be supported, nout is the transaction output which contains the claim to be supported, and amount is the amount which will be added to the value of the claim. If the claim is currently the authoritative claim, this support will go into effect immediately . Otherwise, it will go into effect after 100 blocks. The support will be in effect until it is spent, and will lose its effect when the claim is spent or expires. The amount is a real and is rounded to the nearest .00000001",
         "arguments": [
             {
                 "name": "name",
@@ -298,6 +271,12 @@
                 "type": "number",
                 "description": "The amount in LBC to use to support the claim.",
                 "is_required": true
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "description": "The metadata of the support encoded in hexadecimal.",
+                "is_required": false
             }
         ],
         "examples": [],
@@ -333,30 +312,31 @@
     {
         "name": "getbestblockhash",
         "namespace": "Blockchain",
-        "description": "Returns the hash of the best (tip) block in the longest block chain. Result \"hex\" (string) the block hash hex encoded",
+        "description": "Returns the hash of the best (tip) block in the longest blockchain.",
         "arguments": [],
         "examples": [
             {
                 "cli": "> lbrycrd-cli getbestblockhash",
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getbestblockhash\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
-        ]
+        ],
+        "returns": "\"hex\"      (string) the block hash hex encoded"
     },
     {
         "name": "getblock",
         "namespace": "Blockchain",
-        "description": "If verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'. If verbose is true, returns an Object with information about block <hash>.",
+        "description": "If verbosity is 0, returns a string that is serialized, hex-encoded data for block 'hash'. If verbosity is 1, returns an Object with information about block <hash>. If verbosity is 2, returns an Object with information about block <hash> and information about each transaction.",
         "arguments": [
             {
-                "name": "hash",
+                "name": "blockhash",
                 "type": "string",
                 "description": "The block hash",
                 "is_required": true
             },
             {
-                "name": "verbose",
-                "type": "boolean",
-                "description": "true for a json object, false for the hex encoded data",
+                "name": "verbosity",
+                "type": "number",
+                "description": "0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data",
                 "is_required": false
             }
         ],
@@ -366,12 +346,12 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblock\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n  \"size\" : n,            (numeric) The block size\n  \"height\" : n,          (numeric) The block height or index\n  \"version\" : n,         (numeric) The block version\n  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n  \"merkleroot\" : \"xxxx\", (string) The merkle root\n  \"nameclaimroot\" : \"xxxx\",  (string) The hash of the root of the name claim trie\n  \"tx\" : [               (array of string) The transaction ids\n     \"transactionid\"     (string) The transaction id\n     ,...\n  ],\n  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n  \"nonce\" : n,           (numeric) The nonce\n  \"bits\" : \"1d00ffff\", (string) The bits\n  \"difficulty\" : x.xxx,  (numeric) The difficulty\n  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n}\n\nResult (for verbose=false):\n\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'."
+        "returns": "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n\nResult (for verbosity = 1):\n{\n  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n  \"size\" : n,            (numeric) The block size\n  \"strippedsize\" : n,    (numeric) The block size excluding witness data\n  \"weight\" : n           (numeric) The block weight as defined in BIP 141\n  \"height\" : n,          (numeric) The block height or index\n  \"version\" : n,         (numeric) The block version\n  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n  \"merkleroot\" : \"xxxx\", (string) The merkle root\n  \"nameclaimroot\" : \"xxxx\",  (string) The hash of the root of the name claim trie\n  \"tx\" : [               (array of string) The transaction ids\n     \"transactionid\"     (string) The transaction id\n     ,...\n  ],\n  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n  \"nonce\" : n,           (numeric) The nonce\n  \"bits\" : \"1d00ffff\", (string) The bits\n  \"difficulty\" : x.xxx,  (numeric) The difficulty\n  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n  \"nTx\" : n,             (numeric) The number of transactions in the block.\n  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n}\n\nResult (for verbosity = 2):\n{\n  ...,                     Same output as verbosity = 1.\n  \"tx\" : [               (array of Objects) The transactions in the format of the getrawtransaction RPC. Different from verbosity = 1 \"tx\" result.\n         ,...\n  ],\n  ,...                     Same output as verbosity = 1.\n}"
     },
     {
         "name": "getblockchaininfo",
         "namespace": "Blockchain",
-        "description": "Returns an object containing various state info regarding block chain processing.",
+        "description": "Returns an object containing various state info regarding blockchain processing.",
         "arguments": [],
         "examples": [
             {
@@ -379,12 +359,12 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblockchaininfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"chain\": \"xxxx\",        (string) current network name as defined in BIP70 (main, test, regtest)\n  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n  \"headers\": xxxxxx,        (numeric) the current number of headers we have validated\n  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n  \"pruneheight\": xxxxxx,    (numeric) heighest block available\n  \"softforks\": [            (array) status of softforks in progress\n     {\n        \"id\": \"xxxx\",        (string) name of softfork\n        \"version\": xx,         (numeric) block version\n        \"enforce\": {           (object) progress toward enforcing the softfork rules for new-version blocks\n           \"status\": xx,       (boolean) true if threshold reached\n           \"found\": xx,        (numeric) number of blocks with the new version found\n           \"required\": xx,     (numeric) number of blocks required to trigger\n           \"window\": xx,       (numeric) maximum size of examined window of recent blocks\n        },\n        \"reject\": { ... }      (object) progress toward rejecting pre-softfork blocks (same fields as \"enforce\")\n     }, ...\n  ],\n  \"bip9_softforks\": {          (object) status of BIP9 softforks in progress\n     \"xxxx\" : {                (string) name of the softfork\n        \"status\": \"xxxx\",    (string) one of \"defined\", \"started\", \"lockedin\", \"active\", \"failed\"\n        \"bit\": xx,             (numeric) the bit, 0-28, in the block version field used to signal this soft fork\n        \"startTime\": xx,       (numeric) the minimum median time past of a block at which the bit gains its meaning\n        \"timeout\": xx          (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in\n     }\n  }\n}"
+        "returns": "{\n  \"chain\": \"xxxx\",              (string) current network name as defined in BIP70 (main, test, regtest)\n  \"blocks\": xxxxxx,             (numeric) the current number of blocks processed in the server\n  \"headers\": xxxxxx,            (numeric) the current number of headers we have validated\n  \"bestblockhash\": \"...\",       (string) the hash of the currently best block\n  \"difficulty\": xxxxxx,         (numeric) the current difficulty\n  \"mediantime\": xxxxxx,         (numeric) median time for the current best block\n  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n  \"initialblockdownload\": xxxx, (bool) (debug information) estimate of whether this node is in Initial Block Download mode.\n  \"chainwork\": \"xxxx\"           (string) total amount of work in active chain, in hexadecimal\n  \"size_on_disk\": xxxxxx,       (numeric) the estimated size of the block and undo files on disk\n  \"pruned\": xx,                 (boolean) if the blocks are subject to pruning\n  \"pruneheight\": xxxxxx,        (numeric) lowest-height complete block stored (only present if pruning is enabled)\n  \"automatic_pruning\": xx,      (boolean) whether automatic pruning is enabled (only present if pruning is enabled)\n  \"prune_target_size\": xxxxxx,  (numeric) the target size used by pruning (only present if automatic pruning is enabled)\n  \"softforks\": [                (array) status of softforks in progress\n     {\n        \"id\": \"xxxx\",           (string) name of softfork\n        \"version\": xx,          (numeric) block version\n        \"reject\": {             (object) progress toward rejecting pre-softfork blocks\n           \"status\": xx,        (boolean) true if threshold reached\n        },\n     }, ...\n  ],\n  \"bip9_softforks\": {           (object) status of BIP9 softforks in progress\n     \"xxxx\" : {                 (string) name of the softfork\n        \"status\": \"xxxx\",       (string) one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\"\n        \"bit\": xx,              (numeric) the bit (0-28) in the block version field used to signal this softfork (only for \"started\" status)\n        \"startTime\": xx,        (numeric) the minimum median time past of a block at which the bit gains its meaning\n        \"timeout\": xx,          (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in\n        \"since\": xx,            (numeric) height of the first block to which the status applies\n        \"statistics\": {         (object) numeric statistics about BIP9 signalling for a softfork (only for \"started\" status)\n           \"period\": xx,        (numeric) the length in blocks of the BIP9 signalling period \n           \"threshold\": xx,     (numeric) the number of blocks with the version bit set required to activate the feature \n           \"elapsed\": xx,       (numeric) the number of blocks elapsed since the beginning of the current period \n           \"count\": xx,         (numeric) the number of blocks with the version bit set in the current period \n           \"possible\": xx       (boolean) returns false if there are not enough blocks left in this period to pass activation threshold \n        }\n     }\n  }\n  \"warnings\" : \"...\",           (string) any network and blockchain warnings.\n}"
     },
     {
         "name": "getblockcount",
         "namespace": "Blockchain",
-        "description": "Returns the number of blocks in the longest block chain.",
+        "description": "Returns the number of blocks in the longest blockchain.",
         "arguments": [],
         "examples": [
             {
@@ -397,12 +377,12 @@
     {
         "name": "getblockhash",
         "namespace": "Blockchain",
-        "description": "Returns hash of block in best-block-chain at index provided.",
+        "description": "Returns hash of block in best-block-chain at height provided.",
         "arguments": [
             {
-                "name": "index",
+                "name": "height",
                 "type": "number",
-                "description": "The block index",
+                "description": "The height index",
                 "is_required": true
             }
         ],
@@ -438,7 +418,33 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblockheader\", \"params\": [\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n  \"height\" : n,          (numeric) The block height or index\n  \"version\" : n,         (numeric) The block version\n  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n  \"merkleroot\" : \"xxxx\", (string) The merkle root\n  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n  \"nonce\" : n,           (numeric) The nonce\n  \"bits\" : \"1d00ffff\", (string) The bits\n  \"difficulty\" : x.xxx,  (numeric) The difficulty\n  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n}\n\nResult (for verbose=false):\n\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'."
+        "returns": "{\n  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n  \"height\" : n,          (numeric) The block height or index\n  \"version\" : n,         (numeric) The block version\n  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n  \"merkleroot\" : \"xxxx\", (string) The merkle root\n  \"nameclaimroot\" : \"xxxx\",  (string) The hash of the root of the name claim trie\n  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n  \"nonce\" : n,           (numeric) The nonce\n  \"bits\" : \"1d00ffff\", (string) The bits\n  \"difficulty\" : x.xxx,  (numeric) The difficulty\n  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n  \"nTx\" : n,             (numeric) The number of transactions in the block.\n  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n}\n\nResult (for verbose=false):\n\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'."
+    },
+    {
+        "name": "getblockstats",
+        "namespace": "Blockchain",
+        "description": "Compute per block statistics for a given window. All amounts are in satoshis. It won't work for some heights with pruning. It won't work without -txindex for utxo_size_inc, *fee or *feerate stats.",
+        "arguments": [
+            {
+                "name": "hash_or_height",
+                "type": "number",
+                "description": "The block hash or height of the target block",
+                "is_required": true
+            },
+            {
+                "name": "stats",
+                "type": "array",
+                "description": "Values to plot, by default all values (see result below) [ \"height\", (string, optional) Selected statistic \"time\", (string, optional) Selected statistic ,... ]",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getblockstats 1000 '[\"minfeerate\",\"avgfeerate\"]'",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblockstats\", \"params\": [1000 '[\"minfeerate\",\"avgfeerate\"]'] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{                           (json object)\n  \"avgfee\": xxxxx,          (numeric) Average fee in the block\n  \"avgfeerate\": xxxxx,      (numeric) Average feerate (in satoshis per virtual byte)\n  \"avgtxsize\": xxxxx,       (numeric) Average transaction size\n  \"blockhash\": xxxxx,       (string) The block hash (to check for potential reorgs)\n  \"feerate_percentiles\": [  (array of numeric) Feerates at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per virtual byte)\n      \"10th_percentile_feerate\",      (numeric) The 10th percentile feerate\n      \"25th_percentile_feerate\",      (numeric) The 25th percentile feerate\n      \"50th_percentile_feerate\",      (numeric) The 50th percentile feerate\n      \"75th_percentile_feerate\",      (numeric) The 75th percentile feerate\n      \"90th_percentile_feerate\",      (numeric) The 90th percentile feerate\n  ],\n  \"height\": xxxxx,          (numeric) The height of the block\n  \"ins\": xxxxx,             (numeric) The number of inputs (excluding coinbase)\n  \"maxfee\": xxxxx,          (numeric) Maximum fee in the block\n  \"maxfeerate\": xxxxx,      (numeric) Maximum feerate (in satoshis per virtual byte)\n  \"maxtxsize\": xxxxx,       (numeric) Maximum transaction size\n  \"medianfee\": xxxxx,       (numeric) Truncated median fee in the block\n  \"mediantime\": xxxxx,      (numeric) The block median time past\n  \"mediantxsize\": xxxxx,    (numeric) Truncated median transaction size\n  \"minfee\": xxxxx,          (numeric) Minimum fee in the block\n  \"minfeerate\": xxxxx,      (numeric) Minimum feerate (in satoshis per virtual byte)\n  \"mintxsize\": xxxxx,       (numeric) Minimum transaction size\n  \"outs\": xxxxx,            (numeric) The number of outputs\n  \"subsidy\": xxxxx,         (numeric) The block subsidy\n  \"swtotal_size\": xxxxx,    (numeric) Total size of all segwit transactions\n  \"swtotal_weight\": xxxxx,  (numeric) Total weight of all segwit transactions divided by segwit scale factor (4)\n  \"swtxs\": xxxxx,           (numeric) The number of segwit transactions\n  \"time\": xxxxx,            (numeric) The block time\n  \"total_out\": xxxxx,       (numeric) Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])\n  \"total_size\": xxxxx,      (numeric) Total size of all non-coinbase transactions\n  \"total_weight\": xxxxx,    (numeric) Total weight of all non-coinbase transactions divided by segwit scale factor (4)\n  \"totalfee\": xxxxx,        (numeric) The fee total\n  \"txs\": xxxxx,             (numeric) The number of transactions (excluding coinbase)\n  \"utxo_increase\": xxxxx,   (numeric) The increase/decrease in the number of unspent outputs\n  \"utxo_size_inc\": xxxxx,   (numeric) The increase/decrease in size for the utxo index (not discounting op_return and similar)\n}"
     },
     {
         "name": "getchaintips",
@@ -454,6 +460,32 @@
         "returns": "[\n  {\n    \"height\": xxxx,         (numeric) height of the chain tip\n    \"hash\": \"xxxx\",         (string) block hash of the tip\n    \"branchlen\": 0          (numeric) zero for main chain\n    \"status\": \"active\"      (string) \"active\" for the main chain\n  },\n  {\n    \"height\": xxxx,\n    \"hash\": \"xxxx\",\n    \"branchlen\": 1          (numeric) length of branch connecting the tip to the main chain\n    \"status\": \"xxxx\"        (string) status of the chain (active, valid-fork, valid-headers, headers-only, invalid)\n  }\n]\nPossible values for status:\n1.  \"invalid\"               This branch contains at least one invalid block\n2.  \"headers-only\"          Not all blocks for this branch are available, but the headers are valid\n3.  \"valid-headers\"         All blocks are available for this branch, but they were never fully validated\n4.  \"valid-fork\"            This branch is not part of the active chain, but is fully validated\n5.  \"active\"                This is the tip of the active main chain, which is certainly valid"
     },
     {
+        "name": "getchaintxstats",
+        "namespace": "Blockchain",
+        "description": "Compute statistics about the total number and rate of transactions in the chain.",
+        "arguments": [
+            {
+                "name": "nblocks",
+                "type": "number",
+                "description": "Size of the window in number of blocks (default: one month).",
+                "is_required": false
+            },
+            {
+                "name": "blockhash",
+                "type": "string",
+                "description": "The hash of the block that ends the window.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getchaintxstats",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getchaintxstats\", \"params\": [2016] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"time\": xxxxx,                         (numeric) The timestamp for the final block in the window in UNIX format.\n  \"txcount\": xxxxx,                      (numeric) The total number of transactions in the chain up to that point.\n  \"window_final_block_hash\": \"...\",      (string) The hash of the final block in the window.\n  \"window_block_count\": xxxxx,           (numeric) Size of the window in number of blocks.\n  \"window_tx_count\": xxxxx,              (numeric) The number of transactions in the window. Only returned if \"window_block_count\" is > 0.\n  \"window_interval\": xxxxx,              (numeric) The elapsed time in the window in seconds. Only returned if \"window_block_count\" is > 0.\n  \"txrate\": x.xx,                        (numeric) The average rate of transactions per second in the window. Only returned if \"window_interval\" is > 0.\n}"
+    },
+    {
         "name": "getdifficulty",
         "namespace": "Blockchain",
         "description": "Returns the proof-of-work difficulty as a multiple of the minimum difficulty.",
@@ -467,6 +499,78 @@
         "returns": "n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty."
     },
     {
+        "name": "getmempoolancestors",
+        "namespace": "Blockchain",
+        "description": "If txid is in the mempool, returns all in-mempool ancestors.",
+        "arguments": [
+            {
+                "name": "txid",
+                "type": "string",
+                "description": "The transaction id (must be in mempool)",
+                "is_required": true
+            },
+            {
+                "name": "verbose",
+                "type": "boolean",
+                "description": "True for a json object, false for array of transaction ids",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getmempoolancestors \"mytxid\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempoolancestors\", \"params\": [\"mytxid\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "[                       (json array of strings)\n  \"transactionid\"           (string) The transaction id of an in-mempool ancestor transaction\n  ,...\n]\n\nResult (for verbose=true):\n{                           (json object)\n  \"transactionid\" : {       (json object)\n    \"size\" : n,             (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n    \"fee\" : n,              (numeric) transaction fee in LBC (DEPRECATED)\n    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority (DEPRECATED)\n    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n    \"height\" : n,           (numeric) block height when transaction entered pool\n    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n    \"descendantsize\" : n,   (numeric) virtual transaction size of in-mempool descendants (including this one)\n    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)\n    \"ancestorcount\" : n,    (numeric) number of in-mempool ancestor transactions (including this one)\n    \"ancestorsize\" : n,     (numeric) virtual transaction size of in-mempool ancestors (including this one)\n    \"ancestorfees\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)\n    \"wtxid\" : hash,         (string) hash of serialized transaction, including witness data\n    \"fees\" : {\n        \"base\" : n,         (numeric) transaction fee in LBC\n        \"modified\" : n,     (numeric) transaction fee with fee deltas used for mining priority in LBC\n        \"ancestor\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) in LBC\n        \"descendant\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) in LBC\n    }\n    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n        \"transactionid\",    (string) parent transaction id\n       ... ]\n    \"spentby\" : [           (array) unconfirmed transactions spending outputs from this transaction\n        \"transactionid\",    (string) child transaction id\n       ... ]\n  }, ...\n}"
+    },
+    {
+        "name": "getmempooldescendants",
+        "namespace": "Blockchain",
+        "description": "If txid is in the mempool, returns all in-mempool descendants.",
+        "arguments": [
+            {
+                "name": "txid",
+                "type": "string",
+                "description": "The transaction id (must be in mempool)",
+                "is_required": true
+            },
+            {
+                "name": "verbose",
+                "type": "boolean",
+                "description": "True for a json object, false for array of transaction ids",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getmempooldescendants \"mytxid\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempooldescendants\", \"params\": [\"mytxid\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "[                       (json array of strings)\n  \"transactionid\"           (string) The transaction id of an in-mempool descendant transaction\n  ,...\n]\n\nResult (for verbose=true):\n{                           (json object)\n  \"transactionid\" : {       (json object)\n    \"size\" : n,             (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n    \"fee\" : n,              (numeric) transaction fee in LBC (DEPRECATED)\n    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority (DEPRECATED)\n    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n    \"height\" : n,           (numeric) block height when transaction entered pool\n    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n    \"descendantsize\" : n,   (numeric) virtual transaction size of in-mempool descendants (including this one)\n    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)\n    \"ancestorcount\" : n,    (numeric) number of in-mempool ancestor transactions (including this one)\n    \"ancestorsize\" : n,     (numeric) virtual transaction size of in-mempool ancestors (including this one)\n    \"ancestorfees\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)\n    \"wtxid\" : hash,         (string) hash of serialized transaction, including witness data\n    \"fees\" : {\n        \"base\" : n,         (numeric) transaction fee in LBC\n        \"modified\" : n,     (numeric) transaction fee with fee deltas used for mining priority in LBC\n        \"ancestor\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) in LBC\n        \"descendant\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) in LBC\n    }\n    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n        \"transactionid\",    (string) parent transaction id\n       ... ]\n    \"spentby\" : [           (array) unconfirmed transactions spending outputs from this transaction\n        \"transactionid\",    (string) child transaction id\n       ... ]\n  }, ...\n}"
+    },
+    {
+        "name": "getmempoolentry",
+        "namespace": "Blockchain",
+        "description": "Returns mempool data for given transaction",
+        "arguments": [
+            {
+                "name": "txid",
+                "type": "string",
+                "description": "The transaction id (must be in mempool)",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getmempoolentry \"mytxid\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempoolentry\", \"params\": [\"mytxid\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{                           (json object)\n    \"size\" : n,             (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n    \"fee\" : n,              (numeric) transaction fee in LBC (DEPRECATED)\n    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority (DEPRECATED)\n    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n    \"height\" : n,           (numeric) block height when transaction entered pool\n    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n    \"descendantsize\" : n,   (numeric) virtual transaction size of in-mempool descendants (including this one)\n    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)\n    \"ancestorcount\" : n,    (numeric) number of in-mempool ancestor transactions (including this one)\n    \"ancestorsize\" : n,     (numeric) virtual transaction size of in-mempool ancestors (including this one)\n    \"ancestorfees\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)\n    \"wtxid\" : hash,         (string) hash of serialized transaction, including witness data\n    \"fees\" : {\n        \"base\" : n,         (numeric) transaction fee in LBC\n        \"modified\" : n,     (numeric) transaction fee with fee deltas used for mining priority in LBC\n        \"ancestor\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) in LBC\n        \"descendant\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) in LBC\n    }\n    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n        \"transactionid\",    (string) parent transaction id\n       ... ]\n    \"spentby\" : [           (array) unconfirmed transactions spending outputs from this transaction\n        \"transactionid\",    (string) child transaction id\n       ... ]\n}"
+    },
+    {
         "name": "getmempoolinfo",
         "namespace": "Blockchain",
         "description": "Returns details on the active state of the TX memory pool.",
@@ -477,17 +581,17 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmempoolinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"size\": xxxxx,               (numeric) Current tx count\n  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n  \"mempoolminfee\": xxxxx       (numeric) Minimum fee for tx to be accepted\n}"
+        "returns": "{\n  \"size\": xxxxx,               (numeric) Current tx count\n  \"bytes\": xxxxx,              (numeric) Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted\n  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n  \"mempoolminfee\": xxxxx       (numeric) Minimum fee rate in LBC/kB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee\n  \"minrelaytxfee\": xxxxx       (numeric) Current minimum relay fee for transactions\n}"
     },
     {
         "name": "getrawmempool",
         "namespace": "Blockchain",
-        "description": "Returns all transaction ids in memory pool as a json array of string transaction ids.",
+        "description": "Returns all transaction ids in memory pool as a json array of string transaction ids. Hint: use getmempoolentry to fetch a specific transaction from the mempool.",
         "arguments": [
             {
                 "name": "verbose",
                 "type": "boolean",
-                "description": "true for a json object, false for array of transaction ids",
+                "description": "True for a json object, false for array of transaction ids",
                 "is_required": false
             }
         ],
@@ -497,7 +601,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getrawmempool\", \"params\": [true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[                     (json array of string)\n  \"transactionid\"     (string) The transaction id\n  ,...\n]\n\nResult: (for verbose = true):\n{                           (json object)\n  \"transactionid\" : {       (json object)\n    \"size\" : n,             (numeric) transaction size in bytes\n    \"fee\" : n,              (numeric) transaction fee in LBC\n    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority\n    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n    \"height\" : n,           (numeric) block height when transaction entered pool\n    \"startingpriority\" : n, (numeric) priority when transaction entered pool\n    \"currentpriority\" : n,  (numeric) transaction priority now\n    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n    \"descendantsize\" : n,   (numeric) size of in-mempool descendants (including this one)\n    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one)\n    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n        \"transactionid\",    (string) parent transaction id\n       ... ]\n  }, ...\n}"
+        "returns": "[                     (json array of string)\n  \"transactionid\"     (string) The transaction id\n  ,...\n]\n\nResult: (for verbose = true):\n{                           (json object)\n  \"transactionid\" : {       (json object)\n    \"size\" : n,             (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n    \"fee\" : n,              (numeric) transaction fee in LBC (DEPRECATED)\n    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority (DEPRECATED)\n    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n    \"height\" : n,           (numeric) block height when transaction entered pool\n    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n    \"descendantsize\" : n,   (numeric) virtual transaction size of in-mempool descendants (including this one)\n    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) (DEPRECATED)\n    \"ancestorcount\" : n,    (numeric) number of in-mempool ancestor transactions (including this one)\n    \"ancestorsize\" : n,     (numeric) virtual transaction size of in-mempool ancestors (including this one)\n    \"ancestorfees\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) (DEPRECATED)\n    \"wtxid\" : hash,         (string) hash of serialized transaction, including witness data\n    \"fees\" : {\n        \"base\" : n,         (numeric) transaction fee in LBC\n        \"modified\" : n,     (numeric) transaction fee with fee deltas used for mining priority in LBC\n        \"ancestor\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one) in LBC\n        \"descendant\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one) in LBC\n    }\n    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n        \"transactionid\",    (string) parent transaction id\n       ... ]\n    \"spentby\" : [           (array) unconfirmed transactions spending outputs from this transaction\n        \"transactionid\",    (string) child transaction id\n       ... ]\n  }, ...\n}"
     },
     {
         "name": "gettxout",
@@ -517,9 +621,9 @@
                 "is_required": true
             },
             {
-                "name": "includemempool",
+                "name": "include_mempool",
                 "type": "boolean",
-                "description": "Whether to include the mem pool",
+                "description": "Whether to include the mempool. Default: true. Note that an unspent output that is spent in the mempool won't appear.",
                 "is_required": false
             }
         ],
@@ -537,12 +641,12 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"gettxout\", \"params\": [\"txid\", 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"bestblock\" : \"hash\",    (string) the block hash\n  \"confirmations\" : n,       (numeric) The number of confirmations\n  \"value\" : x.xxx,           (numeric) The transaction value in LBC\n  \"scriptPubKey\" : {         (json object)\n     \"asm\" : \"code\",       (string) \n     \"hex\" : \"hex\",        (string) \n     \"reqSigs\" : n,          (numeric) Number of required signatures\n     \"type\" : \"pubkeyhash\", (string) The type, eg pubkeyhash\n     \"addresses\" : [          (array of string) array of lbrycrd addresses\n        \"lbrycrdaddress\"     (string) lbrycrd address\n        ,...\n     ]\n  },\n  \"version\" : n,            (numeric) The version\n  \"coinbase\" : true|false   (boolean) Coinbase or not\n}"
+        "returns": "{\n  \"bestblock\":  \"hash\",    (string) The hash of the block at the tip of the chain\n  \"confirmations\" : n,       (numeric) The number of confirmations\n  \"value\" : x.xxx,           (numeric) The transaction value in LBC\n  \"scriptPubKey\" : {         (json object)\n     \"asm\" : \"code\",       (string) \n     \"hex\" : \"hex\",        (string) \n     \"reqSigs\" : n,          (numeric) Number of required signatures\n     \"type\" : \"pubkeyhash\", (string) The type, eg pubkeyhash\n     \"addresses\" : [          (array of string) array of lbrycrd addresses\n        \"address\"     (string) lbrycrd address\n        ,...\n     ]\n  },\n  \"coinbase\" : true|false   (boolean) Coinbase or not\n}"
     },
     {
         "name": "gettxoutproof",
         "namespace": "Blockchain",
-        "description": "Returns a hex-encoded proof that \"txid\" was included in a block. NOTE: By default this function only works sometimes. This is when there is an unspent output in the utxo for this transaction. To make it always work, you need to maintain a transaction index, using the -txindex command line option or specify the block in which the transaction is included in manually (by blockhash). Return the raw transaction data.",
+        "description": "Returns a hex-encoded proof that \"txid\" was included in a block. NOTE: By default this function only works sometimes. This is when there is an unspent output in the utxo for this transaction. To make it always work, you need to maintain a transaction index, using the -txindex command line option or specify the block in which the transaction is included manually (by blockhash).",
         "arguments": [
             {
                 "name": "txids",
@@ -551,7 +655,7 @@
                 "is_required": true
             },
             {
-                "name": "block hash",
+                "name": "blockhash",
                 "type": "string",
                 "description": "If specified, looks for txid in the block with this hash",
                 "is_required": false
@@ -571,7 +675,178 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"gettxoutsetinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"height\":n,     (numeric) The current block height (index)\n  \"bestblock\": \"hex\",   (string) the best block hash hex\n  \"transactions\": n,      (numeric) The number of transactions\n  \"txouts\": n,            (numeric) The number of output transactions\n  \"bytes_serialized\": n,  (numeric) The serialized size\n  \"hash_serialized\": \"hash\",   (string) The serialized hash\n  \"total_amount\": x.xxx          (numeric) The total amount\n}"
+        "returns": "{\n  \"height\":n,     (numeric) The current block height (index)\n  \"bestblock\": \"hex\",   (string) The hash of the block at the tip of the chain\n  \"transactions\": n,      (numeric) The number of transactions with unspent outputs\n  \"txouts\": n,            (numeric) The number of unspent transaction outputs\n  \"bogosize\": n,          (numeric) A meaningless metric for UTXO set size\n  \"hash_serialized_2\": \"hash\", (string) The serialized hash\n  \"disk_size\": n,         (numeric) The estimated size of the chainstate on disk\n  \"total_amount\": x.xxx          (numeric) The total amount\n}"
+    },
+    {
+        "name": "preciousblock",
+        "namespace": "Blockchain",
+        "description": "Treats a block as if it were received before others with the same work. A later preciousblock call can override the effect of an earlier one. The effects of preciousblock are not retained across restarts.",
+        "arguments": [
+            {
+                "name": "blockhash",
+                "type": "string",
+                "description": "the hash of the block to mark as precious",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli preciousblock \"blockhash\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"preciousblock\", \"params\": [\"blockhash\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": ""
+    },
+    {
+        "name": "pruneblockchain",
+        "namespace": "Blockchain",
+        "description": "",
+        "arguments": [
+            {
+                "name": "height",
+                "type": "number",
+                "description": "The block height to prune up to. May be set to a discrete height, or a unix timestamp to prune blocks whose block time is at least 2 hours older than the provided timestamp.",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli pruneblockchain 1000",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"pruneblockchain\", \"params\": [1000] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "n    (numeric) Height of the last block pruned."
+    },
+    {
+        "name": "savemempool",
+        "namespace": "Blockchain",
+        "description": "Dumps the mempool to disk. It will fail until the previous dump is fully loaded.",
+        "arguments": [],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli savemempool",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"savemempool\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "scantxoutset",
+        "namespace": "Blockchain",
+        "description": "EXPERIMENTAL warning: this call may be removed or changed in future releases. Scans the unspent transaction output set for entries that match certain output descriptors.",
+        "arguments": [],
+        "examples": [
+            {
+                "title": "addr(<address>)                      Outputs whose scriptPubKey corresponds to the specified address (does not include P2PK)"
+            },
+            {
+                "title": "raw(<hex script>)                    Outputs whose scriptPubKey equals the specified hex scripts"
+            },
+            {
+                "title": "combo(<pubkey>)                      P2PK, P2PKH, P2WPKH, and P2SH-P2WPKH outputs for the given pubkey"
+            },
+            {
+                "title": "pkh(<pubkey>)                        P2PKH outputs for the given pubkey"
+            },
+            {
+                "title": "sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys"
+            },
+            {
+                "title": "In the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one"
+            },
+            {
+                "title": "or more path elements separated by \"/\", and optionally ending in \"/*\" (unhardened), or \"/*'\" or \"/*h\" (hardened) to specify all"
+            },
+            {
+                "title": "unhardened or hardened child keys."
+            },
+            {
+                "title": "In the latter case, a range needs to be specified by below if different from 1000."
+            },
+            {
+                "title": "For more information on output descriptors, see the documentation in the doc/descriptors.md file."
+            },
+            {
+                "title": "Arguments:"
+            },
+            {
+                "title": "1. \"action\"                       (string, required) The action to execute"
+            },
+            {
+                "title": "\"start\" for starting a scan"
+            },
+            {
+                "title": "\"abort\" for aborting the current scan (returns true when abort was successful)"
+            },
+            {
+                "title": "\"status\" for progress report (in %) of the current scan"
+            },
+            {
+                "title": "2. \"scanobjects\"                  (array, required) Array of scan objects"
+            },
+            {
+                "title": "[                             Every scan object is either a string descriptor or an object:"
+            },
+            {
+                "title": "\"descriptor\",             (string, optional) An output descriptor"
+            },
+            {
+                "title": "{                         (object, optional) An object with output descriptor and metadata"
+            },
+            {
+                "title": "\"desc\": \"descriptor\",   (string, required) An output descriptor"
+            },
+            {
+                "title": "\"range\": n,             (numeric, optional) Up to what child index HD chains should be explored (default: 1000)"
+            },
+            {
+                "title": "},"
+            },
+            {
+                "title": "..."
+            },
+            {
+                "title": "]"
+            },
+            {
+                "title": "Result:"
+            },
+            {
+                "title": "{"
+            },
+            {
+                "title": "\"unspents\": ["
+            },
+            {
+                "title": "{"
+            },
+            {
+                "title": "\"txid\" : \"transactionid\",     (string) The transaction id"
+            },
+            {
+                "title": "\"vout\": n,                    (numeric) the vout value"
+            },
+            {
+                "title": "\"scriptPubKey\" : \"script\",    (string) the script key"
+            },
+            {
+                "title": "\"amount\" : x.xxx,             (numeric) The total amount in LBC of the unspent output"
+            },
+            {
+                "title": "\"height\" : n,                 (numeric) Height of the unspent transaction output"
+            },
+            {
+                "title": "}"
+            },
+            {
+                "title": ",...],"
+            },
+            {
+                "title": "\"total_amount\" : x.xxx,          (numeric) The total amount of all found unspent outputs in LBC"
+            },
+            {
+                "title": "]"
+            }
+        ]
     },
     {
         "name": "verifychain",
@@ -585,7 +860,7 @@
                 "is_required": false
             },
             {
-                "name": "numblocks",
+                "name": "nblocks",
                 "type": "number",
                 "description": "The number of blocks to check.",
                 "is_required": false
@@ -612,20 +887,27 @@
             }
         ],
         "examples": [],
-        "returns": "[\"txid\"]      (array, strings) The txid(s) which the proof commits to, or empty array if the proof is invalid"
+        "returns": "[\"txid\"]      (array, strings) The txid(s) which the proof commits to, or empty array if the proof can not be validated."
     },
     {
-        "name": "getinfo",
+        "name": "getmemoryinfo",
         "namespace": "Control",
-        "description": "Returns an object containing various state info.",
-        "arguments": [],
-        "examples": [
+        "description": "Returns an object containing information about memory usage.",
+        "arguments": [
             {
-                "cli": "> lbrycrd-cli getinfo",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "name": "\"mode\" determines what kind of information is returned. This argument is optional, the default mode is \"stats\".\n  - \"stats\" returns general statistics about memory usage in the daemon.\n  - \"mallocinfo\" returns an XML string describing low-level heap state",
+                "type": "only available if compiled with glibc 2.10+",
+                "description": ".",
+                "is_required": true
             }
         ],
-        "returns": "{\n  \"version\": xxxxx,           (numeric) the server version\n  \"protocolversion\": xxxxx,   (numeric) the protocol version\n  \"walletversion\": xxxxx,     (numeric) the wallet version\n  \"balance\": xxxxxxx,         (numeric) the total lbrycrd balance of the wallet\n  \"blocks\": xxxxxx,           (numeric) the current number of blocks processed in the server\n  \"timeoffset\": xxxxx,        (numeric) the time offset\n  \"connections\": xxxxx,       (numeric) the number of connections\n  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n  \"keypoolsize\": xxxx,        (numeric) how many new keys are pre-generated\n  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n  \"paytxfee\": x.xxxx,         (numeric) the transaction fee set in LBC/kB\n  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in LBC/kB\n  \"errors\": \"...\"           (string) any error messages\n}"
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getmemoryinfo",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmemoryinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"locked\": {               (json object) Information about locked memory manager\n    \"used\": xxxxx,          (numeric) Number of bytes used\n    \"free\": xxxxx,          (numeric) Number of bytes available in current arenas\n    \"total\": xxxxxxx,       (numeric) Total number of bytes managed\n    \"locked\": xxxxxx,       (numeric) Amount of bytes that succeeded locking. If this number is smaller than total, locking pages failed at some point and key data could be swapped to disk.\n    \"chunks_used\": xxxxx,   (numeric) Number allocated chunks\n    \"chunks_free\": xxxxx,   (numeric) Number unused chunks\n  }\n}\n\nResult (mode \"mallocinfo\"):\n\"<malloc version=\"1\">...\""
     },
     {
         "name": "help",
@@ -643,19 +925,58 @@
         "returns": "\"text\"     (string) The help text"
     },
     {
+        "name": "logging",
+        "namespace": "Control",
+        "description": "Gets and sets the logging configuration. When called without an argument, returns the list of categories with status that are currently being debug logged or not. When called with arguments, adds or removes categories from debug logging and return the lists above. The arguments are evaluated in order \"include\", \"exclude\". If an item is both included and excluded, it will thus end up being excluded. The valid logging categories are: net, tor, mempool, http, bench, zmq, db, rpc, estimatefee, addrman, selectcoins, reindex, cmpctblock, rand, prune, proxy, mempoolrej, libevent, coindb, qt, leveldb In addition, the following are available as category names with special meanings: - \"all\", \"1\" : represent all logging categories. - \"none\", \"0\" : even if other logging categories are specified, ignore all of them.",
+        "arguments": [
+            {
+                "name": "include",
+                "type": "array",
+                "description": "A json array of categories to add debug logging [ \"category\" (string) the valid logging category ,... ]",
+                "is_required": false
+            },
+            {
+                "name": "exclude",
+                "type": "array",
+                "description": "A json array of categories to remove debug logging [ \"category\" (string) the valid logging category ,... ]",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli logging \"[\\\"all\\\"]\" \"[\\\"http\\\"]\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"logging\", \"params\": [[\"all\"], \"[libevent]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{                   (json object where keys are the logging categories, and values indicates its status\n  \"category\": 0|1,  (numeric) if being debug logged or not. 0:inactive, 1:active\n  ...\n}"
+    },
+    {
         "name": "stop",
         "namespace": "Control",
-        "description": "Stop LBRYcrd server.",
+        "description": "Stop lbrycrd server.",
         "arguments": [],
         "examples": []
     },
     {
+        "name": "uptime",
+        "namespace": "Control",
+        "description": "Returns the total uptime of the server.",
+        "arguments": [],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli uptime",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"uptime\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "ttt        (numeric) The number of seconds that the server has been running"
+    },
+    {
         "name": "generate",
         "namespace": "Generating",
-        "description": "Mine up to numblocks blocks immediately (before the RPC call returns)",
+        "description": "Mine up to nblocks blocks immediately (before the RPC call returns) to an address in the wallet.",
         "arguments": [
             {
-                "name": "numblocks",
+                "name": "nblocks",
                 "type": "number",
                 "description": "How many blocks are generated immediately.",
                 "is_required": true
@@ -663,7 +984,7 @@
             {
                 "name": "maxtries",
                 "type": "number",
-                "description": "How many iterations to try (default = 1000000). Result [ blockhashes ] (array) hashes of blocks generated",
+                "description": "How many iterations to try (default = 1000000).",
                 "is_required": false
             }
         ],
@@ -672,7 +993,8 @@
                 "title": "Generate 11 blocks",
                 "cli": "> lbrycrd-cli generate 11"
             }
-        ]
+        ],
+        "returns": "[ blockhashes ]     (array) hashes of blocks generated"
     },
     {
         "name": "generatetoaddress",
@@ -680,7 +1002,7 @@
         "description": "Mine blocks immediately to a specified address (before the RPC call returns)",
         "arguments": [
             {
-                "name": "numblocks",
+                "name": "nblocks",
                 "type": "number",
                 "description": "How many blocks are generated immediately.",
                 "is_required": true
@@ -688,13 +1010,13 @@
             {
                 "name": "address",
                 "type": "string",
-                "description": "The address to send the newly generated bitcoin to.",
+                "description": "The address to send the newly generated lbry to.",
                 "is_required": true
             },
             {
                 "name": "maxtries",
                 "type": "number",
-                "description": "How many iterations to try (default = 1000000). Result [ blockhashes ] (array) hashes of blocks generated",
+                "description": "How many iterations to try (default = 1000000).",
                 "is_required": false
             }
         ],
@@ -703,52 +1025,28 @@
                 "title": "Generate 11 blocks to myaddress",
                 "cli": "> lbrycrd-cli generatetoaddress 11 \"myaddress\""
             }
-        ]
+        ],
+        "returns": "[ blockhashes ]     (array) hashes of blocks generated"
     },
     {
         "name": "getblocktemplate",
         "namespace": "Mining",
-        "description": "If the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'. It returns data needed to construct a block to work on. See https://en.bitcoin.it/wiki/BIP_0022 for full specification.",
+        "description": "If the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'. It returns data needed to construct a block to work on. For full specification, see BIPs 22, 23, 9, and 145: https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki#getblocktemplate_changes https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki",
         "arguments": [
             {
-                "name": "jsonrequestobject",
-                "type": "string",
-                "description": "A json object in the following spec { \"mode\":\"template\" (string, optional) This must be set to \"template\" or omitted \"capabilities\":[ (array, optional) A list of strings \"support\" (string) client side supported feature, 'longpoll', 'coinbasetxn', 'coinbasevalue', 'proposal', 'serverlist', 'workid' ,... ] }",
+                "name": "template_request",
+                "type": "object",
+                "description": "A json object in the following spec { \"mode\":\"template\" (string, optional) This must be set to \"template\", \"proposal\" (see BIP 23), or omitted \"capabilities\":[ (array, optional) A list of strings \"support\" (string) client side supported feature, 'longpoll', 'coinbasetxn', 'coinbasevalue', 'proposal', 'serverlist', 'workid' ,... ], \"rules\":[ (array, optional) A list of strings \"support\" (string) client side supported softfork deployment ,... ] }",
                 "is_required": false
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli getblocktemplate",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblocktemplate\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli getblocktemplate {\"rules\": [\"segwit\"]}",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getblocktemplate\", \"params\": [{\"rules\": [\"segwit\"]}] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"version\" : n,                    (numeric) The block version\n  \"previousblockhash\" : \"xxxx\",    (string) The hash of current highest block\n  \"transactions\" : [                (array) contents of non-coinbase transactions that should be included in the next block\n      {\n         \"data\" : \"xxxx\",          (string) transaction data encoded in hexadecimal (byte-for-byte)\n         \"hash\" : \"xxxx\",          (string) hash/id encoded in little-endian hexadecimal\n         \"depends\" : [              (array) array of numbers \n             n                        (numeric) transactions before this one (by 1-based index in 'transactions' list) that must be present in the final block if this one is\n             ,...\n         ],\n         \"fee\": n,                   (numeric) difference in value between transaction inputs and outputs (in Satoshis); for coinbase transactions, this is a negative Number of the total collected block fees (ie, not including the block subsidy); if key is not present, fee is unknown and clients MUST NOT assume there isn't one\n         \"sigops\" : n,               (numeric) total number of SigOps, as counted for purposes of block limits; if key is not present, sigop count is unknown and clients MUST NOT assume there aren't any\n         \"required\" : true|false     (boolean) if provided and true, this transaction must be in the final block\n      }\n      ,...\n  ],\n  \"coinbaseaux\" : {                  (json object) data that should be included in the coinbase's scriptSig content\n      \"flags\" : \"flags\"            (string) \n  },\n  \"coinbasevalue\" : n,               (numeric) maximum allowable input to coinbase transaction, including the generation award and transaction fees (in Satoshis)\n  \"coinbasetxn\" : { ... },           (json object) information for coinbase transaction\n  \"target\" : \"xxxx\",               (string) The hash target\n  \"mintime\" : xxx,                   (numeric) The minimum timestamp appropriate for next block time in seconds since epoch (Jan 1 1970 GMT)\n  \"mutable\" : [                      (array of string) list of ways the block template may be changed \n     \"value\"                         (string) A way the block template may be changed, e.g. 'time', 'transactions', 'prevblock'\n     ,...\n  ],\n  \"noncerange\" : \"00000000ffffffff\",   (string) A range of valid nonces\n  \"sigoplimit\" : n,                 (numeric) limit of sigops in blocks\n  \"sizelimit\" : n,                  (numeric) limit of block size\n  \"curtime\" : ttt,                  (numeric) current timestamp in seconds since epoch (Jan 1 1970 GMT)\n  \"bits\" : \"xxx\",                 (string) compressed target of next block\n  \"height\" : n                      (numeric) The height of the next block\n}"
-    },
-    {
-        "name": "getgenerate",
-        "namespace": "Mining",
-        "description": "Return if the server is set to generate coins or not. The default is false. It is set with the command line argument -gen (or lbrycrd.conf setting gen) It can also be set with the setgenerate call. Result true|false (boolean) If the server is set to generate coins or not",
-        "arguments": [],
-        "examples": [
-            {
-                "cli": "> lbrycrd-cli getgenerate",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getgenerate\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
-            }
-        ]
-    },
-    {
-        "name": "gethashespersec",
-        "namespace": "Mining",
-        "description": "Returns a recent hashes per second performance measurement while generating. See the getgenerate and setgenerate calls to turn generation on and off.",
-        "arguments": [],
-        "examples": [
-            {
-                "cli": "> lbrycrd-cli gethashespersec",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"gethashespersec\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
-            }
-        ],
-        "returns": "n            (numeric) The recent hashes per second when generation is on (will return 0 if generation is off)"
+        "returns": "{\n  \"version\" : n,                    (numeric) The preferred block version\n  \"rules\" : [ \"rulename\", ... ],    (array of strings) specific block rules that are to be enforced\n  \"vbavailable\" : {                 (json object) set of pending, supported versionbit (BIP 9) softfork deployments\n      \"rulename\" : bitnumber          (numeric) identifies the bit number as indicating acceptance and readiness for the named softfork rule\n      ,...\n  },\n  \"vbrequired\" : n,                 (numeric) bit mask of versionbits the server requires set in submissions\n  \"previousblockhash\" : \"xxxx\",     (string) The hash of current highest block\n  \"transactions\" : [                (array) contents of non-coinbase transactions that should be included in the next block\n      {\n         \"data\" : \"xxxx\",             (string) transaction data encoded in hexadecimal (byte-for-byte)\n         \"txid\" : \"xxxx\",             (string) transaction id encoded in little-endian hexadecimal\n         \"hash\" : \"xxxx\",             (string) hash encoded in little-endian hexadecimal (including witness data)\n         \"depends\" : [                (array) array of numbers \n             n                          (numeric) transactions before this one (by 1-based index in 'transactions' list) that must be present in the final block if this one is\n             ,...\n         ],\n         \"fee\": n,                    (numeric) difference in value between transaction inputs and outputs (in satoshis); for coinbase transactions, this is a negative Number of the total collected block fees (ie, not including the block subsidy); if key is not present, fee is unknown and clients MUST NOT assume there isn't one\n         \"sigops\" : n,                (numeric) total SigOps cost, as counted for purposes of block limits; if key is not present, sigop cost is unknown and clients MUST NOT assume it is zero\n         \"weight\" : n,                (numeric) total transaction weight, as counted for purposes of block limits\n      }\n      ,...\n  ],\n  \"coinbaseaux\" : {                 (json object) data that should be included in the coinbase's scriptSig content\n      \"flags\" : \"xx\"                  (string) key name is to be ignored, and value included in scriptSig\n  },\n  \"coinbasevalue\" : n,              (numeric) maximum allowable input to coinbase transaction, including the generation award and transaction fees (in satoshis)\n  \"coinbasetxn\" : { ... },          (json object) information for coinbase transaction\n  \"target\" : \"xxxx\",                (string) The hash target\n  \"mintime\" : xxx,                  (numeric) The minimum timestamp appropriate for next block time in seconds since epoch (Jan 1 1970 GMT)\n  \"mutable\" : [                     (array of string) list of ways the block template may be changed \n     \"value\"                          (string) A way the block template may be changed, e.g. 'time', 'transactions', 'prevblock'\n     ,...\n  ],\n  \"noncerange\" : \"00000000ffffffff\", (string) A range of valid nonces\n  \"sigoplimit\" : n,                 (numeric) limit of sigops in blocks\n  \"sizelimit\" : n,                  (numeric) limit of block size\n  \"weightlimit\" : n,                (numeric) limit of block weight\n  \"curtime\" : ttt,                  (numeric) current timestamp in seconds since epoch (Jan 1 1970 GMT)\n  \"bits\" : \"xxxxxxxx\",              (string) compressed target of next block\n  \"height\" : n                      (numeric) The height of the next block\n  \"claimtrie\" : \"00000000ffffffff\", (string) The root hash of the claim trie in hex\n}"
     },
     {
         "name": "getmininginfo",
@@ -761,7 +1059,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getmininginfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"blocks\": nnn,             (numeric) The current block\n  \"currentblocksize\": nnn,   (numeric) The last block size\n  \"currentblocktx\": nnn,     (numeric) The last block transaction\n  \"difficulty\": xxx.xxxxx    (numeric) The current difficulty\n  \"errors\": \"...\"          (string) Current errors\n  \"generate\": true|false     (boolean) If the generation is on or off (see getgenerate or setgenerate calls)\n  \"genproclimit\": n          (numeric) The processor limit for generation. -1 if no generation. (see getgenerate or setgenerate calls)\n  \"hashespersec\": n          (numeric) The hashes per second of the generation, or 0 if no generation.\n  \"pooledtx\": n              (numeric) The size of the mem pool\n  \"testnet\": true|false      (boolean) If using testnet or not\n  \"chain\": \"xxxx\",         (string) current network name as defined in BIP70 (main, test, regtest)\n}"
+        "returns": "{\n  \"blocks\": nnn,             (numeric) The current block\n  \"currentblockweight\": nnn, (numeric) The last block weight\n  \"currentblocktx\": nnn,     (numeric) The last block transaction\n  \"difficulty\": xxx.xxxxx    (numeric) The current difficulty\n  \"networkhashps\": nnn,      (numeric) The network hashes per second\n  \"pooledtx\": n              (numeric) The size of the mempool\n  \"chain\": \"xxxx\",           (string) current network name as defined in BIP70 (main, test, regtest)\n  \"warnings\": \"...\"          (string) any network and blockchain warnings\n}"
     },
     {
         "name": "getnetworkhashps",
@@ -769,7 +1067,7 @@
         "description": "Returns the estimated network hashes per second based on the last n blocks. Pass in [blocks] to override # of blocks, -1 specifies since last difficulty change. Pass in [height] to estimate the network speed at the time when a certain block was found.",
         "arguments": [
             {
-                "name": "blocks",
+                "name": "nblocks",
                 "type": "number",
                 "description": "The number of blocks, or -1 for blocks since last difficulty change.",
                 "is_required": false
@@ -801,15 +1099,15 @@
                 "is_required": true
             },
             {
-                "name": "priority delta",
+                "name": "dummy",
                 "type": "number",
-                "description": "The priority to add or subtract. The transaction selection algorithm considers the tx as it would have a higher priority. (priority of a transaction is calculated: coinage * value_in_satoshis / txsize)",
-                "is_required": true
+                "description": "API-Compatibility for previous API. Must be zero or null. DEPRECATED. For forward compatibility use named arguments and omit this parameter.",
+                "is_required": false
             },
             {
-                "name": "fee delta",
+                "name": "fee_delta",
                 "type": "number",
-                "description": "The fee value (in satoshis) to add (or subtract, if negative). The fee is not actually paid, only the algorithm for selecting transactions into a block considers the transaction as it would have paid a higher (or lower) fee. Result true (boolean) Returns true",
+                "description": "The fee value (in satoshis) to add (or subtract, if negative). Note, that this value is not a fee rate. It is a value to modify absolute fee of the TX. The fee is not actually paid, only the algorithm for selecting transactions into a block considers the transaction as it would have paid a higher (or lower) fee.",
                 "is_required": true
             }
         ],
@@ -818,49 +1116,13 @@
                 "cli": "> lbrycrd-cli prioritisetransaction \"txid\" 0.0 10000",
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"prioritisetransaction\", \"params\": [\"txid\", 0.0, 10000] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
-        ]
-    },
-    {
-        "name": "setgenerate",
-        "namespace": "Mining",
-        "description": "Set 'generate' true or false to turn generation on or off. Generation is limited to 'genproclimit' processors, -1 is unlimited. See the getgenerate call for the current setting.",
-        "arguments": [
-            {
-                "name": "generate",
-                "type": "boolean",
-                "description": "Set to true to turn on generation, off to turn off.",
-                "is_required": true
-            },
-            {
-                "name": "genproclimit",
-                "type": "number",
-                "description": "Set the processor limit for when generation is on. Can be -1 for unlimited.",
-                "is_required": false
-            }
         ],
-        "examples": [
-            {
-                "title": "Set the generation on with a limit of one processor",
-                "cli": "> lbrycrd-cli setgenerate true 1"
-            },
-            {
-                "title": "Check the setting",
-                "cli": "> lbrycrd-cli getgenerate"
-            },
-            {
-                "title": "Turn off generation",
-                "cli": "> lbrycrd-cli setgenerate false"
-            },
-            {
-                "title": "Using json rpc",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setgenerate\", \"params\": [true, 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
-            }
-        ]
+        "returns": "true              (boolean) Returns true"
     },
     {
         "name": "submitblock",
         "namespace": "Mining",
-        "description": "Attempts to submit new block to network. The 'jsonparametersobject' parameter is currently ignored. See https://en.bitcoin.it/wiki/BIP_0022 for full specification.",
+        "description": "Attempts to submit new block to network. See https://en.bitcoin.it/wiki/BIP_0022 for full specification.",
         "arguments": [
             {
                 "name": "hexdata",
@@ -869,9 +1131,9 @@
                 "is_required": true
             },
             {
-                "name": "jsonparametersobject",
-                "type": "string",
-                "description": "object of optional parameters { \"workid\" : \"id\" (string, optional) if the server provided a workid, it MUST be included with submissions }",
+                "name": "dummy",
+                "type": "optional",
+                "description": "dummy value, for compatibility with BIP",
                 "is_required": false
             }
         ],
@@ -886,7 +1148,7 @@
     {
         "name": "addnode",
         "namespace": "Network",
-        "description": "Attempts add or remove a node from the addnode list. Or try a connection to a node once.",
+        "description": "Attempts to add or remove a node from the addnode list. Or try a connection to a node once. Nodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be full nodes/support SegWit as other outbound peers are (though such peers will not be synced from).",
         "arguments": [
             {
                 "name": "node",
@@ -923,33 +1185,33 @@
     {
         "name": "disconnectnode",
         "namespace": "Network",
-        "description": "Immediately disconnects from the specified node.",
+        "description": "Immediately disconnects from the specified peer node. Strictly one out of 'address' and 'nodeid' can be provided to identify the node. To disconnect by nodeid, either set 'address' to the empty string, or call using the named 'nodeid' argument only.",
         "arguments": [
             {
-                "name": "node",
+                "name": "address",
                 "type": "string",
-                "description": "The node (see getpeerinfo for nodes)",
-                "is_required": true
+                "description": "The IP address/port of the node",
+                "is_required": false
+            },
+            {
+                "name": "nodeid",
+                "type": "number",
+                "description": "The node ID (see getpeerinfo for node IDs)",
+                "is_required": false
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli disconnectnode \"192.168.0.6:8333\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"disconnectnode\", \"params\": [\"192.168.0.6:8333\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli disconnectnode \"\" 1",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"disconnectnode\", \"params\": [\"\", 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ]
     },
     {
         "name": "getaddednodeinfo",
         "namespace": "Network",
-        "description": "Returns information about the given added node, or all added nodes (note that onetry addnodes are not listed here) If dns is false, only a list of added nodes will be provided, otherwise connected information will also be available.",
+        "description": "Returns information about the given added node, or all added nodes (note that onetry addnodes are not listed here)",
         "arguments": [
-            {
-                "name": "dns",
-                "type": "boolean",
-                "description": "If false, only a list of added nodes will be provided, otherwise connected information will also be available.",
-                "is_required": true
-            },
             {
                 "name": "node",
                 "type": "string",
@@ -959,11 +1221,11 @@
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli getaddednodeinfo true \"192.168.0.201\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddednodeinfo\", \"params\": [true, \"192.168.0.201\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli getaddednodeinfo \"192.168.0.201\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddednodeinfo\", \"params\": [\"192.168.0.201\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[\n  {\n    \"addednode\" : \"192.168.0.201\",   (string) The node ip address\n    \"connected\" : true|false,          (boolean) If connected\n    \"addresses\" : [\n       {\n         \"address\" : \"192.168.0.201:8333\",  (string) The lbrycrd server host and port\n         \"connected\" : \"outbound\"           (string) connection, inbound or outbound\n       }\n       ,...\n     ]\n  }\n  ,...\n]"
+        "returns": "[\n  {\n    \"addednode\" : \"192.168.0.201\",   (string) The node IP address or name (as provided to addnode)\n    \"connected\" : true|false,          (boolean) If connected\n    \"addresses\" : [                    (list of objects) Only when connected = true\n       {\n         \"address\" : \"192.168.0.201:8333\",  (string) The lbrycrd server IP and port we're connected to\n         \"connected\" : \"outbound\"           (string) connection, inbound or outbound\n       }\n     ]\n  }\n  ,...\n]"
     },
     {
         "name": "getconnectioncount",
@@ -989,7 +1251,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getnettotals\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"totalbytesrecv\": n,   (numeric) Total bytes received\n  \"totalbytessent\": n,   (numeric) Total bytes sent\n  \"timemillis\": t,       (numeric) Total cpu time\n  \"uploadtarget\":\n  {\n    \"timeframe\": n,                         (numeric) Length of the measuring timeframe in seconds\n    \"target\": n,                            (numeric) Target in bytes\n    \"target_reached\": true|false,           (boolean) True if target is reached\n    \"serve_historical_blocks\": true|false,  (boolean) True if serving historical blocks\n    \"bytes_left_in_cycle\": t,               (numeric) Bytes left in current time cycle\n    \"time_left_in_cycle\": t                 (numeric) Seconds left in current time cycle\n  }\n}"
+        "returns": "{\n  \"totalbytesrecv\": n,   (numeric) Total bytes received\n  \"totalbytessent\": n,   (numeric) Total bytes sent\n  \"timemillis\": t,       (numeric) Current UNIX time in milliseconds\n  \"uploadtarget\":\n  {\n    \"timeframe\": n,                         (numeric) Length of the measuring timeframe in seconds\n    \"target\": n,                            (numeric) Target in bytes\n    \"target_reached\": true|false,           (boolean) True if target is reached\n    \"serve_historical_blocks\": true|false,  (boolean) True if serving historical blocks\n    \"bytes_left_in_cycle\": t,               (numeric) Bytes left in current time cycle\n    \"time_left_in_cycle\": t                 (numeric) Seconds left in current time cycle\n  }\n}"
     },
     {
         "name": "getnetworkinfo",
@@ -1002,7 +1264,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getnetworkinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"version\": xxxxx,                      (numeric) the server version\n  \"subversion\": \"/Satoshi:x.x.x/\",     (string) the server subversion string\n  \"protocolversion\": xxxxx,              (numeric) the protocol version\n  \"localservices\": \"xxxxxxxxxxxxxxxx\", (string) the services we offer to the network\n  \"timeoffset\": xxxxx,                   (numeric) the time offset\n  \"connections\": xxxxx,                  (numeric) the number of connections\n  \"networks\": [                          (array) information per network\n  {\n    \"name\": \"xxx\",                     (string) network (ipv4, ipv6 or onion)\n    \"limited\": true|false,               (boolean) is the network limited using -onlynet?\n    \"reachable\": true|false,             (boolean) is the network reachable?\n    \"proxy\": \"host:port\"               (string) the proxy that is used for this network, or empty if none\n  }\n  ,...\n  ],\n  \"relayfee\": x.xxxxxxxx,                (numeric) minimum relay fee for non-free transactions in LBC/kB\n  \"localaddresses\": [                    (array) list of local addresses\n  {\n    \"address\": \"xxxx\",                 (string) network address\n    \"port\": xxx,                         (numeric) network port\n    \"score\": xxx                         (numeric) relative score\n  }\n  ,...\n  ]\n  \"warnings\": \"...\"                    (string) any network warnings (such as alert messages) \n}"
+        "returns": "{\n  \"version\": xxxxx,                      (numeric) the server version\n  \"subversion\": \"/Satoshi:x.x.x/\",     (string) the server subversion string\n  \"protocolversion\": xxxxx,              (numeric) the protocol version\n  \"localservices\": \"xxxxxxxxxxxxxxxx\", (string) the services we offer to the network\n  \"localrelay\": true|false,              (bool) true if transaction relay is requested from peers\n  \"timeoffset\": xxxxx,                   (numeric) the time offset\n  \"connections\": xxxxx,                  (numeric) the number of connections\n  \"networkactive\": true|false,           (bool) whether p2p networking is enabled\n  \"networks\": [                          (array) information per network\n  {\n    \"name\": \"xxx\",                     (string) network (ipv4, ipv6 or onion)\n    \"limited\": true|false,               (boolean) is the network limited using -onlynet?\n    \"reachable\": true|false,             (boolean) is the network reachable?\n    \"proxy\": \"host:port\"               (string) the proxy that is used for this network, or empty if none\n    \"proxy_randomize_credentials\": true|false,  (string) Whether randomized credentials are used\n  }\n  ,...\n  ],\n  \"relayfee\": x.xxxxxxxx,                (numeric) minimum relay fee for transactions in LBC/kB\n  \"incrementalfee\": x.xxxxxxxx,          (numeric) minimum fee increment for mempool limiting or BIP 125 replacement in LBC/kB\n  \"localaddresses\": [                    (array) list of local addresses\n  {\n    \"address\": \"xxxx\",                 (string) network address\n    \"port\": xxx,                         (numeric) network port\n    \"score\": xxx                         (numeric) relative score\n  }\n  ,...\n  ]\n  \"warnings\": \"...\"                    (string) any network and blockchain warnings\n}"
     },
     {
         "name": "getpeerinfo",
@@ -1015,7 +1277,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getpeerinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[\n  {\n    \"id\": n,                   (numeric) Peer index\n    \"addr\":\"host:port\",      (string) The ip address and port of the peer\n    \"addrlocal\":\"ip:port\",   (string) local address\n    \"services\":\"xxxxxxxxxxxxxxxx\",   (string) The services offered\n    \"relaytxes\":true|false,    (boolean) Whether peer has asked us to relay transactions to it\n    \"lastsend\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last send\n    \"lastrecv\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last receive\n    \"bytessent\": n,            (numeric) The total bytes sent\n    \"bytesrecv\": n,            (numeric) The total bytes received\n    \"conntime\": ttt,           (numeric) The connection time in seconds since epoch (Jan 1 1970 GMT)\n    \"timeoffset\": ttt,         (numeric) The time offset in seconds\n    \"pingtime\": n,             (numeric) ping time (if available)\n    \"minping\": n,              (numeric) minimum observed ping time (if any at all)\n    \"pingwait\": n,             (numeric) ping wait (if non-zero)\n    \"version\": v,              (numeric) The peer version, such as 7001\n    \"subver\": \"/Satoshi:0.8.5/\",  (string) The string version\n    \"inbound\": true|false,     (boolean) Inbound (true) or Outbound (false)\n    \"startingheight\": n,       (numeric) The starting height (block) of the peer\n    \"banscore\": n,             (numeric) The ban score\n    \"synced_headers\": n,       (numeric) The last header we have in common with this peer\n    \"synced_blocks\": n,        (numeric) The last block we have in common with this peer\n    \"inflight\": [\n       n,                        (numeric) The heights of blocks we're currently asking from this peer\n       ...\n    ]\n    \"bytessent_per_msg\": {\n       \"addr\": n,             (numeric) The total bytes sent aggregated by message type\n       ...\n    }\n    \"bytesrecv_per_msg\": {\n       \"addr\": n,             (numeric) The total bytes received aggregated by message type\n       ...\n    }\n  }\n  ,...\n]"
+        "returns": "[\n  {\n    \"id\": n,                   (numeric) Peer index\n    \"addr\":\"host:port\",      (string) The IP address and port of the peer\n    \"addrbind\":\"ip:port\",    (string) Bind address of the connection to the peer\n    \"addrlocal\":\"ip:port\",   (string) Local address as reported by the peer\n    \"services\":\"xxxxxxxxxxxxxxxx\",   (string) The services offered\n    \"relaytxes\":true|false,    (boolean) Whether peer has asked us to relay transactions to it\n    \"lastsend\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last send\n    \"lastrecv\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last receive\n    \"bytessent\": n,            (numeric) The total bytes sent\n    \"bytesrecv\": n,            (numeric) The total bytes received\n    \"conntime\": ttt,           (numeric) The connection time in seconds since epoch (Jan 1 1970 GMT)\n    \"timeoffset\": ttt,         (numeric) The time offset in seconds\n    \"pingtime\": n,             (numeric) ping time (if available)\n    \"minping\": n,              (numeric) minimum observed ping time (if any at all)\n    \"pingwait\": n,             (numeric) ping wait (if non-zero)\n    \"version\": v,              (numeric) The peer version, such as 70001\n    \"subver\": \"/Satoshi:0.8.5/\",  (string) The string version\n    \"inbound\": true|false,     (boolean) Inbound (true) or Outbound (false)\n    \"addnode\": true|false,     (boolean) Whether connection was due to addnode/-connect or if it was an automatic/inbound connection\n    \"startingheight\": n,       (numeric) The starting height (block) of the peer\n    \"banscore\": n,             (numeric) The ban score\n    \"synced_headers\": n,       (numeric) The last header we have in common with this peer\n    \"synced_blocks\": n,        (numeric) The last block we have in common with this peer\n    \"inflight\": [\n       n,                        (numeric) The heights of blocks we're currently asking from this peer\n       ...\n    ],\n    \"whitelisted\": true|false, (boolean) Whether the peer is whitelisted\n    \"bytessent_per_msg\": {\n       \"addr\": n,              (numeric) The total bytes sent aggregated by message type\n       ...\n    },\n    \"bytesrecv_per_msg\": {\n       \"addr\": n,              (numeric) The total bytes received aggregated by message type\n       ...\n    }\n  }\n  ,...\n]"
     },
     {
         "name": "listbanned",
@@ -1044,55 +1306,143 @@
     {
         "name": "setban",
         "namespace": "Network",
-        "description": "Attempts add or remove a IP/Subnet from the banned list.",
+        "description": "Attempts to add or remove an IP/Subnet from the banned list.",
         "arguments": [
             {
-                "name": "ip(/netmask)",
+                "name": "subnet",
                 "type": "string",
-                "description": "The IP/Subnet (see getpeerinfo for nodes ip) with a optional netmask (default is /32 = single ip)",
+                "description": "The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP)",
                 "is_required": true
             },
             {
                 "name": "command",
                 "type": "string",
-                "description": "'add' to add a IP/Subnet to the list, 'remove' to remove a IP/Subnet from the list",
+                "description": "'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list",
                 "is_required": true
             },
             {
                 "name": "bantime",
                 "type": "number",
-                "description": "time in seconds how long (or until when if [absolute] is set) the ip is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)",
+                "description": "time in seconds how long (or until when if [absolute] is set) the IP is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)",
                 "is_required": false
             },
             {
                 "name": "absolute",
                 "type": "boolean",
-                "description": "If set, the bantime must be a absolute timestamp in seconds since epoch (Jan 1 1970 GMT)",
+                "description": "If set, the bantime must be an absolute timestamp in seconds since epoch (Jan 1 1970 GMT)",
                 "is_required": false
             }
         ],
         "examples": [
             {
                 "cli": "> lbrycrd-cli setban \"192.168.0.0/24\" \"add\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setban\", \"params\": [\"192.168.0.6\", \"add\" 86400] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setban\", \"params\": [\"192.168.0.6\", \"add\", 86400] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ]
     },
     {
-        "name": "createrawtransaction",
-        "namespace": "Rawtransactions",
-        "description": "Create a transaction spending the given inputs and creating new outputs. Outputs can be addresses or data. Returns hex-encoded raw transaction. Note that the transaction's inputs are not signed, and it is not stored in the wallet or transmitted to the network.",
+        "name": "setnetworkactive",
+        "namespace": "Network",
+        "description": "Disable/enable all p2p network activity.",
         "arguments": [
             {
-                "name": "transactions",
+                "name": "state",
+                "type": "boolean",
+                "description": "true to enable networking, false to disable",
+                "is_required": true
+            }
+        ],
+        "examples": []
+    },
+    {
+        "name": "combinepsbt",
+        "namespace": "Rawtransactions",
+        "description": "Combine multiple partially signed LBRY transactions into one transaction. Implements the Combiner role.",
+        "arguments": [
+            {
+                "name": "txs",
                 "type": "string",
-                "description": "A json array of json objects [ { \"txid\":\"id\", (string, required) The transaction id \"vout\":n (numeric, required) The output number } ,... ]",
+                "description": "A json array of base64 strings of partially signed transactions [ \"psbt\" (string) A base64 string of a PSBT ,... ]",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli combinepsbt [\"mybase64_1\", \"mybase64_2\", \"mybase64_3\"]"
+            }
+        ],
+        "returns": "\"psbt\"          (string) The base64-encoded partially signed transaction"
+    },
+    {
+        "name": "combinerawtransaction",
+        "namespace": "Rawtransactions",
+        "description": "Combine multiple partially signed transactions into one transaction. The combined transaction may be another partially signed transaction or a fully signed transaction.",
+        "arguments": [
+            {
+                "name": "txs",
+                "type": "string",
+                "description": "A json array of hex strings of partially signed transactions [ \"hexstring\" (string) A transaction hash ,... ]",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli combinerawtransaction [\"myhex1\", \"myhex2\", \"myhex3\"]"
+            }
+        ],
+        "returns": "\"hex\"            (string) The hex-encoded raw transaction with signature(s)"
+    },
+    {
+        "name": "converttopsbt",
+        "namespace": "Rawtransactions",
+        "description": "Converts a network serialized transaction to a PSBT. This should be used only with createrawtransaction and fundrawtransaction createpsbt and walletcreatefundedpsbt should be used for new applications.",
+        "arguments": [
+            {
+                "name": "hexstring",
+                "type": "string",
+                "description": "The hex string of a raw transaction",
+                "is_required": true
+            },
+            {
+                "name": "permitsigdata",
+                "type": "boolean",
+                "description": "If true, any signatures in the input will be discarded and conversion. will continue. If false, RPC will fail if any signatures are present.",
+                "is_required": false
+            },
+            {
+                "name": "iswitness",
+                "type": "boolean",
+                "description": "Whether the transaction hex is a serialized witness transaction. If iswitness is not present, heuristic tests will be used in decoding. If true, only witness deserializaion will be tried. If false, only non-witness deserialization wil be tried. Only has an effect if permitsigdata is true.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "title": "Create a transaction",
+                "cli": "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\""
+            },
+            {
+                "title": "Convert the transaction to a PSBT",
+                "cli": "> lbrycrd-cli converttopsbt \"rawtransaction\""
+            }
+        ],
+        "returns": "\"psbt\"        (string)  The resulting raw transaction (base64-encoded string)"
+    },
+    {
+        "name": "createpsbt",
+        "namespace": "Rawtransactions",
+        "description": "Creates a transaction in the Partially Signed Transaction format. Implements the Creator role.",
+        "arguments": [
+            {
+                "name": "inputs",
+                "type": "array",
+                "description": "A json array of json objects [ { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"sequence\":n (numeric, optional) The sequence number } ,... ]",
                 "is_required": true
             },
             {
                 "name": "outputs",
-                "type": "string",
-                "description": "a json object with outputs { \"address\": x.xxx (numeric or string, required) The key is the lbrycrd address, the numeric value (can be string) is the LBC amount \"data\": \"hex\", (string, required) The key is \"data\", the value is hex encoded data ... }",
+                "type": "array",
+                "description": "a json array with outputs (key-value pairs), where none of the keys are duplicated. That is, each address can only appear once and there can only be one 'data' object. [ { \"address\": x.xxx, (obj, optional) A key-value pair. The key (string) is the lbry address, the value (float or string) is the amount in LBC }, { \"data\": \"hex\" (obj, optional) A key-value pair. The key must be \"data\", the value is hex encoded data } ,... More key-value pairs of the above form. For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also accepted as second parameter. ]",
                 "is_required": true
             },
             {
@@ -1100,15 +1450,77 @@
                 "type": "number",
                 "description": "Raw locktime. Non-0 value also locktime-activates inputs",
                 "is_required": false
+            },
+            {
+                "name": "replaceable",
+                "type": "boolean",
+                "description": "Marks this transaction as BIP125 replaceable. Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.",
+                "is_required": false
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"data\\\":\\\"00010203\\\"}\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"data\\\":\\\"00010203\\\"}\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli createpsbt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\""
             }
         ],
-        "returns": "\"transaction\"            (string) hex string of the transaction"
+        "returns": "\"psbt\"        (string)  The resulting raw transaction (base64-encoded string)"
+    },
+    {
+        "name": "createrawtransaction",
+        "namespace": "Rawtransactions",
+        "description": "Create a transaction spending the given inputs and creating new outputs. Outputs can be addresses or data. Returns hex-encoded raw transaction. Note that the transaction's inputs are not signed, and it is not stored in the wallet or transmitted to the network.",
+        "arguments": [
+            {
+                "name": "inputs",
+                "type": "array",
+                "description": "A json array of json objects [ { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"sequence\":n (numeric, optional) The sequence number } ,... ]",
+                "is_required": true
+            },
+            {
+                "name": "outputs",
+                "type": "array",
+                "description": "a json array with outputs (key-value pairs), where none of the keys are duplicated. That is, each address can only appear once and there can only be one 'data' object. [ { \"address\": x.xxx, (obj, optional) A key-value pair. The key (string) is the lbry address, the value (float or string) is the amount in LBC }, { \"data\": \"hex\" (obj, optional) A key-value pair. The key must be \"data\", the value is hex encoded data } ,... More key-value pairs of the above form. For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also accepted as second parameter. ]",
+                "is_required": true
+            },
+            {
+                "name": "locktime",
+                "type": "number",
+                "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+                "is_required": false
+            },
+            {
+                "name": "replaceable",
+                "type": "boolean",
+                "description": "Marks this transaction as BIP125 replaceable. Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createrawtransaction\", \"params\": [\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"data\\\":\\\"00010203\\\"}]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "\"transaction\"              (string) hex string of the transaction"
+    },
+    {
+        "name": "decodepsbt",
+        "namespace": "Rawtransactions",
+        "description": "Return a JSON object representing the serialized, base64-encoded partially signed LBRY transaction.",
+        "arguments": [
+            {
+                "name": "psbt",
+                "type": "string",
+                "description": "The PSBT base64 string",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli decodepsbt \"psbt\""
+            }
+        ],
+        "returns": "{\n  \"tx\" : {                   (json object) The decoded network-serialized unsigned transaction.\n    ...                                      The layout is the same as the output of decoderawtransaction.\n  },\n  \"unknown\" : {                (json object) The unknown global fields\n    \"key\" : \"value\"            (key-value pair) An unknown key-value pair\n     ...\n  },\n  \"inputs\" : [                 (array of json objects)\n    {\n      \"non_witness_utxo\" : {   (json object, optional) Decoded network transaction for non-witness UTXOs\n        ...\n      },\n      \"witness_utxo\" : {            (json object, optional) Transaction output for witness UTXOs\n        \"amount\" : x.xxx,           (numeric) The value in LBC\n        \"scriptPubKey\" : {          (json object)\n          \"asm\" : \"asm\",            (string) The asm\n          \"hex\" : \"hex\",            (string) The hex\n          \"type\" : \"pubkeyhash\",    (string) The type, eg 'pubkeyhash'\n          \"address\" : \"address\"     (string) LBRY address if there is one\n        }\n      },\n      \"partial_signatures\" : {             (json object, optional)\n        \"pubkey\" : \"signature\",           (string) The public key and signature that corresponds to it.\n        ,...\n      }\n      \"sighash\" : \"type\",                  (string, optional) The sighash type to be used\n      \"redeem_script\" : {       (json object, optional)\n          \"asm\" : \"asm\",            (string) The asm\n          \"hex\" : \"hex\",            (string) The hex\n          \"type\" : \"pubkeyhash\",    (string) The type, eg 'pubkeyhash'\n        }\n      \"witness_script\" : {       (json object, optional)\n          \"asm\" : \"asm\",            (string) The asm\n          \"hex\" : \"hex\",            (string) The hex\n          \"type\" : \"pubkeyhash\",    (string) The type, eg 'pubkeyhash'\n        }\n      \"bip32_derivs\" : {          (json object, optional)\n        \"pubkey\" : {                     (json object, optional) The public key with the derivation path as the value.\n          \"master_fingerprint\" : \"fingerprint\"     (string) The fingerprint of the master key\n          \"path\" : \"path\",                         (string) The path\n        }\n        ,...\n      }\n      \"final_scriptsig\" : {       (json object, optional)\n          \"asm\" : \"asm\",            (string) The asm\n          \"hex\" : \"hex\",            (string) The hex\n        }\n       \"final_scriptwitness\": [\"hex\", ...] (array of string) hex-encoded witness data (if any)\n      \"unknown\" : {                (json object) The unknown global fields\n        \"key\" : \"value\"            (key-value pair) An unknown key-value pair\n         ...\n      },\n    }\n    ,...\n  ]\n  \"outputs\" : [                 (array of json objects)\n    {\n      \"redeem_script\" : {       (json object, optional)\n          \"asm\" : \"asm\",            (string) The asm\n          \"hex\" : \"hex\",            (string) The hex\n          \"type\" : \"pubkeyhash\",    (string) The type, eg 'pubkeyhash'\n        }\n      \"witness_script\" : {       (json object, optional)\n          \"asm\" : \"asm\",            (string) The asm\n          \"hex\" : \"hex\",            (string) The hex\n          \"type\" : \"pubkeyhash\",    (string) The type, eg 'pubkeyhash'\n      }\n      \"bip32_derivs\" : [          (array of json objects, optional)\n        {\n          \"pubkey\" : \"pubkey\",                     (string) The public key this path corresponds to\n          \"master_fingerprint\" : \"fingerprint\"     (string) The fingerprint of the master key\n          \"path\" : \"path\",                         (string) The path\n          }\n        }\n        ,...\n      ],\n      \"unknown\" : {                (json object) The unknown global fields\n        \"key\" : \"value\"            (key-value pair) An unknown key-value pair\n         ...\n      },\n    }\n    ,...\n  ]\n  \"fee\" : fee                      (numeric, optional) The transaction fee paid if all UTXOs slots in the PSBT have been filled.\n}"
     },
     {
         "name": "decoderawtransaction",
@@ -1116,10 +1528,16 @@
         "description": "Return a JSON object representing the serialized, hex-encoded transaction.",
         "arguments": [
             {
-                "name": "hex",
+                "name": "hexstring",
                 "type": "string",
                 "description": "The transaction hex string",
                 "is_required": true
+            },
+            {
+                "name": "iswitness",
+                "type": "boolean",
+                "description": "Whether the transaction hex is a serialized witness transaction If iswitness is not present, heuristic tests will be used in decoding",
+                "is_required": false
             }
         ],
         "examples": [
@@ -1128,7 +1546,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"decoderawtransaction\", \"params\": [\"hexstring\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"txid\" : \"id\",        (string) The transaction id\n  \"size\" : n,             (numeric) The transaction size\n  \"version\" : n,          (numeric) The version\n  \"locktime\" : ttt,       (numeric) The lock time\n  \"vin\" : [               (array of json objects)\n     {\n       \"txid\": \"id\",    (string) The transaction id\n       \"vout\": n,         (numeric) The output number\n       \"scriptSig\": {     (json object) The script\n         \"asm\": \"asm\",  (string) asm\n         \"hex\": \"hex\"   (string) hex\n       },\n       \"sequence\": n     (numeric) The script sequence number\n     }\n     ,...\n  ],\n  \"vout\" : [             (array of json objects)\n     {\n       \"value\" : x.xxx,            (numeric) The value in LBC\n       \"n\" : n,                    (numeric) index\n       \"scriptPubKey\" : {          (json object)\n         \"asm\" : \"asm\",          (string) the asm\n         \"hex\" : \"hex\",          (string) the hex\n         \"reqSigs\" : n,            (numeric) The required sigs\n         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n         \"addresses\" : [           (json array of string)\n           \"12tvKAXCxZjSmdNbao16dKXC8tRWfcF5oc\"   (string) lbrycrd address\n           ,...\n         ]\n       }\n     }\n     ,...\n  ],\n}"
+        "returns": "{\n  \"txid\" : \"id\",        (string) The transaction id\n  \"hash\" : \"id\",        (string) The transaction hash (differs from txid for witness transactions)\n  \"size\" : n,             (numeric) The transaction size\n  \"vsize\" : n,            (numeric) The virtual transaction size (differs from size for witness transactions)\n  \"weight\" : n,           (numeric) The transaction's weight (between vsize*4 - 3 and vsize*4)\n  \"version\" : n,          (numeric) The version\n  \"locktime\" : ttt,       (numeric) The lock time\n  \"vin\" : [               (array of json objects)\n     {\n       \"txid\": \"id\",    (string) The transaction id\n       \"vout\": n,         (numeric) The output number\n       \"scriptSig\": {     (json object) The script\n         \"asm\": \"asm\",  (string) asm\n         \"hex\": \"hex\"   (string) hex\n       },\n       \"txinwitness\": [\"hex\", ...] (array of string) hex-encoded witness data (if any)\n       \"sequence\": n     (numeric) The script sequence number\n     }\n     ,...\n  ],\n  \"vout\" : [             (array of json objects)\n     {\n       \"value\" : x.xxx,            (numeric) The value in LBC\n       \"n\" : n,                    (numeric) index\n       \"scriptPubKey\" : {          (json object)\n         \"asm\" : \"asm\",          (string) the asm\n         \"hex\" : \"hex\",          (string) the hex\n         \"reqSigs\" : n,            (numeric) The required sigs\n         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n         \"addresses\" : [           (json array of string)\n           \"12tvKAXCxZjSmdNbao16dKXC8tRWfcF5oc\"   (string) lbry address\n           ,...\n         ]\n       }\n     }\n     ,...\n  ],\n}"
     },
     {
         "name": "decodescript",
@@ -1136,7 +1554,7 @@
         "description": "Decode a hex-encoded script.",
         "arguments": [
             {
-                "name": "hex",
+                "name": "hexstring",
                 "type": "string",
                 "description": "the hex encoded script",
                 "is_required": true
@@ -1148,12 +1566,37 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"decodescript\", \"params\": [\"hexstring\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"asm\":\"asm\",   (string) Script public key\n  \"hex\":\"hex\",   (string) hex encoded public key\n  \"type\":\"type\", (string) The output type\n  \"reqSigs\": n,    (numeric) The required signatures\n  \"addresses\": [   (json array of string)\n     \"address\"     (string) lbrycrd address\n     ,...\n  ],\n  \"p2sh\",\"address\" (string) script address\n}"
+        "returns": "{\n  \"asm\":\"asm\",   (string) Script public key\n  \"hex\":\"hex\",   (string) hex encoded public key\n  \"type\":\"type\", (string) The output type\n  \"reqSigs\": n,    (numeric) The required signatures\n  \"addresses\": [   (json array of string)\n     \"address\"     (string) lbry address\n     ,...\n  ],\n  \"p2sh\",\"address\" (string) address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH).\n}"
+    },
+    {
+        "name": "finalizepsbt",
+        "namespace": "Rawtransactions",
+        "description": "Finalize the inputs of a PSBT. If the transaction is fully signed, it will produce a network serialized transaction which can be broadcast with sendrawtransaction. Otherwise a PSBT will be created which has the final_scriptSig and final_scriptWitness fields filled for inputs that are complete. Implements the Finalizer and Extractor roles.",
+        "arguments": [
+            {
+                "name": "psbt",
+                "type": "string",
+                "description": "A base64 string of a PSBT",
+                "is_required": true
+            },
+            {
+                "name": "extract",
+                "type": "boolean",
+                "description": "If true and the transaction is complete, extract and return the complete transaction in normal network serialization instead of the PSBT.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli finalizepsbt \"psbt\""
+            }
+        ],
+        "returns": "{\n  \"psbt\" : \"value\",          (string) The base64-encoded partially signed transaction if not extracted\n  \"hex\" : \"value\",           (string) The hex-encoded network transaction if extracted\n  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n  ]\n}"
     },
     {
         "name": "fundrawtransaction",
         "namespace": "Rawtransactions",
-        "description": "Add inputs to a transaction until it has enough in value to meet its out value. This will not modify existing inputs, and will add one change output to the outputs. Note that inputs which were signed may need to be resigned after completion since in/outputs have been added. The inputs added will not be signed, use signrawtransaction for that. Note that all existing inputs must have their previous output transaction be in the wallet. Note that all inputs selected must be of standard form and P2SH scripts must be in the wallet using importaddress or addmultisigaddress (to calculate fees). Only pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only",
+        "description": "Add inputs to a transaction until it has enough in value to meet its out value. This will not modify existing inputs, and will add at most one change output to the outputs. No existing outputs will be modified unless \"subtractFeeFromOutputs\" is specified. Note that inputs which were signed may need to be resigned after completion since in/outputs have been added. The inputs added will not be signed, use signrawtransaction for that. Note that all existing inputs must have their previous output transaction be in the wallet. Note that all inputs selected must be of standard form and P2SH scripts must be in the wallet using importaddress or addmultisigaddress (to calculate fees). You can see whether this is the case by checking the \"solvable\" field in the listunspent output. Only pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only",
         "arguments": [
             {
                 "name": "hexstring",
@@ -1164,7 +1607,13 @@
             {
                 "name": "options",
                 "type": "object",
-                "description": "{ \"changeAddress\" (string, optional, default pool address) The bitcoin address to receive the change \"changePosition\" (numeric, optional, default random) The index of the change output \"includeWatching\" (boolean, optional, default false) Also select inputs which are watch only \"lockUnspents\" (boolean, optional, default false) Lock selected unspent outputs } for backward compatibility: passing in a true instead of an object will result in {\"includeWatching\":true}",
+                "description": "{ \"changeAddress\" (string, optional, default pool address) The bitcoin address to receive the change \"changePosition\" (numeric, optional, default random) The index of the change output \"change_type\" (string, optional) The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype. \"includeWatching\" (boolean, optional, default false) Also select inputs which are watch only \"lockUnspents\" (boolean, optional, default false) Lock selected unspent outputs \"feeRate\" (numeric, optional, default not set: makes wallet determine the fee) Set a specific fee rate in LBC/kB \"subtractFeeFromOutputs\" (array, optional) A json array of integers. The fee will be equally deducted from the amount of each specified output. The outputs are specified by their zero-based index, before any change output is added. Those recipients will receive less bitcoins than you enter in their corresponding amount field. If no outputs are specified here, the sender pays the fee. [vout_index,...] \"replaceable\" (boolean, optional) Marks this transaction as BIP125 replaceable. Allows this transaction to be replaced by a transaction with higher fees \"conf_target\" (numeric, optional) Confirmation target (in blocks) \"estimate_mode\" (string, optional, default=UNSET) The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\" } for backward compatibility: passing in a true instead of an object will result in {\"includeWatching\":true}",
+                "is_required": false
+            },
+            {
+                "name": "iswitness",
+                "type": "boolean",
+                "description": "Whether the transaction hex is a serialized witness transaction If iswitness is not present, heuristic tests will be used in decoding",
                 "is_required": false
             }
         ],
@@ -1186,12 +1635,12 @@
                 "cli": "> lbrycrd-cli sendrawtransaction \"signedtransactionhex\""
             }
         ],
-        "returns": "{\n  \"hex\":       \"value\", (string)  The resulting raw transaction (hex-encoded string)\n  \"fee\":       n,         (numeric) Fee the resulting transaction pays\n  \"changepos\": n          (numeric) The position of the added change output, or -1\n}\n\"hex\""
+        "returns": "{\n  \"hex\":       \"value\", (string)  The resulting raw transaction (hex-encoded string)\n  \"fee\":       n,         (numeric) Fee in LBC the resulting transaction pays\n  \"changepos\": n          (numeric) The position of the added change output, or -1\n}"
     },
     {
         "name": "getrawtransaction",
         "namespace": "Rawtransactions",
-        "description": "NOTE: By default this function only works sometimes. This is when the tx is in the mempool or there is an unspent output in the utxo for this transaction. To make it always work, you need to maintain a transaction index, using the -txindex command line option. Return the raw transaction data. If verbose=0, returns a string that is serialized, hex-encoded data for 'txid'. If verbose is non-zero, returns an Object with information about 'txid'.",
+        "description": "NOTE: By default this function only works for mempool transactions. If the -txindex option is enabled, it also works for blockchain transactions. If the block which contains the transaction is known, its hash can be provided even for nodes without -txindex. Note that if a blockhash is provided, only that block will be searched and if the transaction is in the mempool or other blocks, or if this node does not have the given block available, the transaction will not be found. DEPRECATED: for now, it also works for transactions with unspent outputs. Return the raw transaction data. If verbose is 'true', returns an Object with information about 'txid'. If verbose is 'false' or omitted, returns a string that is serialized, hex-encoded data for 'txid'.",
         "arguments": [
             {
                 "name": "txid",
@@ -1201,18 +1650,24 @@
             },
             {
                 "name": "verbose",
-                "type": "number",
-                "description": "If 0, return a string, other return a json object",
+                "type": "boolean",
+                "description": "If false, return a string, otherwise return a json object",
+                "is_required": false
+            },
+            {
+                "name": "blockhash",
+                "type": "string",
+                "description": "The block in which to look for the transaction",
                 "is_required": false
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli getrawtransaction \"mytxid\" 1",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getrawtransaction\", \"params\": [\"mytxid\", 1] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli getrawtransaction \"mytxid\" true \"myblockhash\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getrawtransaction\", \"params\": [\"mytxid\", true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n\nResult (if verbose > 0):\n{\n  \"hex\" : \"data\",       (string) The serialized, hex-encoded data for 'txid'\n  \"txid\" : \"id\",        (string) The transaction id (same as provided)\n  \"size\" : n,             (numeric) The transaction size\n  \"version\" : n,          (numeric) The version\n  \"locktime\" : ttt,       (numeric) The lock time\n  \"vin\" : [               (array of json objects)\n     {\n       \"txid\": \"id\",    (string) The transaction id\n       \"vout\": n,         (numeric) \n       \"scriptSig\": {     (json object) The script\n         \"asm\": \"asm\",  (string) asm\n         \"hex\": \"hex\"   (string) hex\n       },\n       \"sequence\": n      (numeric) The script sequence number\n     }\n     ,...\n  ],\n  \"vout\" : [              (array of json objects)\n     {\n       \"value\" : x.xxx,            (numeric) The value in LBC\n       \"n\" : n,                    (numeric) index\n       \"scriptPubKey\" : {          (json object)\n         \"asm\" : \"asm\",          (string) the asm\n         \"hex\" : \"hex\",          (string) the hex\n         \"reqSigs\" : n,            (numeric) The required sigs\n         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n         \"addresses\" : [           (json array of string)\n           \"lbrycrdaddress\"        (string) lbrycrd address\n           ,...\n         ]\n       }\n     }\n     ,...\n  ],\n  \"blockhash\" : \"hash\",   (string) the block hash\n  \"confirmations\" : n,      (numeric) The confirmations\n  \"time\" : ttt,             (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT)\n  \"blocktime\" : ttt         (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n}"
+        "returns": "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n\nResult (if verbose is set to true):\n{\n  \"in_active_chain\": b, (bool) Whether specified block is in the active chain or not (only present with explicit \"blockhash\" argument)\n  \"hex\" : \"data\",       (string) The serialized, hex-encoded data for 'txid'\n  \"txid\" : \"id\",        (string) The transaction id (same as provided)\n  \"hash\" : \"id\",        (string) The transaction hash (differs from txid for witness transactions)\n  \"size\" : n,             (numeric) The serialized transaction size\n  \"vsize\" : n,            (numeric) The virtual transaction size (differs from size for witness transactions)\n  \"weight\" : n,           (numeric) The transaction's weight (between vsize*4-3 and vsize*4)\n  \"version\" : n,          (numeric) The version\n  \"locktime\" : ttt,       (numeric) The lock time\n  \"vin\" : [               (array of json objects)\n     {\n       \"txid\": \"id\",    (string) The transaction id\n       \"vout\": n,         (numeric) \n       \"scriptSig\": {     (json object) The script\n         \"asm\": \"asm\",  (string) asm\n         \"hex\": \"hex\"   (string) hex\n       },\n       \"sequence\": n      (numeric) The script sequence number\n       \"txinwitness\": [\"hex\", ...] (array of string) hex-encoded witness data (if any)\n     }\n     ,...\n  ],\n  \"vout\" : [              (array of json objects)\n     {\n       \"value\" : x.xxx,            (numeric) The value in LBC\n       \"n\" : n,                    (numeric) index\n       \"scriptPubKey\" : {          (json object)\n         \"asm\" : \"asm\",          (string) the asm\n         \"hex\" : \"hex\",          (string) the hex\n         \"reqSigs\" : n,            (numeric) The required sigs\n         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n         \"addresses\" : [           (json array of string)\n           \"address\"        (string) lbry address\n           ,...\n         ]\n       }\n     }\n     ,...\n  ],\n  \"blockhash\" : \"hash\",   (string) the block hash\n  \"confirmations\" : n,      (numeric) The confirmations\n  \"time\" : ttt,             (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT)\n  \"blocktime\" : ttt         (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n}"
     },
     {
         "name": "sendrawtransaction",
@@ -1255,7 +1710,7 @@
     {
         "name": "signrawtransaction",
         "namespace": "Rawtransactions",
-        "description": "Sign inputs for raw transaction (serialized, hex-encoded). The second optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain. The third optional argument (may be null) is an array of base58-encoded private keys that, if given, will be the only keys used to sign the transaction.",
+        "description": "DEPRECATED. Sign inputs for raw transaction (serialized, hex-encoded). The second optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain. The third optional argument (may be null) is an array of base58-encoded private keys that, if given, will be the only keys used to sign the transaction.",
         "arguments": [
             {
                 "name": "hexstring",
@@ -1266,11 +1721,11 @@
             {
                 "name": "prevtxs",
                 "type": "string",
-                "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\" (string, required for P2SH) redeem script } ,... ]",
+                "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\", (string, required for P2SH or P2WSH) redeem script \"amount\": value (numeric, required) The amount spent } ,... ]",
                 "is_required": false
             },
             {
-                "name": "privatekeys",
+                "name": "privkeys",
                 "type": "string",
                 "description": "A json array of base58-encoded private keys for signing [ (json array of strings, or 'null' if none provided) \"privatekey\" (string) private key in base58-encoding ,... ]",
                 "is_required": false
@@ -1291,6 +1746,82 @@
         "returns": "{\n  \"hex\" : \"value\",           (string) The hex-encoded raw transaction with signature(s)\n  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n  \"errors\" : [                 (json array of objects) Script verification errors (if there are any)\n    {\n      \"txid\" : \"hash\",           (string) The hash of the referenced, previous transaction\n      \"vout\" : n,                (numeric) The index of the output to spent and used as input\n      \"scriptSig\" : \"hex\",       (string) The hex-encoded signature script\n      \"sequence\" : n,            (numeric) Script sequence number\n      \"error\" : \"text\"           (string) Verification or signing error related to the input\n    }\n    ,...\n  ]\n}"
     },
     {
+        "name": "signrawtransactionwithkey",
+        "namespace": "Rawtransactions",
+        "description": "Sign inputs for raw transaction (serialized, hex-encoded). The second argument is an array of base58-encoded private keys that will be the only keys used to sign the transaction. The third optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain.",
+        "arguments": [
+            {
+                "name": "hexstring",
+                "type": "string",
+                "description": "The transaction hex string",
+                "is_required": true
+            },
+            {
+                "name": "privkeys",
+                "type": "string",
+                "description": "A json array of base58-encoded private keys for signing [ (json array of strings) \"privatekey\" (string) private key in base58-encoding ,... ]",
+                "is_required": true
+            },
+            {
+                "name": "prevtxs",
+                "type": "string",
+                "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\", (string, required for P2SH or P2WSH) redeem script \"amount\": value (numeric, required) The amount spent } ,... ]",
+                "is_required": false
+            },
+            {
+                "name": "sighashtype",
+                "type": "string",
+                "description": "The signature hash type. Must be one of \"ALL\" \"NONE\" \"SINGLE\" \"ALL|ANYONECANPAY\" \"NONE|ANYONECANPAY\" \"SINGLE|ANYONECANPAY\"",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli signrawtransactionwithkey \"myhex\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signrawtransactionwithkey\", \"params\": [\"myhex\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"hex\" : \"value\",                  (string) The hex-encoded raw transaction with signature(s)\n  \"complete\" : true|false,          (boolean) If the transaction has a complete set of signatures\n  \"errors\" : [                      (json array of objects) Script verification errors (if there are any)\n    {\n      \"txid\" : \"hash\",              (string) The hash of the referenced, previous transaction\n      \"vout\" : n,                   (numeric) The index of the output to spent and used as input\n      \"scriptSig\" : \"hex\",          (string) The hex-encoded signature script\n      \"sequence\" : n,               (numeric) Script sequence number\n      \"error\" : \"text\"              (string) Verification or signing error related to the input\n    }\n    ,...\n  ]\n}"
+    },
+    {
+        "name": "testmempoolaccept",
+        "namespace": "Rawtransactions",
+        "description": "Returns if raw transaction (serialized, hex-encoded) would be accepted by mempool. This checks if the transaction violates the consensus or policy rules. See sendrawtransaction call.",
+        "arguments": [
+            {
+                "name": "[\"rawtxs\"]",
+                "type": "array",
+                "description": "An array of hex strings of raw transactions. Length must be one for now.",
+                "is_required": true
+            },
+            {
+                "name": "allowhighfees",
+                "type": "boolean",
+                "description": "Allow high fees",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "title": "Create a transaction",
+                "cli": "> lbrycrd-cli createrawtransaction \"[{\\\"txid\\\" : \\\"mytxid\\\",\\\"vout\\\":0}]\" \"{\\\"myaddress\\\":0.01}\""
+            },
+            {
+                "title": "Sign the transaction, and get back the hex",
+                "cli": "> lbrycrd-cli signrawtransaction \"myhex\""
+            },
+            {
+                "title": "Test acceptance of the transaction (signed hex)",
+                "cli": "> lbrycrd-cli testmempoolaccept [\"signedhex\"]"
+            },
+            {
+                "title": "As a json rpc call",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"testmempoolaccept\", \"params\": [[\"signedhex\"]] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "[                   (array) The result of the mempool acceptance test for each raw transaction in the input array.\n                            Length is exactly one for now.\n {\n  \"txid\"           (string) The transaction hash in hex\n  \"allowed\"        (boolean) If the mempool allows this tx to be inserted\n  \"reject-reason\"  (string) Rejection string (only present when 'allowed' is false)\n }\n]"
+    },
+    {
         "name": "createmultisig",
         "namespace": "Util",
         "description": "Creates a multi-signature address with n signature of m keys required. It returns a json object with the address and redeemScript.",
@@ -1298,76 +1829,50 @@
             {
                 "name": "nrequired",
                 "type": "number",
-                "description": "The number of required signatures out of the n keys or addresses.",
+                "description": "The number of required signatures out of the n keys.",
                 "is_required": true
             },
             {
                 "name": "keys",
                 "type": "string",
-                "description": "A json array of keys which are lbrycrd addresses or hex-encoded public keys [ \"key\" (string) lbrycrd address or hex-encoded public key ,... ]",
+                "description": "A json array of hex-encoded public keys [ \"key\" (string) The hex-encoded public key ,... ]",
                 "is_required": true
+            },
+            {
+                "name": "address_type",
+                "type": "string",
+                "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is legacy.",
+                "is_required": false
             }
         ],
         "examples": [
             {
-                "title": "Create a multisig address from 2 addresses",
-                "cli": "> lbrycrd-cli createmultisig 2 \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\""
+                "title": "Create a multisig address from 2 public keys",
+                "cli": "> lbrycrd-cli createmultisig 2 \"[\\\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\\\",\\\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\\\"]\""
             },
             {
                 "title": "As a json rpc call",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createmultisig\", \"params\": [2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createmultisig\", \"params\": [2, \"[\\\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\\\",\\\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
         "returns": "{\n  \"address\":\"multisigaddress\",  (string) The value of the new multisig address.\n  \"redeemScript\":\"script\"       (string) The string value of the hex-encoded redemption script.\n}"
     },
     {
-        "name": "estimatefee",
-        "namespace": "Util",
-        "description": "Estimates the approximate fee per kilobyte needed for a transaction to begin confirmation within nblocks blocks.",
-        "arguments": [
-            {
-                "name": "nblocks",
-                "type": "number",
-                "description": [],
-                "is_required": true
-            }
-        ],
-        "examples": [
-            {
-                "cli": "> lbrycrd-cli estimatefee 6"
-            }
-        ],
-        "returns": "n              (numeric) estimated fee-per-kilobyte\n\nA negative value is returned if not enough transactions and blocks\nhave been observed to make an estimate."
-    },
-    {
-        "name": "estimatepriority",
-        "namespace": "Util",
-        "description": "Estimates the approximate priority a zero-fee transaction needs to begin confirmation within nblocks blocks.",
-        "arguments": [
-            {
-                "name": "nblocks",
-                "type": "number",
-                "description": [],
-                "is_required": true
-            }
-        ],
-        "examples": [
-            {
-                "cli": "> lbrycrd-cli estimatepriority 6"
-            }
-        ],
-        "returns": "n              (numeric) estimated priority\n\nA negative value is returned if not enough transactions and blocks\nhave been observed to make an estimate."
-    },
-    {
         "name": "estimatesmartfee",
         "namespace": "Util",
-        "description": "WARNING: This interface is unstable and may disappear or change! Estimates the approximate fee per kilobyte needed for a transaction to begin confirmation within nblocks blocks if possible and return the number of blocks for which the estimate is valid.",
+        "description": "Estimates the approximate fee per kilobyte needed for a transaction to begin confirmation within conf_target blocks if possible and return the number of blocks for which the estimate is valid. Uses virtual transaction size as defined in BIP 141 (witness data is discounted).",
         "arguments": [
             {
-                "name": "nblocks",
+                "name": "conf_target",
                 "type": "number",
-                "description": [],
+                "description": "Confirmation target in blocks (1 - 1008)",
                 "is_required": true
+            },
+            {
+                "name": "estimate_mode",
+                "type": "string",
+                "description": "The fee estimate mode. Whether to return a more conservative estimate which also satisfies a longer history. A conservative estimate potentially returns a higher feerate and is more likely to be sufficient for the desired target, but is not as responsive to short term drops in the prevailing fee market. Must be one of: \"UNSET\" (defaults to CONSERVATIVE) \"ECONOMICAL\" \"CONSERVATIVE\"",
+                "is_required": false
             }
         ],
         "examples": [
@@ -1375,36 +1880,51 @@
                 "cli": "> lbrycrd-cli estimatesmartfee 6"
             }
         ],
-        "returns": "{\n  \"feerate\" : x.x,     (numeric) estimate fee-per-kilobyte (in BTC)\n  \"blocks\" : n         (numeric) block number where estimate was found\n}\n\nA negative value is returned if not enough transactions and blocks\nhave been observed to make an estimate for any number of blocks.\nHowever it will not return a value below the mempool reject fee."
+        "returns": "{\n  \"feerate\" : x.x,     (numeric, optional) estimate fee rate in LBC/kB\n  \"errors\": [ str... ] (json array of strings, optional) Errors encountered during processing\n  \"blocks\" : n         (numeric) block number where estimate was found\n}\n\nThe request target will be clamped between 2 and the highest target\nfee estimation is able to return based on how long it has been running.\nAn error is returned if not enough transactions and blocks\nhave been observed to make an estimate for any number of blocks."
     },
     {
-        "name": "estimatesmartpriority",
+        "name": "signmessagewithprivkey",
         "namespace": "Util",
-        "description": "WARNING: This interface is unstable and may disappear or change! Estimates the approximate priority a zero-fee transaction needs to begin confirmation within nblocks blocks if possible and return the number of blocks for which the estimate is valid.",
+        "description": "Sign a message with the private key of an address",
         "arguments": [
             {
-                "name": "nblocks",
-                "type": "number",
-                "description": [],
+                "name": "privkey",
+                "type": "string",
+                "description": "The private key to sign the message with.",
+                "is_required": true
+            },
+            {
+                "name": "message",
+                "type": "string",
+                "description": "The message to create a signature of.",
                 "is_required": true
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli estimatesmartpriority 6"
+                "title": "Create the signature",
+                "cli": "> lbrycrd-cli signmessagewithprivkey \"privkey\" \"my message\""
+            },
+            {
+                "title": "Verify the signature",
+                "cli": "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\""
+            },
+            {
+                "title": "As json rpc",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signmessagewithprivkey\", \"params\": [\"privkey\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"priority\" : x.x,    (numeric) estimated priority\n  \"blocks\" : n         (numeric) block number where estimate was found\n}\n\nA negative value is returned if not enough transactions and blocks\nhave been observed to make an estimate for any number of blocks.\nHowever if the mempool reject fee is set it will return 1e9 * MAX_MONEY."
+        "returns": "\"signature\"          (string) The signature of the message encoded in base 64"
     },
     {
         "name": "validateaddress",
         "namespace": "Util",
-        "description": "Return information about the given lbrycrd address.",
+        "description": "Return information about the given lbry address. DEPRECATION WARNING: Parts of this command have been deprecated and moved to getaddressinfo. Clients must transition to using getaddressinfo to access this information before upgrading to v0.18. The following deprecated fields have moved to getaddressinfo and will only be shown here with -deprecatedrpc=validateaddress: ismine, iswatchonly, script, hex, pubkeys, sigsrequired, pubkey, addresses, embedded, iscompressed, account, timestamp, hdkeypath, kdmasterkeyid.",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
-                "description": "The lbrycrd address to validate",
+                "description": "The lbry address to validate",
                 "is_required": true
             }
         ],
@@ -1414,7 +1934,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"validateaddress\", \"params\": [\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"isvalid\" : true|false,       (boolean) If the address is valid or not. If not, this is the only property returned.\n  \"address\" : \"lbrycrdaddress\", (string) The lbrycrd address validated\n  \"scriptPubKey\" : \"hex\",       (string) The hex encoded scriptPubKey generated by the address\n  \"ismine\" : true|false,        (boolean) If the address is yours or not\n  \"iswatchonly\" : true|false,   (boolean) If the address is watchonly\n  \"isscript\" : true|false,      (boolean) If the key is a script\n  \"pubkey\" : \"publickeyhex\",    (string) The hex value of the raw public key\n  \"iscompressed\" : true|false,  (boolean) If the address is compressed\n  \"account\" : \"account\"         (string) DEPRECATED. The account associated with the address, \"\" is the default account\n}"
+        "returns": "{\n  \"isvalid\" : true|false,       (boolean) If the address is valid or not. If not, this is the only property returned.\n  \"address\" : \"address\",        (string) The lbry address validated\n  \"scriptPubKey\" : \"hex\",       (string) The hex encoded scriptPubKey generated by the address\n  \"isscript\" : true|false,      (boolean) If the key is a script\n  \"iswitness\" : true|false,     (boolean) If the address is a witness address\n  \"witness_version\" : version   (numeric, optional) The version number of the witness program\n  \"witness_program\" : \"hex\"     (string, optional) The hex value of the witness program\n}"
     },
     {
         "name": "verifymessage",
@@ -1422,9 +1942,9 @@
         "description": "Verify a signed message",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
-                "description": "The lbrycrd address to use for the signature.",
+                "description": "The lbry address to use for the signature.",
                 "is_required": true
             },
             {
@@ -1447,15 +1967,15 @@
             },
             {
                 "title": "Create the signature",
-                "cli": "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"my message\""
+                "cli": "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\""
             },
             {
                 "title": "Verify the signature",
-                "cli": "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"signature\" \"my message\""
+                "cli": "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\""
             },
             {
                 "title": "As json rpc",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"verifymessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", \"signature\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"verifymessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"signature\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
         "returns": "true|false   (boolean) If the signature is verified or not."
@@ -1463,7 +1983,7 @@
     {
         "name": "abandontransaction",
         "namespace": "Wallet",
-        "description": "Mark in-wallet transaction <txid> as abandoned This will mark this transaction and all its in-wallet descendants as abandoned which will allow for their inputs to be respent. It can be used to replace \"stuck\" or evicted transactions. It only works on transactions which are not included in a block and are not currently in the mempool. It has no effect on transactions which are already conflicted or abandoned.",
+        "description": "Mark in-wallet transaction <txid> as abandoned This will mark this transaction and all its in-wallet descendants as abandoned which will allow for their inputs to be respent. It can be used to replace \"stuck\" or evicted transactions. It only works on transactions which are not included in a block and are not currently in the mempool. It has no effect on transactions which are already abandoned.",
         "arguments": [
             {
                 "name": "txid",
@@ -1481,9 +2001,29 @@
         "returns": ""
     },
     {
+        "name": "abortrescan",
+        "namespace": "Wallet",
+        "description": "Stops current wallet rescan triggered by an RPC call, e.g. by an importprivkey call.",
+        "arguments": [],
+        "examples": [
+            {
+                "title": "Import a private key",
+                "cli": "> lbrycrd-cli importprivkey \"mykey\""
+            },
+            {
+                "title": "Abort the running wallet rescan",
+                "cli": "> lbrycrd-cli abortrescan"
+            },
+            {
+                "title": "As a JSON-RPC call",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"abortrescan\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
         "name": "addmultisigaddress",
         "namespace": "Wallet",
-        "description": "Add a nrequired-to-sign multisignature address to the wallet. Each key is a Bitcoin address or hex-encoded public key. If 'account' is specified (DEPRECATED), assign address to that account.",
+        "description": "Add a nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup. Each key is a Bitcoin address or hex-encoded public key. This functionality is only intended for use with non-watchonly addresses. See `importaddress` for watchonly p2sh address support. If 'label' is specified, assign address to that label.",
         "arguments": [
             {
                 "name": "nrequired",
@@ -1492,15 +2032,21 @@
                 "is_required": true
             },
             {
-                "name": "keysobject",
+                "name": "keys",
                 "type": "string",
-                "description": "A json array of lbrycrd addresses or hex-encoded public keys [ \"address\" (string) lbrycrd address or hex-encoded public key ..., ]",
+                "description": "A json array of bitcoin addresses or hex-encoded public keys [ \"address\" (string) bitcoin address or hex-encoded public key ..., ]",
                 "is_required": true
             },
             {
-                "name": "account",
+                "name": "label",
                 "type": "string",
-                "description": "DEPRECATED. An account to assign the addresses to.",
+                "description": "A label to assign the addresses to.",
+                "is_required": false
+            },
+            {
+                "name": "address_type",
+                "type": "string",
+                "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -addresstype.",
                 "is_required": false
             }
         ],
@@ -1514,7 +2060,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"addmultisigaddress\", \"params\": [2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"lbrycrdaddress\"  (string) A lbrycrd address associated with the keys."
+        "returns": "{\n  \"address\":\"multisigaddress\",    (string) The value of the new multisig address.\n  \"redeemScript\":\"script\"         (string) The string value of the hex-encoded redemption script.\n}"
     },
     {
         "name": "backupwallet",
@@ -1536,14 +2082,66 @@
         ]
     },
     {
-        "name": "dumpprivkey",
+        "name": "bumpfee",
         "namespace": "Wallet",
-        "description": "Reveals the private key corresponding to 'lbrycrdaddress'. Then the importprivkey can be used with this output",
+        "description": "Bumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B. An opt-in RBF transaction with the given txid must be in the wallet. The command will pay the additional fee by decreasing (or perhaps removing) its change output. If the change output is not big enough to cover the increased fee, the command will currently fail instead of adding new inputs to compensate. (A future implementation could improve this.) The command will fail if the wallet or mempool contains a transaction that spends one of T's outputs. By default, the new fee will be calculated automatically using estimatesmartfee. The user can specify a confirmation target for estimatesmartfee. Alternatively, the user can specify totalFee, or use RPC settxfee to set a higher fee rate. At a minimum, the new fee rate must be high enough to pay an additional new relay fee (incrementalfee returned by getnetworkinfo) to enter the node's mempool.",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "txid",
                 "type": "string",
-                "description": "The lbrycrd address for the private key",
+                "description": "The txid to be bumped",
+                "is_required": true
+            },
+            {
+                "name": "options",
+                "type": "object",
+                "description": "{ \"confTarget\" (numeric, optional) Confirmation target (in blocks) \"totalFee\" (numeric, optional) Total fee (NOT feerate) to pay, in satoshis. In rare cases, the actual fee paid might be slightly higher than the specified totalFee if the tx change output has to be removed because it is too close to the dust threshold. \"replaceable\" (boolean, optional, default true) Whether the new transaction should still be marked bip-125 replaceable. If true, the sequence numbers in the transaction will be left unchanged from the original. If false, any input sequence numbers in the original transaction that were less than 0xfffffffe will be increased to 0xfffffffe so the new transaction will not be explicitly bip-125 replaceable (though it may still be replaceable in practice, for example if it has unconfirmed ancestors which are replaceable). \"estimate_mode\" (string, optional, default=UNSET) The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\" }",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "title": "Bump the fee, get the new transaction's txid",
+                "cli": "> lbrycrd-cli bumpfee <txid>"
+            }
+        ],
+        "returns": "{\n  \"txid\":    \"value\",   (string)  The id of the new transaction\n  \"origfee\":  n,         (numeric) Fee of the replaced transaction\n  \"fee\":      n,         (numeric) Fee of the new transaction\n  \"errors\":  [ str... ] (json array of strings) Errors encountered during processing (may be empty)\n}"
+    },
+    {
+        "name": "createwallet",
+        "namespace": "Wallet",
+        "description": "Creates and loads a new wallet.",
+        "arguments": [
+            {
+                "name": "wallet_name",
+                "type": "string",
+                "description": "The name for the new wallet. If this is a path, the wallet will be created at the path location.",
+                "is_required": true
+            },
+            {
+                "name": "disable_private_keys",
+                "type": "boolean",
+                "description": "Disable the possibility of private keys (only watchonlys are possible in this mode).",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli createwallet \"testwallet\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"createwallet\", \"params\": [\"testwallet\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"name\" :    <wallet_name>,        (string) The wallet name if created successfully. If the wallet was created using a full path, the wallet_name will be the full path.\n  \"warning\" : <warning>,            (string) Warning message if wallet was not loaded cleanly.\n}"
+    },
+    {
+        "name": "dumpprivkey",
+        "namespace": "Wallet",
+        "description": "Reveals the private key corresponding to 'address'. Then the importprivkey can be used with this output",
+        "arguments": [
+            {
+                "name": "address",
+                "type": "string",
+                "description": "The bitcoin address for the private key",
                 "is_required": true
             }
         ],
@@ -1558,12 +2156,12 @@
     {
         "name": "dumpwallet",
         "namespace": "Wallet",
-        "description": "Dumps all wallet keys in a human-readable format.",
+        "description": "Dumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files. Imported scripts are included in the dumpfile, but corresponding BIP173 addresses, etc. may not be added automatically by importwallet. Note that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by only backing up the seed itself, and must be backed up too (e.g. ensure you back up the whole dumpfile).",
         "arguments": [
             {
                 "name": "filename",
                 "type": "string",
-                "description": "The filename",
+                "description": "The filename with path (either absolute or relative to bitcoind)",
                 "is_required": true
             }
         ],
@@ -1572,12 +2170,13 @@
                 "cli": "> lbrycrd-cli dumpwallet \"test\"",
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"dumpwallet\", \"params\": [\"test\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
-        ]
+        ],
+        "returns": "{                           (json object)\n  \"filename\" : {        (string) The filename with full absolute path\n}"
     },
     {
         "name": "encryptwallet",
         "namespace": "Wallet",
-        "description": "Encrypts the wallet with 'passphrase'. This is for first time encryption. After this, any calls that interact with private keys such as sending or signing will require the passphrase to be set prior the making these calls. Use the walletpassphrase call for this, and then walletlock call. If the wallet is already encrypted, use the walletpassphrasechange call. Note that this will shutdown the server.",
+        "description": "Encrypts the wallet with 'passphrase'. This is for first time encryption. After this, any calls that interact with private keys such as sending or signing will require the passphrase to be set prior the making these calls. Use the walletpassphrase call for this, and then walletlock call. If the wallet is already encrypted, use the walletpassphrasechange call.",
         "arguments": [
             {
                 "name": "passphrase",
@@ -1588,16 +2187,16 @@
         ],
         "examples": [
             {
-                "title": "Encrypt you wallet",
+                "title": "Encrypt your wallet",
                 "cli": "> lbrycrd-cli encryptwallet \"my pass phrase\""
             },
             {
-                "title": "Now set the passphrase to use the wallet, such as for signing or sending LBC",
+                "title": "Now set the passphrase to use the wallet, such as for signing or sending bitcoin",
                 "cli": "> lbrycrd-cli walletpassphrase \"my pass phrase\""
             },
             {
-                "title": "Now we can so something like sign",
-                "cli": "> lbrycrd-cli signmessage \"lbrycrdaddress\" \"test message\""
+                "title": "Now we can do something like sign",
+                "cli": "> lbrycrd-cli signmessage \"address\" \"test message\""
             },
             {
                 "title": "Now lock the wallet again by removing the passphrase",
@@ -1615,16 +2214,16 @@
         "description": "DEPRECATED. Returns the account associated with the given address.",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
-                "description": "The lbrycrd address for account lookup.",
+                "description": "The bitcoin address for account lookup.",
                 "is_required": true
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli getaccount \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaccount\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli getaccount \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaccount\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
         "returns": "\"accountname\"        (string) the account address"
@@ -1637,7 +2236,7 @@
             {
                 "name": "account",
                 "type": "string",
-                "description": "The account name for the address. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created and a new address created if there is no account by the given name.",
+                "description": "The account for the address. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created and a new address created if there is no account by the given name.",
                 "is_required": true
             }
         ],
@@ -1647,7 +2246,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaccountaddress\", \"params\": [\"myaccount\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"lbrycrdaddress\"   (string) The account lbrycrd address"
+        "returns": "\"address\"          (string) The account bitcoin address"
     },
     {
         "name": "getaddressesbyaccount",
@@ -1667,39 +2266,85 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddressesbyaccount\", \"params\": [\"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[                     (json array of string)\n  \"lbrycrdaddress\"  (string) a lbrycrd address associated with the given account\n  ,...\n]"
+        "returns": "[                     (json array of string)\n  \"address\"         (string) a bitcoin address associated with the given account\n  ,...\n]"
+    },
+    {
+        "name": "getaddressesbylabel",
+        "namespace": "Wallet",
+        "description": "Returns the list of addresses assigned the specified label.",
+        "arguments": [
+            {
+                "name": "label",
+                "type": "string",
+                "description": "The label.",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getaddressesbylabel \"tabby\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddressesbylabel\", \"params\": [\"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{ (json object with addresses as keys)\n  \"address\": { (json object with information about address)\n    \"purpose\": \"string\" (string)  Purpose of address (\"send\" for sending address, \"receive\" for receiving address)\n  },...\n}"
+    },
+    {
+        "name": "getaddressinfo",
+        "namespace": "Wallet",
+        "description": "Return information about the given bitcoin address. Some information requires the address to be in the wallet.",
+        "arguments": [
+            {
+                "name": "address",
+                "type": "string",
+                "description": "The bitcoin address to get the information of.",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getaddressinfo \"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getaddressinfo\", \"params\": [\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"address\" : \"address\",        (string) The bitcoin address validated\n  \"scriptPubKey\" : \"hex\",       (string) The hex encoded scriptPubKey generated by the address\n  \"ismine\" : true|false,        (boolean) If the address is yours or not\n  \"iswatchonly\" : true|false,   (boolean) If the address is watchonly\n  \"isscript\" : true|false,      (boolean) If the key is a script\n  \"iswitness\" : true|false,     (boolean) If the address is a witness address\n  \"witness_version\" : version   (numeric, optional) The version number of the witness program\n  \"witness_program\" : \"hex\"     (string, optional) The hex value of the witness program\n  \"script\" : \"type\"             (string, optional) The output script type. Only if \"isscript\" is true and the redeemscript is known. Possible types: nonstandard, pubkey, pubkeyhash, scripthash, multisig, nulldata, witness_v0_keyhash, witness_v0_scripthash, witness_unknown\n  \"hex\" : \"hex\",                (string, optional) The redeemscript for the p2sh address\n  \"pubkeys\"                     (string, optional) Array of pubkeys associated with the known redeemscript (only if \"script\" is \"multisig\")\n    [\n      \"pubkey\"\n      ,...\n    ]\n  \"sigsrequired\" : xxxxx        (numeric, optional) Number of signatures required to spend multisig output (only if \"script\" is \"multisig\")\n  \"pubkey\" : \"publickeyhex\",    (string, optional) The hex value of the raw public key, for single-key addresses (possibly embedded in P2SH or P2WSH)\n  \"embedded\" : {...},           (object, optional) Information about the address embedded in P2SH or P2WSH, if relevant and known. It includes all getaddressinfo output fields for the embedded address, excluding metadata (\"timestamp\", \"hdkeypath\", \"hdseedid\") and relation to the wallet (\"ismine\", \"iswatchonly\", \"account\").\n  \"iscompressed\" : true|false,  (boolean) If the address is compressed\n  \"label\" :  \"label\"         (string) The label associated with the address, \"\" is the default account\n  \"account\" : \"account\"         (string) DEPRECATED. This field will be removed in V0.18. To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The account associated with the address, \"\" is the default account\n  \"timestamp\" : timestamp,      (number, optional) The creation time of the key if available in seconds since epoch (Jan 1 1970 GMT)\n  \"hdkeypath\" : \"keypath\"       (string, optional) The HD keypath if the key is HD and available\n  \"hdseedid\" : \"<hash160>\"      (string, optional) The Hash160 of the HD seed\n  \"hdmasterkeyid\" : \"<hash160>\" (string, optional) alias for hdseedid maintained for backwards compatibility. Will be removed in V0.18.\n  \"labels\"                      (object) Array of labels associated with the address.\n    [\n      { (json object of label data)\n        \"name\": \"labelname\" (string) The label\n        \"purpose\": \"string\" (string) Purpose of address (\"send\" for sending address, \"receive\" for receiving address)\n      },...\n    ]\n}"
     },
     {
         "name": "getbalance",
         "namespace": "Wallet",
-        "description": "If account is not specified, returns the server's total available balance. If account is specified (DEPRECATED), returns the balance in the account. Note that the account \"\" is not the same as leaving the parameter out. The server total may be different to the balance in the default \"\" account.",
+        "description": "If account is not specified, returns the server's total available balance. The available balance is what the wallet considers currently spendable, and is thus affected by options which limit spendability such as -spendzeroconfchange. If account is specified (DEPRECATED), returns the balance in the account. Note that the account \"\" is not the same as leaving the parameter out. The server total may be different to the balance in the default \"\" account.",
         "arguments": [
             {
                 "name": "account",
                 "type": "string",
-                "description": "DEPRECATED. The selected account, or \"*\" for entire wallet. It may be the default account using \"\".",
+                "description": "DEPRECATED. This argument will be removed in V0.",
                 "is_required": false
+            },
+            {
+                "name": "To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. The account string may be given as a\n                     specific account name to find the balance associated with wallet keys in\n                     a named account, or as the empty string",
+                "type": "\"\"",
+                "description": "to find the balance associated with wallet keys not in any named account, or as \"*\" to find the balance associated with all wallet keys regardless of account. When this option is specified, it calculates the balance in a different way than when it is not specified, and which can count spends twice when there are conflicting pending transactions (such as those created by the bumpfee command), temporarily resulting in low or even negative balances. In general, account balance calculation is not considered reliable and has resulted in confusing outcomes, so it is recommended to avoid passing this argument.",
+                "is_required": true
             },
             {
                 "name": "minconf",
                 "type": "number",
-                "description": "Only include transactions confirmed at least this many times.",
+                "description": "Only include transactions confirmed at least this many times. The default is 1 if an account is provided or 0 if no account is provided",
                 "is_required": false
             },
             {
-                "name": "includeWatchonly",
+                "name": "include_watchonly",
                 "type": "boolean",
-                "description": "Also include balance in watchonly addresses (see 'importaddress')",
+                "description": "Also include balance in watch-only addresses (see 'importaddress')",
                 "is_required": false
             }
         ],
         "examples": [
             {
-                "title": "The total amount in the wallet",
+                "title": "The total amount in the wallet with 1 or more confirmations",
                 "cli": "> lbrycrd-cli getbalance"
             },
             {
-                "title": "The total amount in the wallet at least 5 blocks confirmed",
+                "title": "The total amount in the wallet at least 6 blocks confirmed",
                 "cli": "> lbrycrd-cli getbalance \"*\" 6"
             },
             {
@@ -1712,12 +2357,18 @@
     {
         "name": "getnewaddress",
         "namespace": "Wallet",
-        "description": "Returns a new Bitcoin address for receiving payments. If 'account' is specified (DEPRECATED), it is added to the address book so payments received with the address will be credited to 'account'.",
+        "description": "Returns a new Bitcoin address for receiving payments. If 'label' is specified, it is added to the address book so payments received with the address will be associated with 'label'.",
         "arguments": [
             {
-                "name": "account",
+                "name": "label",
                 "type": "string",
-                "description": "DEPRECATED. The account name for the address to be linked to. If not provided, the default account \"\" is used. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created if there is no account by the given name.",
+                "description": "The label name for the address to be linked to. If not provided, the default label \"\" is used. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name.",
+                "is_required": false
+            },
+            {
+                "name": "address_type",
+                "type": "string",
+                "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -addresstype.",
                 "is_required": false
             }
         ],
@@ -1727,13 +2378,20 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getnewaddress\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"lbrycrdaddress\"    (string) The new lbrycrd address"
+        "returns": "\"address\"    (string) The new bitcoin address"
     },
     {
         "name": "getrawchangeaddress",
         "namespace": "Wallet",
         "description": "Returns a new Bitcoin address, for receiving change. This is for use with raw transactions, NOT normal use.",
-        "arguments": [],
+        "arguments": [
+            {
+                "name": "address_type",
+                "type": "string",
+                "description": "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype.",
+                "is_required": false
+            }
+        ],
         "examples": [
             {
                 "cli": "> lbrycrd-cli getrawchangeaddress",
@@ -1743,52 +2401,14 @@
         "returns": "\"address\"    (string) The address"
     },
     {
-        "name": "getreceivedbyaccount",
-        "namespace": "Wallet",
-        "description": "DEPRECATED. Returns the total amount received by addresses with <account> in transactions with at least [minconf] confirmations.",
-        "arguments": [
-            {
-                "name": "account",
-                "type": "string",
-                "description": "The selected account, may be the default account using \"\".",
-                "is_required": true
-            },
-            {
-                "name": "minconf",
-                "type": "number",
-                "description": "Only include transactions confirmed at least this many times.",
-                "is_required": false
-            }
-        ],
-        "examples": [
-            {
-                "title": "Amount received by the default account with at least 1 confirmation",
-                "cli": "> lbrycrd-cli getreceivedbyaccount \"\""
-            },
-            {
-                "title": "Amount received at the tabby account including unconfirmed amounts with zero confirmations",
-                "cli": "> lbrycrd-cli getreceivedbyaccount \"tabby\" 0"
-            },
-            {
-                "title": "The amount with at least 6 confirmation, very safe",
-                "cli": "> lbrycrd-cli getreceivedbyaccount \"tabby\" 6"
-            },
-            {
-                "title": "As a json rpc call",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbyaccount\", \"params\": [\"tabby\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
-            }
-        ],
-        "returns": "amount              (numeric) The total amount in LBC received for this account."
-    },
-    {
         "name": "getreceivedbyaddress",
         "namespace": "Wallet",
-        "description": "Returns the total amount received by the given lbrycrdaddress in transactions with at least minconf confirmations.",
+        "description": "Returns the total amount received by the given address in transactions with at least minconf confirmations.",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
-                "description": "The lbrycrd address for transactions.",
+                "description": "The bitcoin address for transactions.",
                 "is_required": true
             },
             {
@@ -1801,22 +2421,60 @@
         "examples": [
             {
                 "title": "The amount from transactions with at least 1 confirmation",
-                "cli": "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\""
+                "cli": "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\""
             },
             {
                 "title": "The amount including unconfirmed transactions, zero confirmations",
-                "cli": "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" 0"
+                "cli": "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 0"
             },
             {
-                "title": "The amount with at least 6 confirmation, very safe",
-                "cli": "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" 6"
+                "title": "The amount with at least 6 confirmations",
+                "cli": "> lbrycrd-cli getreceivedbyaddress \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 6"
             },
             {
                 "title": "As a json rpc call",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbyaddress\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbyaddress\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
         "returns": "amount   (numeric) The total amount in LBC received at this address."
+    },
+    {
+        "name": "getreceivedbylabel",
+        "namespace": "Wallet",
+        "description": "Returns the total amount received by addresses with <label> in transactions with at least [minconf] confirmations.",
+        "arguments": [
+            {
+                "name": "label",
+                "type": "string",
+                "description": "The selected label, may be the default label using \"\".",
+                "is_required": true
+            },
+            {
+                "name": "minconf",
+                "type": "number",
+                "description": "Only include transactions confirmed at least this many times.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "title": "Amount received by the default label with at least 1 confirmation",
+                "cli": "> lbrycrd-cli getreceivedbylabel \"\""
+            },
+            {
+                "title": "Amount received at the tabby label including unconfirmed amounts with zero confirmations",
+                "cli": "> lbrycrd-cli getreceivedbylabel \"tabby\" 0"
+            },
+            {
+                "title": "The amount with at least 6 confirmations",
+                "cli": "> lbrycrd-cli getreceivedbylabel \"tabby\" 6"
+            },
+            {
+                "title": "As a json rpc call",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getreceivedbylabel\", \"params\": [\"tabby\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "amount              (numeric) The total amount in LBC received for this label."
     },
     {
         "name": "gettransaction",
@@ -1830,9 +2488,9 @@
                 "is_required": true
             },
             {
-                "name": "includeWatchonly",
+                "name": "include_watchonly",
                 "type": "boolean",
-                "description": "Whether to include watchonly addresses in balance calculation and details[]",
+                "description": "Whether to include watch-only addresses in balance calculation and details[]",
                 "is_required": false
             }
         ],
@@ -1842,7 +2500,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"gettransaction\", \"params\": [\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"amount\" : x.xxx,        (numeric) The transaction amount in LBC\n  \"confirmations\" : n,     (numeric) The number of confirmations\n  \"blockhash\" : \"hash\",  (string) The block hash\n  \"blockindex\" : xx,       (numeric) The index of the transaction in the block that includes it\n  \"blocktime\" : ttt,       (numeric) The time in seconds since epoch (1 Jan 1970 GMT)\n  \"txid\" : \"transactionid\",   (string) The transaction id.\n  \"time\" : ttt,            (numeric) The transaction time in seconds since epoch (1 Jan 1970 GMT)\n  \"timereceived\" : ttt,    (numeric) The time received in seconds since epoch (1 Jan 1970 GMT)\n  \"bip125-replaceable\": \"yes|no|unknown\"  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n                                                   may be unknown for unconfirmed transactions not in the mempool\n  \"details\" : [\n    {\n      \"account\" : \"accountname\",  (string) DEPRECATED. The account name involved in the transaction, can be \"\" for the default account.\n      \"address\" : \"lbrycrdaddress\",   (string) The lbrycrd address involved in the transaction\n      \"category\" : \"send|receive\",    (string) The category, either 'send' or 'receive'\n      \"amount\" : x.xxx,                 (numeric) The amount in LBC\n      \"label\" : \"label\",              (string) A comment for the address/transaction, if any\n      \"vout\" : n,                       (numeric) the vout value\n    }\n    ,...\n  ],\n  \"hex\" : \"data\"         (string) Raw data for transaction\n}"
+        "returns": "{\n  \"amount\" : x.xxx,        (numeric) The transaction amount in LBC\n  \"fee\": x.xxx,            (numeric) The amount of the fee in LBC. This is negative and only available for the \n                              'send' category of transactions.\n  \"confirmations\" : n,     (numeric) The number of confirmations\n  \"blockhash\" : \"hash\",  (string) The block hash\n  \"blockindex\" : xx,       (numeric) The index of the transaction in the block that includes it\n  \"blocktime\" : ttt,       (numeric) The time in seconds since epoch (1 Jan 1970 GMT)\n  \"txid\" : \"transactionid\",   (string) The transaction id.\n  \"time\" : ttt,            (numeric) The transaction time in seconds since epoch (1 Jan 1970 GMT)\n  \"timereceived\" : ttt,    (numeric) The time received in seconds since epoch (1 Jan 1970 GMT)\n  \"bip125-replaceable\": \"yes|no|unknown\",  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n                                                   may be unknown for unconfirmed transactions not in the mempool\n  \"details\" : [\n    {\n      \"account\" : \"accountname\",      (string) DEPRECATED. This field will be removed in a V0.18. To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The account name involved in the transaction, can be \"\" for the default account.\n      \"address\" : \"address\",          (string) The bitcoin address involved in the transaction\n      \"category\" : \"send|receive\",    (string) The category, either 'send' or 'receive'\n      \"amount\" : x.xxx,                 (numeric) The amount in LBC\n      \"label\" : \"label\",              (string) A comment for the address/transaction, if any\n      \"vout\" : n,                       (numeric) the vout value\n      \"fee\": x.xxx,                     (numeric) The amount of the fee in LBC. This is negative and only available for the \n                                           'send' category of transactions.\n      \"abandoned\": xxx                  (bool) 'true' if the transaction has been abandoned (inputs are respendable). Only available for the \n                                           'send' category of transactions.\n    }\n    ,...\n  ],\n  \"hex\" : \"data\"         (string) Raw data for transaction\n}"
     },
     {
         "name": "getunconfirmedbalance",
@@ -1862,17 +2520,17 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getwalletinfo\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"walletversion\": xxxxx,     (numeric) the wallet version\n  \"balance\": xxxxxxx,         (numeric) the total confirmed balance of the wallet in LBC\n  \"unconfirmed_balance\": xxx, (numeric) the total unconfirmed balance of the wallet in LBC\n  \"immature_balance\": xxxxxx, (numeric) the total immature balance of the wallet in LBC\n  \"txcount\": xxxxxxx,         (numeric) the total number of transactions in the wallet\n  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n  \"keypoolsize\": xxxx,        (numeric) how many new keys are pre-generated\n  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n  \"paytxfee\": x.xxxx,         (numeric) the transaction fee configuration, set in LBC/kB\n}"
+        "returns": "{\n  \"walletname\": xxxxx,               (string) the wallet name\n  \"walletversion\": xxxxx,            (numeric) the wallet version\n  \"balance\": xxxxxxx,                (numeric) the total confirmed balance of the wallet in LBC\n  \"unconfirmed_balance\": xxx,        (numeric) the total unconfirmed balance of the wallet in LBC\n  \"immature_balance\": xxxxxx,        (numeric) the total immature balance of the wallet in LBC\n  \"txcount\": xxxxxxx,                (numeric) the total number of transactions in the wallet\n  \"keypoololdest\": xxxxxx,           (numeric) the timestamp (seconds since Unix epoch) of the oldest pre-generated key in the key pool\n  \"keypoolsize\": xxxx,               (numeric) how many new keys are pre-generated (only counts external keys)\n  \"keypoolsize_hd_internal\": xxxx,   (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)\n  \"unlocked_until\": ttt,             (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n  \"paytxfee\": x.xxxx,                (numeric) the transaction fee configuration, set in LBC/kB\n  \"hdseedid\": \"<hash160>\"            (string, optional) the Hash160 of the HD seed (only present when HD is enabled)\n  \"hdmasterkeyid\": \"<hash160>\"       (string, optional) alias for hdseedid retained for backwards-compatibility. Will be removed in V0.18.\n  \"private_keys_enabled\": true|false (boolean) false if privatekeys are disabled for this wallet (enforced watch-only wallet)\n}"
     },
     {
         "name": "importaddress",
         "namespace": "Wallet",
-        "description": "Adds a script (in hex) or address that can be watched as if it were in your wallet but cannot be used to spend.",
+        "description": "Adds an address or script (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.",
         "arguments": [
             {
-                "name": "script",
+                "name": "address",
                 "type": "string",
-                "description": "The hex-encoded script (or address)",
+                "description": "The Bitcoin address (or hex-encoded script)",
                 "is_required": true
             },
             {
@@ -1890,32 +2548,60 @@
             {
                 "name": "p2sh",
                 "type": "boolean",
-                "description": "Add the P2SH version of the script as well Note: This call can take minutes to complete if rescan is true. If you have the full public key, you should call importpubkey instead of this.",
+                "description": "Add the P2SH version of the script as well Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported address exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes. If you have the full public key, you should call importpubkey instead of this. Note: If you import a non-standard raw script in hex form, outputs sending to it will be treated as change, and not show up in many RPCs.",
                 "is_required": false
             }
         ],
         "examples": [
             {
-                "title": "Import a script with rescan",
-                "cli": "> lbrycrd-cli importaddress \"myscript\""
+                "title": "Import an address with rescan",
+                "cli": "> lbrycrd-cli importaddress \"myaddress\""
             },
             {
                 "title": "Import using a label without rescan",
-                "cli": "> lbrycrd-cli importaddress \"myscript\" \"testing\" false"
+                "cli": "> lbrycrd-cli importaddress \"myaddress\" \"testing\" false"
             },
             {
                 "title": "As a JSON-RPC call",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"importaddress\", \"params\": [\"myscript\", \"testing\", false] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"importaddress\", \"params\": [\"myaddress\", \"testing\", false] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "importmulti",
+        "namespace": "Wallet",
+        "description": "Import addresses/scripts (with private or public keys, redeem script (P2SH)), rescanning all addresses in one-shot-only (rescan can be disabled via options). Requires a new wallet backup.",
+        "arguments": [
+            {
+                "name": "requests",
+                "type": "array",
+                "description": "Data to be imported [ (array of json objects) { \"scriptPubKey\": \"<script>\" | { \"address\":\"<address>\" }, (string / json, required) Type of scriptPubKey (string for script, json for address) \"timestamp\": timestamp | \"now\" , (integer / string, required) Creation time of the key in seconds since epoch (Jan 1 1970 GMT), or the string \"now\" to substitute the current synced blockchain time. The timestamp of the oldest key will determine how far back blockchain rescans need to begin for missing wallet transactions. \"now\" can be specified to bypass scanning, for keys which are known to never have been used, and 0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest key creation time of all keys being imported by the importmulti call will be scanned. \"redeemscript\": \"<script>\" , (string, optional) Allowed only if the scriptPubKey is a P2SH address or a P2SH scriptPubKey \"pubkeys\": [\"<pubKey>\", ... ] , (array, optional) Array of strings giving pubkeys that must occur in the output or redeemscript \"keys\": [\"<key>\", ... ] , (array, optional) Array of strings giving private keys whose corresponding public keys must occur in the output or redeemscript \"internal\": <true> , (boolean, optional, default: false) Stating whether matching outputs should be treated as not incoming payments aka change \"watchonly\": <true> , (boolean, optional, default: false) Stating whether matching outputs should be considered watched even when they're not spendable, only allowed if keys are empty \"label\": <label> , (string, optional, default: '') Label to assign to the address (aka account name, for now), only allowed with internal=false } ,... ]",
+                "is_required": true
+            },
+            {
+                "name": "options",
+                "type": "json",
+                "description": "{ \"rescan\": <false>, (boolean, optional, default: true) Stating if should rescan the blockchain after all imports } Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported keys, addresses or scripts exists but related transactions are still missing.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli importmulti '[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }]' '{ \"rescan\": false}'",
+                "title": "Response is an array with the same size as the input that has the execution result :"
+            },
+            {
+                "title": "[{ \"success\": true } , { \"success\": false, \"error\": { \"code\": -1, \"message\": \"Internal Server Error\"} }, ... ]"
             }
         ]
     },
     {
         "name": "importprivkey",
         "namespace": "Wallet",
-        "description": "Adds a private key (as returned by dumpprivkey) to your wallet.",
+        "description": "Adds a private key (as returned by dumpprivkey) to your wallet. Requires a new wallet backup. Hint: use importmulti to import more than one private key.",
         "arguments": [
             {
-                "name": "lbrycrdprivkey",
+                "name": "privkey",
                 "type": "string",
                 "description": "The private key (see dumpprivkey)",
                 "is_required": true
@@ -1929,7 +2615,7 @@
             {
                 "name": "rescan",
                 "type": "boolean",
-                "description": "Rescan the wallet for transactions Note: This call can take minutes to complete if rescan is true.",
+                "description": "Rescan the wallet for transactions Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported key exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.",
                 "is_required": false
             }
         ],
@@ -1945,6 +2631,10 @@
             {
                 "title": "Import using a label and without rescan",
                 "cli": "> lbrycrd-cli importprivkey \"mykey\" \"testing\" false"
+            },
+            {
+                "title": "Import using default blank label and without rescan",
+                "cli": "> lbrycrd-cli importprivkey \"mykey\" \"\" false"
             },
             {
                 "title": "As a JSON-RPC call",
@@ -1968,12 +2658,6 @@
                 "type": "string",
                 "description": "The hex output from gettxoutproof that contains the transaction",
                 "is_required": true
-            },
-            {
-                "name": "label",
-                "type": "string",
-                "description": "An optional label",
-                "is_required": false
             }
         ],
         "examples": []
@@ -1981,7 +2665,7 @@
     {
         "name": "importpubkey",
         "namespace": "Wallet",
-        "description": "Adds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend.",
+        "description": "Adds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.",
         "arguments": [
             {
                 "name": "pubkey",
@@ -1998,7 +2682,7 @@
             {
                 "name": "rescan",
                 "type": "boolean",
-                "description": "Rescan the wallet for transactions Note: This call can take minutes to complete if rescan is true.",
+                "description": "Rescan the wallet for transactions Note: This call can take over an hour to complete if rescan is true, during that time, other rpc calls may report that the imported pubkey exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.",
                 "is_required": false
             }
         ],
@@ -2020,7 +2704,7 @@
     {
         "name": "importwallet",
         "namespace": "Wallet",
-        "description": "Imports keys from a wallet dump file (see dumpwallet).",
+        "description": "Imports keys from a wallet dump file (see dumpwallet). Requires a new wallet backup to include imported keys.",
         "arguments": [
             {
                 "name": "filename",
@@ -2075,9 +2759,9 @@
                 "is_required": false
             },
             {
-                "name": "includeWatchonly",
+                "name": "include_watchonly",
                 "type": "boolean",
-                "description": "Include balances in watchonly addresses (see 'importaddress')",
+                "description": "Include balances in watch-only addresses (see 'importaddress')",
                 "is_required": false
             }
         ],
@@ -2112,7 +2796,39 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listaddressgroupings\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[\n  [\n    [\n      \"lbrycrdaddress\",     (string) The lbrycrd address\n      amount,                 (numeric) The amount in LBC\n      \"account\"             (string, optional) The account (DEPRECATED)\n    ]\n    ,...\n  ]\n  ,...\n]"
+        "returns": "[\n  [\n    [\n      \"address\",            (string) The bitcoin address\n      amount,                 (numeric) The amount in LBC\n      \"label\"               (string, optional) The label\n    ]\n    ,...\n  ]\n  ,...\n]"
+    },
+    {
+        "name": "listlabels",
+        "namespace": "Wallet",
+        "description": "Returns the list of all labels, or labels that are assigned to addresses with a specific purpose.",
+        "arguments": [
+            {
+                "name": "purpose",
+                "type": "string",
+                "description": "Address purpose to list labels for ('send','receive'). An empty string is the same as not providing this argument.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "title": "List all labels",
+                "cli": "> lbrycrd-cli listlabels"
+            },
+            {
+                "title": "List labels that have receiving addresses",
+                "cli": "> lbrycrd-cli listlabels receive"
+            },
+            {
+                "title": "List labels that have sending addresses",
+                "cli": "> lbrycrd-cli listlabels send"
+            },
+            {
+                "title": "As json rpc call",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listlabels\", \"params\": [receive] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "[               (json array of string)\n  \"label\",      (string) Label name\n  ...\n]"
     },
     {
         "name": "listlockunspent",
@@ -2144,38 +2860,6 @@
         "returns": "[\n  {\n    \"txid\" : \"transactionid\",     (string) The transaction id locked\n    \"vout\" : n                      (numeric) The vout value\n  }\n  ,...\n]"
     },
     {
-        "name": "listreceivedbyaccount",
-        "namespace": "Wallet",
-        "description": "DEPRECATED. List balances by account.",
-        "arguments": [
-            {
-                "name": "minconf",
-                "type": "number",
-                "description": "The minimum number of confirmations before payments are included.",
-                "is_required": false
-            },
-            {
-                "name": "includeempty",
-                "type": "boolean",
-                "description": "Whether to include accounts that haven't received any payments.",
-                "is_required": false
-            },
-            {
-                "name": "includeWatchonly",
-                "type": "boolean",
-                "description": "Whether to include watchonly addresses (see 'importaddress').",
-                "is_required": false
-            }
-        ],
-        "examples": [
-            {
-                "cli": "> lbrycrd-cli listreceivedbyaccount 6 true",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbyaccount\", \"params\": [6, true, true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
-            }
-        ],
-        "returns": "[\n  {\n    \"involvesWatchonly\" : true,   (bool) Only returned if imported addresses were involved in transaction\n    \"account\" : \"accountname\",  (string) The account name of the receiving account\n    \"amount\" : x.xxx,             (numeric) The total amount received by addresses with this account\n    \"confirmations\" : n,          (numeric) The number of confirmations of the most recent transaction included\n    \"label\" : \"label\"           (string) A comment for the address/transaction, if any\n  }\n  ,...\n]"
-    },
-    {
         "name": "listreceivedbyaddress",
         "namespace": "Wallet",
         "description": "List balances by receiving address.",
@@ -2187,30 +2871,68 @@
                 "is_required": false
             },
             {
-                "name": "includeempty",
+                "name": "include_empty",
                 "type": "boolean",
                 "description": "Whether to include addresses that haven't received any payments.",
                 "is_required": false
             },
             {
-                "name": "includeWatchonly",
+                "name": "include_watchonly",
                 "type": "boolean",
-                "description": "Whether to include watchonly addresses (see 'importaddress').",
+                "description": "Whether to include watch-only addresses (see 'importaddress').",
+                "is_required": false
+            },
+            {
+                "name": "address_filter",
+                "type": "string",
+                "description": "If present, only return information on this address.",
                 "is_required": false
             }
         ],
         "examples": [
             {
                 "cli": "> lbrycrd-cli listreceivedbyaddress 6 true",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbyaddress\", \"params\": [6, true, true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbyaddress\", \"params\": [6, true, true, \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[\n  {\n    \"involvesWatchonly\" : true,        (bool) Only returned if imported addresses were involved in transaction\n    \"address\" : \"receivingaddress\",  (string) The receiving address\n    \"account\" : \"accountname\",       (string) DEPRECATED. The account of the receiving address. The default account is \"\".\n    \"amount\" : x.xxx,                  (numeric) The total amount in LBC received by the address\n    \"confirmations\" : n,               (numeric) The number of confirmations of the most recent transaction included\n    \"label\" : \"label\"                (string) A comment for the address/transaction, if any\n  }\n  ,...\n]"
+        "returns": "[\n  {\n    \"involvesWatchonly\" : true,        (bool) Only returned if imported addresses were involved in transaction\n    \"address\" : \"receivingaddress\",  (string) The receiving address\n    \"account\" : \"accountname\",       (string) DEPRECATED. Backwards compatible alias for label.\n    \"amount\" : x.xxx,                  (numeric) The total amount in LBC received by the address\n    \"confirmations\" : n,               (numeric) The number of confirmations of the most recent transaction included\n    \"label\" : \"label\",               (string) The label of the receiving address. The default label is \"\".\n    \"txids\": [\n       \"txid\",                         (string) The ids of transactions received with the address \n       ...\n    ]\n  }\n  ,...\n]"
+    },
+    {
+        "name": "listreceivedbylabel",
+        "namespace": "Wallet",
+        "description": "List received transactions by label.",
+        "arguments": [
+            {
+                "name": "minconf",
+                "type": "number",
+                "description": "The minimum number of confirmations before payments are included.",
+                "is_required": false
+            },
+            {
+                "name": "include_empty",
+                "type": "boolean",
+                "description": "Whether to include labels that haven't received any payments.",
+                "is_required": false
+            },
+            {
+                "name": "include_watchonly",
+                "type": "boolean",
+                "description": "Whether to include watch-only addresses (see 'importaddress').",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli listreceivedbylabel 6 true",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listreceivedbylabel\", \"params\": [6, true, true] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "[\n  {\n    \"involvesWatchonly\" : true,   (bool) Only returned if imported addresses were involved in transaction\n    \"account\" : \"accountname\",  (string) DEPRECATED. Backwards compatible alias for label.\n    \"amount\" : x.xxx,             (numeric) The total amount received by addresses with this label\n    \"confirmations\" : n,          (numeric) The number of confirmations of the most recent transaction included\n    \"label\" : \"label\"           (string) The label of the receiving address. The default label is \"\".\n  }\n  ,...\n]"
     },
     {
         "name": "listsinceblock",
         "namespace": "Wallet",
-        "description": "Get all transactions in blocks since block [blockhash], or all transactions if omitted",
+        "description": "Get all transactions in blocks since block [blockhash], or all transactions if omitted. If \"blockhash\" is no longer a part of the main chain, transactions from the fork point onward are included. Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.",
         "arguments": [
             {
                 "name": "blockhash",
@@ -2219,15 +2941,21 @@
                 "is_required": false
             },
             {
-                "name": "target-confirmations:",
+                "name": "target_confirmations:",
                 "type": "number",
-                "description": "The confirmations required, must be 1 or more",
+                "description": "Return the nth block hash from the main chain. e.g. 1 would mean the best block hash. Note: this is not used as a filter, but only affects [lastblock] in the return value",
                 "is_required": false
             },
             {
-                "name": "includeWatchonly:",
+                "name": "include_watchonly:",
                 "type": "boolean",
-                "description": "Include transactions to watchonly addresses (see 'importaddress')",
+                "description": "Include transactions to watch-only addresses (see 'importaddress')",
+                "is_required": false
+            },
+            {
+                "name": "include_removed:",
+                "type": "boolean",
+                "description": "Show transactions that were removed due to a reorg in the \"removed\" array (not guaranteed to work on pruned nodes)",
                 "is_required": false
             }
         ],
@@ -2237,7 +2965,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listsinceblock\", \"params\": [\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\", 6] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{\n  \"transactions\": [\n    \"account\":\"accountname\",       (string) DEPRECATED. The account name associated with the transaction. Will be \"\" for the default account.\n    \"address\":\"lbrycrdaddress\",    (string) The lbrycrd address of the transaction. Not present for move transactions (category = move).\n    \"category\":\"send|receive\",     (string) The transaction category. 'send' has negative amounts, 'receive' has positive amounts.\n    \"amount\": x.xxx,          (numeric) The amount in LBC. This is negative for the 'send' category, and for the 'move' category for moves \n                                          outbound. It is positive for the 'receive' category, and for the 'move' category for inbound funds.\n    \"vout\" : n,               (numeric) the vout value\n    \"fee\": x.xxx,             (numeric) The amount of the fee in LBC. This is negative and only available for the 'send' category of transactions.\n    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and 'receive' category of transactions.\n    \"blockhash\": \"hashvalue\",     (string) The block hash containing the transaction. Available for 'send' and 'receive' category of transactions.\n    \"blockindex\": n,          (numeric) The index of the transaction in the block that includes it. Available for 'send' and 'receive' category of transactions.\n    \"blocktime\": xxx,         (numeric) The block time in seconds since epoch (1 Jan 1970 GMT).\n    \"txid\": \"transactionid\",  (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT).\n    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (Jan 1 1970 GMT). Available for 'send' and 'receive' category of transactions.\n    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n    \"label\" : \"label\"       (string) A comment for the address/transaction, if any\n    \"to\": \"...\",            (string) If a comment to is associated with the transaction.\n  ],\n  \"lastblock\": \"lastblockhash\"     (string) The hash of the last block\n}"
+        "returns": "{\n  \"transactions\": [\n    \"account\":\"accountname\",       (string) DEPRECATED. This field will be removed in V0.18. To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The account name associated with the transaction. Will be \"\" for the default account.\n    \"address\":\"address\",    (string) The bitcoin address of the transaction. Not present for move transactions (category = move).\n    \"category\":\"send|receive\",     (string) The transaction category. 'send' has negative amounts, 'receive' has positive amounts.\n    \"amount\": x.xxx,          (numeric) The amount in LBC. This is negative for the 'send' category, and for the 'move' category for moves \n                                          outbound. It is positive for the 'receive' category, and for the 'move' category for inbound funds.\n    \"vout\" : n,               (numeric) the vout value\n    \"fee\": x.xxx,             (numeric) The amount of the fee in LBC. This is negative and only available for the 'send' category of transactions.\n    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and 'receive' category of transactions.\n                                          When it's < 0, it means the transaction conflicted that many blocks ago.\n    \"blockhash\": \"hashvalue\",     (string) The block hash containing the transaction. Available for 'send' and 'receive' category of transactions.\n    \"blockindex\": n,          (numeric) The index of the transaction in the block that includes it. Available for 'send' and 'receive' category of transactions.\n    \"blocktime\": xxx,         (numeric) The block time in seconds since epoch (1 Jan 1970 GMT).\n    \"txid\": \"transactionid\",  (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT).\n    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (Jan 1 1970 GMT). Available for 'send' and 'receive' category of transactions.\n    \"bip125-replaceable\": \"yes|no|unknown\",  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n                                                   may be unknown for unconfirmed transactions not in the mempool\n    \"abandoned\": xxx,         (bool) 'true' if the transaction has been abandoned (inputs are respendable). Only available for the 'send' category of transactions.\n    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n    \"label\" : \"label\"       (string) A comment for the address/transaction, if any\n    \"to\": \"...\",            (string) If a comment to is associated with the transaction.\n  ],\n  \"removed\": [\n    <structure is the same as \"transactions\" above, only present if include_removed=true>\n    Note: transactions that were re-added in the active chain will appear as-is in this array, and may thus have a positive confirmation count.\n  ],\n  \"lastblock\": \"lastblockhash\"     (string) The hash of the block (target_confirmations-1) from the best block on the main chain. This is typically used to feed back into listsinceblock the next time you call it. So you would generally use a target_confirmations of say 6, so you will be continually re-notified of transactions until they've reached 6 confirmations plus any new ones\n}"
     },
     {
         "name": "listtransactions",
@@ -2247,7 +2975,7 @@
             {
                 "name": "account",
                 "type": "string",
-                "description": "DEPRECATED. The account name. Should be \"*\".",
+                "description": "DEPRECATED. This argument will be removed in V0.",
                 "is_required": false
             },
             {
@@ -2257,15 +2985,15 @@
                 "is_required": false
             },
             {
-                "name": "from",
+                "name": "skip",
                 "type": "number",
                 "description": "The number of transactions to skip",
                 "is_required": false
             },
             {
-                "name": "includeWatchonly",
+                "name": "include_watchonly",
                 "type": "boolean",
-                "description": "Include transactions to watchonly addresses (see 'importaddress')",
+                "description": "Include transactions to watch-only addresses (see 'importaddress')",
                 "is_required": false
             }
         ],
@@ -2283,25 +3011,94 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listtransactions\", \"params\": [\"*\", 20, 100] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "[\n  {\n    \"account\":\"accountname\",       (string) DEPRECATED. The account name associated with the transaction. \n                                                It will be \"\" for the default account.\n    \"address\":\"lbrycrdaddress\",    (string) The lbrycrd address of the transaction. Not present for \n                                                move transactions (category = move).\n    \"category\":\"send|receive|move\", (string) The transaction category. 'move' is a local (off blockchain)\n                                                transaction between accounts, and not associated with an address,\n                                                transaction id or block. 'send' and 'receive' transactions are \n                                                associated with an address, transaction id and block details\n    \"amount\": x.xxx,          (numeric) The amount in LBC. This is negative for the 'send' category, and for the\n                                         'move' category for moves outbound. It is positive for the 'receive' category,\n                                         and for the 'move' category for inbound funds.\n    \"vout\": n,                (numeric) the vout value\n    \"fee\": x.xxx,             (numeric) The amount of the fee in LBC. This is negative and only available for the \n                                         'send' category of transactions.\n    \"abandoned\": xxx          (bool) 'true' if the transaction has been abandoned (inputs are respendable).\n    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and \n                                         'receive' category of transactions. Negative confirmations indicate the\n                                         transaction conflicts with the block chain\n    \"trusted\": xxx            (bool) Whether we consider the outputs of this unconfirmed transaction safe to spend.\n    \"blockhash\": \"hashvalue\", (string) The block hash containing the transaction. Available for 'send' and 'receive'\n                                          category of transactions.\n    \"blockindex\": n,          (numeric) The index of the transaction in the block that includes it. Available for 'send' and 'receive'\n                                          category of transactions.\n    \"blocktime\": xxx,         (numeric) The block time in seconds since epoch (1 Jan 1970 GMT).\n    \"txid\": \"transactionid\", (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (midnight Jan 1 1970 GMT). Available \n                                          for 'send' and 'receive' category of transactions.\n    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n    \"label\": \"label\"        (string) A comment for the address/transaction, if any\n    \"otheraccount\": \"accountname\",  (string) For the 'move' category of transactions, the account the funds came \n                                          from (for receiving funds, positive amounts), or went to (for sending funds,\n                                          negative amounts).\n    \"bip125-replaceable\": \"yes|no|unknown\"  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n                                                     may be unknown for unconfirmed transactions not in the mempool\n  }\n]"
+        "returns": "[\n  {\n    \"account\":\"accountname\",       (string) DEPRECATED. This field will be removed in V0.18. The account name associated with the transaction. \n                                                It will be \"\" for the default account.\n    \"address\":\"address\",    (string) The bitcoin address of the transaction. Not present for \n                                                move transactions (category = move).\n    \"category\":\"send|receive|move\", (string) The transaction category. 'move' is a local (off blockchain)\n                                                transaction between accounts, and not associated with an address,\n                                                transaction id or block. 'send' and 'receive' transactions are \n                                                associated with an address, transaction id and block details\n    \"amount\": x.xxx,          (numeric) The amount in LBC. This is negative for the 'send' category, and for the\n                                         'move' category for moves outbound. It is positive for the 'receive' category,\n                                         and for the 'move' category for inbound funds.\n    \"label\": \"label\",       (string) A comment for the address/transaction, if any\n    \"vout\": n,                (numeric) the vout value\n    \"fee\": x.xxx,             (numeric) The amount of the fee in LBC. This is negative and only available for the \n                                         'send' category of transactions.\n    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and \n                                         'receive' category of transactions. Negative confirmations indicate the\n                                         transaction conflicts with the block chain\n    \"trusted\": xxx,           (bool) Whether we consider the outputs of this unconfirmed transaction safe to spend.\n    \"blockhash\": \"hashvalue\", (string) The block hash containing the transaction. Available for 'send' and 'receive'\n                                          category of transactions.\n    \"blockindex\": n,          (numeric) The index of the transaction in the block that includes it. Available for 'send' and 'receive'\n                                          category of transactions.\n    \"blocktime\": xxx,         (numeric) The block time in seconds since epoch (1 Jan 1970 GMT).\n    \"txid\": \"transactionid\", (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (midnight Jan 1 1970 GMT). Available \n                                          for 'send' and 'receive' category of transactions.\n    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n    \"otheraccount\": \"accountname\",  (string) DEPRECATED. This field will be removed in V0.18. For the 'move' category of transactions, the account the funds came \n                                          from (for receiving funds, positive amounts), or went to (for sending funds,\n                                          negative amounts).\n    \"bip125-replaceable\": \"yes|no|unknown\",  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n                                                     may be unknown for unconfirmed transactions not in the mempool\n    \"abandoned\": xxx          (bool) 'true' if the transaction has been abandoned (inputs are respendable). Only available for the \n                                         'send' category of transactions.\n  }\n]"
     },
     {
         "name": "listunspent",
         "namespace": "Wallet",
         "description": "Returns array of unspent transaction outputs with between minconf and maxconf (inclusive) confirmations. Optionally filter to only include txouts paid to specified addresses.",
+        "arguments": [
+            {
+                "name": "minconf",
+                "type": "number",
+                "description": "The minimum confirmations to filter",
+                "is_required": false
+            },
+            {
+                "name": "maxconf",
+                "type": "number",
+                "description": "The maximum confirmations to filter",
+                "is_required": false
+            },
+            {
+                "name": "addresses",
+                "type": "string",
+                "description": "A json array of bitcoin addresses to filter [ \"address\" (string) bitcoin address ,... ]",
+                "is_required": true
+            },
+            {
+                "name": "include_unsafe",
+                "type": "boolean",
+                "description": "Include outputs that are not safe to spend See description of \"safe\" attribute below.",
+                "is_required": false
+            },
+            {
+                "name": "query_options",
+                "type": "json",
+                "description": "JSON with query options { \"minimumAmount\" (numeric or string, default=0) Minimum value of each UTXO in LBC \"maximumAmount\" (numeric or string, default=unlimited) Maximum value of each UTXO in LBC \"maximumCount\" (numeric or string, default=unlimited) Maximum number of UTXOs \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in LBC } Result [ (array of json object) { \"txid\" : \"txid\", (string) the transaction id \"vout\" : n, (numeric) the vout value \"address\" : \"address\", (string) the bitcoin address \"label\" : \"label\", (string) The associated label, or \"\" for the default label \"account\" : \"account\", (string) DEPRECATED. This field will be removed in V0.",
+                "is_required": false
+            },
+            {
+                "name": "To see this deprecated field, start bitcoind with -deprecatedrpc=accounts. The associated account, or \"\" for the default account\n    \"scriptPubKey\" : \"key\",",
+                "type": "string",
+                "description": "the script key \"amount\" : x.xxx, (numeric) the transaction output amount in LBC \"confirmations\" : n, (numeric) The number of confirmations \"redeemScript\" : n (string) The redeemScript if scriptPubKey is P2SH \"spendable\" : xxx, (bool) Whether we have the private keys to spend this output \"solvable\" : xxx, (bool) Whether we know how to spend this output, ignoring the lack of keys \"safe\" : xxx (bool) Whether this output is considered safe to spend. Unconfirmed transactions from outside keys and unconfirmed replacement transactions are considered unsafe and are not eligible for spending by fundrawtransaction and sendtoaddress. } ,... ]",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli listunspent 6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listunspent\", \"params\": [6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "listwallets",
+        "namespace": "Wallet",
+        "description": "Returns a list of currently loaded wallets. For full information on the wallet, use \"getwalletinfo\"",
         "arguments": [],
         "examples": [
             {
-                "cli": "> lbrycrd-cli listunspent 6 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listunspent\", \"params\": [6, 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli listwallets",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"listwallets\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "{txid, vout, scriptPubKey, amount, confirmations}\n\nArguments:\n1. minconf          (numeric, optional, default=1) The minimum confirmations to filter\n2. maxconf          (numeric, optional, default=9999999) The maximum confirmations to filter\n3. \"addresses\"    (string) A json array of lbrycrd addresses to filter\n    [\n      \"address\"   (string) lbrycrd address\n      ,...\n    ]\n\nResult\n[                   (array of json object)\n  {\n    \"txid\" : \"txid\",        (string) the transaction id \n    \"vout\" : n,               (numeric) the vout value\n    \"address\" : \"address\",  (string) the lbrycrd address\n    \"account\" : \"account\",  (string) DEPRECATED. The associated account, or \"\" for the default account\n    \"scriptPubKey\" : \"key\", (string) the script key\n    \"amount\" : x.xxx,         (numeric) the transaction amount in LBC\n    \"confirmations\" : n       (numeric) The number of confirmations\n  }\n  ,...\n]"
+        "returns": "[                         (json array of strings)\n  \"walletname\"            (string) the wallet name\n   ...\n]"
+    },
+    {
+        "name": "loadwallet",
+        "namespace": "Wallet",
+        "description": "Loads a wallet from a wallet file or directory. Note that all wallet command-line options used when starting bitcoind will be applied to the new wallet (eg -zapwallettxes, upgradewallet, rescan, etc).",
+        "arguments": [
+            {
+                "name": "filename",
+                "type": "string",
+                "description": "The wallet directory or .dat file.",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli loadwallet \"test.dat\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"loadwallet\", \"params\": [\"test.dat\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"name\" :    <wallet_name>,        (string) The wallet name if loaded successfully.\n  \"warning\" : <warning>,            (string) Warning message if wallet was not loaded cleanly.\n}"
     },
     {
         "name": "lockunspent",
         "namespace": "Wallet",
-        "description": "Updates list of temporarily unspendable outputs. Temporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs. If no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked. A locked transaction output will not be chosen by automatic coin selection, when spending LBC. Locks are stored in memory only. Nodes start with zero locked outputs, and the locked output list is always cleared (by virtue of process exit) when a node stops or fails. Also see the listunspent call",
+        "description": "Updates list of temporarily unspendable outputs. Temporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs. If no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked. A locked transaction output will not be chosen by automatic coin selection, when spending bitcoins. Locks are stored in memory only. Nodes start with zero locked outputs, and the locked output list is always cleared (by virtue of process exit) when a node stops or fails. Also see the listunspent call",
         "arguments": [
             {
                 "name": "unlock",
@@ -2364,9 +3161,9 @@
                 "is_required": true
             },
             {
-                "name": "minconf",
+                "name": "(dummy)",
                 "type": "number",
-                "description": "Only use funds with at least this many confirmations.",
+                "description": "Ignored. Remains for backward compatibility.",
                 "is_required": false
             },
             {
@@ -2395,7 +3192,7 @@
     {
         "name": "removeprunedfunds",
         "namespace": "Wallet",
-        "description": "Deletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will effect wallet balances.",
+        "description": "Deletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.",
         "arguments": [
             {
                 "name": "txid",
@@ -2408,25 +3205,51 @@
             {
                 "cli": "> lbrycrd-cli removeprunedfunds \"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"",
                 "title": "As a JSON-RPC call",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"removprunedfunds\", \"params\": [\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"removeprunedfunds\", \"params\": [\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ]
     },
     {
+        "name": "rescanblockchain",
+        "namespace": "Wallet",
+        "description": "Rescan the local blockchain for wallet related transactions.",
+        "arguments": [
+            {
+                "name": "start_height",
+                "type": "number",
+                "description": "block height where the rescan should start",
+                "is_required": false
+            },
+            {
+                "name": "stop_height",
+                "type": "number",
+                "description": "the last block height that should be scanned",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli rescanblockchain 100000 120000",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"rescanblockchain\", \"params\": [100000, 120000] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"start_height\"     (numeric) The block height where the rescan has started. If omitted, rescan started from the genesis block.\n  \"stop_height\"      (numeric) The height of the last rescanned block. If omitted, rescan stopped at the chain tip.\n}"
+    },
+    {
         "name": "sendfrom",
         "namespace": "Wallet",
-        "description": "DEPRECATED (use sendtoaddress). Sent an amount from an account to a lbrycrd address.",
+        "description": "DEPRECATED (use sendtoaddress). Sent an amount from an account to a bitcoin address.",
         "arguments": [
             {
                 "name": "fromaccount",
                 "type": "string",
-                "description": "The name of the account to send funds from. May be the default account using \"\".",
+                "description": "The name of the account to send funds from. May be the default account using \"\". Specifying an account does not influence coin selection, but it does associate the newly created transaction with the account, so the account's balance computation and transaction history can reflect the spend.",
                 "is_required": true
             },
             {
-                "name": "tolbrycrdaddress",
+                "name": "toaddress",
                 "type": "string",
-                "description": "The lbrycrd address to send funds to.",
+                "description": "The bitcoin address to send funds to.",
                 "is_required": true
             },
             {
@@ -2448,7 +3271,7 @@
                 "is_required": false
             },
             {
-                "name": "comment-to",
+                "name": "comment_to",
                 "type": "string",
                 "description": "An optional comment to store the name of the person or organization to which you're sending the transaction. This is not part of the transaction, it is just kept in your wallet.",
                 "is_required": false
@@ -2468,7 +3291,7 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendfrom\", \"params\": [\"tabby\", \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.01, 6, \"donation\", \"seans outpost\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"transactionid\"        (string) The transaction id."
+        "returns": "\"txid\"                 (string) The transaction id."
     },
     {
         "name": "sendmany",
@@ -2484,7 +3307,7 @@
             {
                 "name": "amounts",
                 "type": "string",
-                "description": "A json object with addresses and amounts { \"address\":amount (numeric or string) The lbrycrd address is the key, the numeric amount (can be string) in LBC is the value ,... }",
+                "description": "A json object with addresses and amounts { \"address\":amount (numeric or string) The bitcoin address is the key, the numeric amount (can be string) in LBC is the value ,... }",
                 "is_required": true
             },
             {
@@ -2500,31 +3323,49 @@
                 "is_required": false
             },
             {
-                "name": "subtractfeefromamount",
+                "name": "subtractfeefrom",
+                "type": "array",
+                "description": "A json array with addresses. The fee will be equally deducted from the amount of each selected address. Those recipients will receive less bitcoins than you enter in their corresponding amount field. If no addresses are specified here, the sender pays the fee. [ \"address\" (string) Subtract fee from this address ,... ]",
+                "is_required": false
+            },
+            {
+                "name": "replaceable",
+                "type": "boolean",
+                "description": "Allow this transaction to be replaced by a transaction with higher fees via BIP 125",
+                "is_required": false
+            },
+            {
+                "name": "conf_target",
+                "type": "number",
+                "description": "Confirmation target (in blocks)",
+                "is_required": false
+            },
+            {
+                "name": "estimate_mode",
                 "type": "string",
-                "description": "A json array with addresses. The fee will be equally deducted from the amount of each selected address. Those recipients will receive less LBC than you enter in their corresponding amount field. If no addresses are specified here, the sender pays the fee. [ \"address\" (string) Subtract fee from this address ,... ]",
+                "description": "The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\"",
                 "is_required": false
             }
         ],
         "examples": [
             {
                 "title": "Send two amounts to two different addresses:",
-                "cli": "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\""
+                "cli": "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\""
             },
             {
                 "title": "Send two amounts to two different addresses setting the confirmation and comment:",
-                "cli": "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 6 \"testing\""
+                "cli": "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 6 \"testing\""
             },
             {
                 "title": "Send two amounts to two different addresses, subtract fee from amount:",
-                "cli": "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 1 \"\" \"[\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\",\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\"]\""
+                "cli": "> lbrycrd-cli sendmany \"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 1 \"\" \"[\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\",\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\"]\""
             },
             {
                 "title": "As a json rpc call",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendmany\", \"params\": [\"\", \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\", 6, \"testing\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendmany\", \"params\": [\"\", {\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\":0.01,\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\":0.02}, 6, \"testing\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"transactionid\"          (string) The transaction id for the send. Only 1 transaction is created regardless of \n                                    the number of addresses."
+        "returns": "\"txid\"                   (string) The transaction id for the send. Only 1 transaction is created regardless of \n                                    the number of addresses."
     },
     {
         "name": "sendtoaddress",
@@ -2532,9 +3373,9 @@
         "description": "Send an amount to a given address.",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
-                "description": "The lbrycrd address to send to.",
+                "description": "The bitcoin address to send to.",
                 "is_required": true
             },
             {
@@ -2550,7 +3391,7 @@
                 "is_required": false
             },
             {
-                "name": "comment-to",
+                "name": "comment_to",
                 "type": "string",
                 "description": "A comment to store the name of the person or organization to which you're sending the transaction. This is not part of the transaction, just kept in your wallet.",
                 "is_required": false
@@ -2558,7 +3399,25 @@
             {
                 "name": "subtractfeefromamount",
                 "type": "boolean",
-                "description": "The fee will be deducted from the amount being sent. The recipient will receive less LBC than you enter in the amount field.",
+                "description": "The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field.",
+                "is_required": false
+            },
+            {
+                "name": "replaceable",
+                "type": "boolean",
+                "description": "Allow this transaction to be replaced by a transaction with higher fees via BIP 125",
+                "is_required": false
+            },
+            {
+                "name": "conf_target",
+                "type": "number",
+                "description": "Confirmation target (in blocks)",
+                "is_required": false
+            },
+            {
+                "name": "estimate_mode",
+                "type": "string",
+                "description": "The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\"",
                 "is_required": false
             }
         ],
@@ -2568,37 +3427,62 @@
                 "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendtoaddress\", \"params\": [\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
-        "returns": "\"transactionid\"  (string) The transaction id."
+        "returns": "\"txid\"                  (string) The transaction id."
     },
     {
-        "name": "setaccount",
+        "name": "sethdseed",
         "namespace": "Wallet",
-        "description": "DEPRECATED. Sets the account associated with the given address.",
+        "description": "Set or generate a new HD wallet seed. Non-HD wallets will not be upgraded to being a HD wallet. Wallets that are already HD will have a new HD seed set so that new keys added to the keypool will be derived from this new seed. Note that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet seed.",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "newkeypool",
+                "type": "boolean",
+                "description": "Whether to flush old unused addresses, including change addresses, from the keypool and regenerate it. If true, the next address from getnewaddress and change address from getrawchangeaddress will be from this new seed. If false, addresses (including change addresses if the wallet already had HD Chain Split enabled) from the existing keypool will be used until it has been depleted.",
+                "is_required": false
+            },
+            {
+                "name": "seed",
                 "type": "string",
-                "description": "The lbrycrd address to be associated with an account.",
+                "description": "The WIF private key to use as the new HD seed; if not provided a random seed will be used. The seed value can be retrieved using the dumpwallet command. It is the private key marked hdseed=1",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli sethdseed true \"wifkey\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sethdseed\", \"params\": [true, \"wifkey\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "setlabel",
+        "namespace": "Wallet",
+        "description": "Sets the label associated with the given address.",
+        "arguments": [
+            {
+                "name": "address",
+                "type": "string",
+                "description": "The bitcoin address to be associated with a label.",
                 "is_required": true
             },
             {
-                "name": "account",
+                "name": "label",
                 "type": "string",
-                "description": "The account to assign the address to.",
+                "description": "The label to assign to the address.",
                 "is_required": true
             }
         ],
         "examples": [
             {
-                "cli": "> lbrycrd-cli setaccount \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"tabby\"",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setaccount\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", \"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "cli": "> lbrycrd-cli setlabel \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"tabby\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"setlabel\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"tabby\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ]
     },
     {
         "name": "settxfee",
         "namespace": "Wallet",
-        "description": "Set the transaction fee per kB. Overwrites the paytxfee parameter.",
+        "description": "Set the transaction fee per kB for this wallet. Overrides the global -paytxfee command line parameter.",
         "arguments": [
             {
                 "name": "amount",
@@ -2620,9 +3504,9 @@
         "description": "Sign a message with the private key of an address",
         "arguments": [
             {
-                "name": "lbrycrdaddress",
+                "name": "address",
                 "type": "string",
-                "description": "The lbrycrd address to use for the private key.",
+                "description": "The bitcoin address to use for the private key.",
                 "is_required": true
             },
             {
@@ -2639,17 +3523,244 @@
             },
             {
                 "title": "Create the signature",
-                "cli": "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"my message\""
+                "cli": "> lbrycrd-cli signmessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\""
             },
             {
                 "title": "Verify the signature",
-                "cli": "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\" \"signature\" \"my message\""
+                "cli": "> lbrycrd-cli verifymessage \"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\""
             },
             {
                 "title": "As json rpc",
-                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signmessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signmessage\", \"params\": [\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"my message\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
             }
         ],
         "returns": "\"signature\"          (string) The signature of the message encoded in base 64"
+    },
+    {
+        "name": "signrawtransactionwithwallet",
+        "namespace": "Wallet",
+        "description": "Sign inputs for raw transaction (serialized, hex-encoded). The second optional argument (may be null) is an array of previous transaction outputs that this transaction depends on but may not yet be in the block chain.",
+        "arguments": [
+            {
+                "name": "hexstring",
+                "type": "string",
+                "description": "The transaction hex string",
+                "is_required": true
+            },
+            {
+                "name": "prevtxs",
+                "type": "string",
+                "description": "An json array of previous dependent transaction outputs [ (json array of json objects, or 'null' if none provided) { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"scriptPubKey\": \"hex\", (string, required) script key \"redeemScript\": \"hex\", (string, required for P2SH or P2WSH) redeem script \"amount\": value (numeric, required) The amount spent } ,... ]",
+                "is_required": false
+            },
+            {
+                "name": "sighashtype",
+                "type": "string",
+                "description": "The signature hash type. Must be one of \"ALL\" \"NONE\" \"SINGLE\" \"ALL|ANYONECANPAY\" \"NONE|ANYONECANPAY\" \"SINGLE|ANYONECANPAY\"",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli signrawtransactionwithwallet \"myhex\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"signrawtransactionwithwallet\", \"params\": [\"myhex\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "{\n  \"hex\" : \"value\",                  (string) The hex-encoded raw transaction with signature(s)\n  \"complete\" : true|false,          (boolean) If the transaction has a complete set of signatures\n  \"errors\" : [                      (json array of objects) Script verification errors (if there are any)\n    {\n      \"txid\" : \"hash\",              (string) The hash of the referenced, previous transaction\n      \"vout\" : n,                   (numeric) The index of the output to spent and used as input\n      \"scriptSig\" : \"hex\",          (string) The hex-encoded signature script\n      \"sequence\" : n,               (numeric) Script sequence number\n      \"error\" : \"text\"              (string) Verification or signing error related to the input\n    }\n    ,...\n  ]\n}"
+    },
+    {
+        "name": "unloadwallet",
+        "namespace": "Wallet",
+        "description": "Unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument. Specifying the wallet name on a wallet endpoint is invalid.",
+        "arguments": [
+            {
+                "name": "wallet_name",
+                "type": "string",
+                "description": "The name of the wallet to unload.",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli unloadwallet wallet_name",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"unloadwallet\", \"params\": [wallet_name] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "walletcreatefundedpsbt",
+        "namespace": "Wallet",
+        "description": "Creates and funds a transaction in the Partially Signed Transaction format. Inputs will be added if supplied inputs are not enough Implements the Creator and Updater roles.",
+        "arguments": [
+            {
+                "name": "inputs",
+                "type": "array",
+                "description": "A json array of json objects [ { \"txid\":\"id\", (string, required) The transaction id \"vout\":n, (numeric, required) The output number \"sequence\":n (numeric, optional) The sequence number } ,... ]",
+                "is_required": true
+            },
+            {
+                "name": "outputs",
+                "type": "array",
+                "description": "a json array with outputs (key-value pairs), where none of the keys are duplicated. That is, each address can only appear once and there can only be one 'data' object. [ { \"address\": x.xxx, (obj, optional) A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in LBC }, { \"data\": \"hex\" (obj, optional) A key-value pair. The key must be \"data\", the value is hex encoded data } ,... More key-value pairs of the above form. For compatibility reasons, a dictionary, which holds the key-value pairs directly, is also accepted as second parameter. ]",
+                "is_required": true
+            },
+            {
+                "name": "locktime",
+                "type": "number",
+                "description": "Raw locktime. Non-0 value also locktime-activates inputs",
+                "is_required": false
+            },
+            {
+                "name": "options",
+                "type": "object",
+                "description": "{ \"changeAddress\" (string, optional, default pool address) The bitcoin address to receive the change \"changePosition\" (numeric, optional, default random) The index of the change output \"change_type\" (string, optional) The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype. \"includeWatching\" (boolean, optional, default false) Also select inputs which are watch only \"lockUnspents\" (boolean, optional, default false) Lock selected unspent outputs \"feeRate\" (numeric, optional, default not set: makes wallet determine the fee) Set a specific fee rate in LBC/kB \"subtractFeeFromOutputs\" (array, optional) A json array of integers. The fee will be equally deducted from the amount of each specified output. The outputs are specified by their zero-based index, before any change output is added. Those recipients will receive less bitcoins than you enter in their corresponding amount field. If no outputs are specified here, the sender pays the fee. [vout_index,...] \"replaceable\" (boolean, optional) Marks this transaction as BIP125 replaceable. Allows this transaction to be replaced by a transaction with higher fees \"conf_target\" (numeric, optional) Confirmation target (in blocks) \"estimate_mode\" (string, optional, default=UNSET) The fee estimate mode, must be one of: \"UNSET\" \"ECONOMICAL\" \"CONSERVATIVE\" }",
+                "is_required": false
+            },
+            {
+                "name": "bip32derivs",
+                "type": "boolean",
+                "description": "If true, includes the BIP 32 derivation paths for public keys if we know them",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "title": "Create a transaction with no inputs",
+                "cli": "> lbrycrd-cli walletcreatefundedpsbt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\""
+            }
+        ],
+        "returns": "{\n  \"psbt\": \"value\",        (string)  The resulting raw transaction (base64-encoded string)\n  \"fee\":       n,         (numeric) Fee in LBC the resulting transaction pays\n  \"changepos\": n          (numeric) The position of the added change output, or -1\n}"
+    },
+    {
+        "name": "walletlock",
+        "namespace": "Wallet",
+        "description": "Removes the wallet encryption key from memory, locking the wallet. After calling this method, you will need to call walletpassphrase again before being able to call any methods which require the wallet to be unlocked.",
+        "arguments": [],
+        "examples": [
+            {
+                "title": "Set the passphrase for 2 minutes to perform a transaction",
+                "cli": "> lbrycrd-cli walletpassphrase \"my pass phrase\" 120"
+            },
+            {
+                "title": "Perform a send (requires passphrase set)",
+                "cli": "> lbrycrd-cli sendtoaddress \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 1.0"
+            },
+            {
+                "title": "Clear the passphrase since we are done before 2 minutes is up",
+                "cli": "> lbrycrd-cli walletlock"
+            },
+            {
+                "title": "As json rpc call",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"walletlock\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "walletpassphrase",
+        "namespace": "Wallet",
+        "description": "Stores the wallet decryption key in memory for 'timeout' seconds. This is needed prior to performing transactions related to private keys such as sending bitcoins",
+        "arguments": [
+            {
+                "name": "passphrase",
+                "type": "string",
+                "description": "The wallet passphrase",
+                "is_required": true
+            },
+            {
+                "name": "timeout",
+                "type": "number",
+                "description": "The time to keep the decryption key in seconds; capped at 100000000 (~3 years). Note: Issuing the walletpassphrase command while the wallet is already unlocked will set a new unlock time that overrides the old one.",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "title": "Unlock the wallet for 60 seconds",
+                "cli": "> lbrycrd-cli walletpassphrase \"my pass phrase\" 60"
+            },
+            {
+                "title": "Lock the wallet again (before 60 seconds)",
+                "cli": "> lbrycrd-cli walletlock"
+            },
+            {
+                "title": "As json rpc call",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"walletpassphrase\", \"params\": [\"my pass phrase\", 60] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "walletpassphrasechange",
+        "namespace": "Wallet",
+        "description": "Changes the wallet passphrase from 'oldpassphrase' to 'newpassphrase'.",
+        "arguments": [
+            {
+                "name": "oldpassphrase",
+                "type": "string",
+                "description": "The current passphrase",
+                "is_required": true
+            },
+            {
+                "name": "newpassphrase",
+                "type": "string",
+                "description": "The new passphrase",
+                "is_required": true
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli walletpassphrasechange \"old one\" \"new one\"",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"walletpassphrasechange\", \"params\": [\"old one\", \"new one\"] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ]
+    },
+    {
+        "name": "walletprocesspsbt",
+        "namespace": "Wallet",
+        "description": "Update a PSBT with input information from our wallet and then sign inputs that we can sign for.",
+        "arguments": [
+            {
+                "name": "psbt",
+                "type": "string",
+                "description": "The transaction base64 string",
+                "is_required": true
+            },
+            {
+                "name": "sign",
+                "type": "boolean",
+                "description": "Also sign the transaction when updating",
+                "is_required": false
+            },
+            {
+                "name": "sighashtype",
+                "type": "string",
+                "description": "The signature hash type to sign with if not specified by the PSBT. Must be one of \"ALL\" \"NONE\" \"SINGLE\" \"ALL|ANYONECANPAY\" \"NONE|ANYONECANPAY\" \"SINGLE|ANYONECANPAY\"",
+                "is_required": false
+            },
+            {
+                "name": "bip32derivs",
+                "type": "boolean",
+                "description": "If true, includes the BIP 32 derivation paths for public keys if we know them",
+                "is_required": false
+            }
+        ],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli walletprocesspsbt \"psbt\""
+            }
+        ],
+        "returns": "{\n  \"psbt\" : \"value\",          (string) The base64-encoded partially signed transaction\n  \"complete\" : true|false,   (boolean) If the transaction has a complete set of signatures\n  ]\n}"
+    },
+    {
+        "name": "getzmqnotifications",
+        "namespace": "Zmq",
+        "description": "Returns information about the active ZeroMQ notifications.",
+        "arguments": [],
+        "examples": [
+            {
+                "cli": "> lbrycrd-cli getzmqnotifications",
+                "curl": "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"getzmqnotifications\", \"params\": [] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/"
+            }
+        ],
+        "returns": "[\n  {                        (json object)\n    \"type\": \"pubhashtx\",   (string) Type of notification\n    \"address\": \"...\"       (string) Address of the publisher\n  },\n  ...\n]"
     }
 ]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -149,6 +149,7 @@ BITCOIN_CORE_H = \
   policy/policy.h \
   policy/rbf.h \
   pow.h \
+  prefixtrie.h \
   protocol.h \
   random.h \
   reverse_iterator.h \
@@ -249,6 +250,7 @@ libbitcoin_server_a_SOURCES = \
   policy/policy.cpp \
   policy/rbf.cpp \
   pow.cpp \
+  prefixtrie.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
   rpc/claimtrie.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -70,6 +70,7 @@ BITCOIN_TESTS =\
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
+  test/prefixtrie_tests.cpp \
   test/prevector_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
@@ -150,7 +151,6 @@ test_test_lbrycrd_fuzzy_LDADD = \
   $(LIBSECP256K1)
 
 test_test_lbrycrd_fuzzy_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS) $(ICU_LIBS)
-#
 
 nodist_test_test_lbrycrd_SOURCES = $(GENERATED_TEST_FILES)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,6 +143,8 @@ public:
         consensus.nAllowMinDiffMinHeight = -1;
         consensus.nAllowMinDiffMaxHeight = -1;
         consensus.nNormalizedNameForkHeight = 539940; // targeting 21 March 2019
+        consensus.nMinTakeoverWorkaroundHeight = 496850;
+        consensus.nMaxTakeoverWorkaroundHeight = 10000000;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
@@ -258,6 +260,8 @@ public:
         consensus.nAllowMinDiffMinHeight = 277299;
         consensus.nAllowMinDiffMaxHeight = 1100000;
         consensus.nNormalizedNameForkHeight = 993380;   // targeting, 21 Feb 2019
+        consensus.nMinTakeoverWorkaroundHeight = 99;
+        consensus.nMaxTakeoverWorkaroundHeight = 10000000;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
@@ -361,6 +365,8 @@ public:
         consensus.nAllowMinDiffMinHeight = -1;
         consensus.nAllowMinDiffMaxHeight = -1;
         consensus.nNormalizedNameForkHeight = 250; // SDK depends upon this number
+        consensus.nMinTakeoverWorkaroundHeight = -1;
+        consensus.nMaxTakeoverWorkaroundHeight = -1;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -2,20 +2,22 @@
 #define BITCOIN_CLAIMTRIE_H
 
 #include <amount.h>
+#include <chain.h>
+#include <chainparams.h>
+#include <dbwrapper.h>
+#include <prefixtrie.h>
+#include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
 #include <util.h>
-#include <dbwrapper.h>
-#include <chainparams.h>
-#include <primitives/transaction.h>
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
+#include <unordered_map>
+#include <unordered_set>
 
 // leveldb keys
-#define HASH_BLOCK 'h'
-#define CURRENT_HEIGHT 't'
 #define TRIE_NODE 'n'
 #define CLAIM_BY_ID 'i'
 #define CLAIM_QUEUE_ROW 'r'
@@ -26,11 +28,10 @@
 #define SUPPORT_QUEUE_NAME_ROW 'p'
 #define SUPPORT_EXP_QUEUE_ROW 'x'
 
-uint256 getValueHash(COutPoint outPoint, int nHeightOfLastTakeover);
+uint256 getValueHash(const COutPoint& outPoint, int nHeightOfLastTakeover);
 
-class CClaimValue
+struct CClaimValue
 {
-public:
     COutPoint outPoint;
     uint160 claimId;
     CAmount nAmount;
@@ -38,14 +39,14 @@ public:
     int nHeight;
     int nValidAtHeight;
 
-    CClaimValue() {};
+    CClaimValue()
+    {
+    }
 
-    CClaimValue(COutPoint outPoint, uint160 claimId, CAmount nAmount, int nHeight,
-                int nValidAtHeight)
-                : outPoint(outPoint), claimId(claimId)
-                , nAmount(nAmount), nEffectiveAmount(nAmount)
-                , nHeight(nHeight), nValidAtHeight(nValidAtHeight)
-    {}
+    CClaimValue(const COutPoint& outPoint, const uint160& claimId, CAmount nAmount, int nHeight, int nValidAtHeight)
+        : outPoint(outPoint), claimId(claimId), nAmount(nAmount), nEffectiveAmount(nAmount), nHeight(nHeight), nValidAtHeight(nValidAtHeight)
+    {
+    }
 
     CClaimValue(CClaimValue&&) = default;
     CClaimValue(const CClaimValue&) = default;
@@ -55,7 +56,8 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(outPoint);
         READWRITE(claimId);
         READWRITE(nAmount);
@@ -67,17 +69,13 @@ public:
     {
         if (nEffectiveAmount < other.nEffectiveAmount)
             return true;
-        else if (nEffectiveAmount == other.nEffectiveAmount)
-        {
-            if (nHeight > other.nHeight)
-                return true;
-            else if (nHeight == other.nHeight)
-            {
-                if (outPoint != other.outPoint && !(outPoint < other.outPoint))
-                    return true;
-            }
-        }
-        return false;
+        if (nEffectiveAmount != other.nEffectiveAmount)
+            return false;
+        if (nHeight > other.nHeight)
+            return true;
+        if (nHeight != other.nHeight)
+            return false;
+        return outPoint != other.outPoint && !(outPoint < other.outPoint);
     }
 
     bool operator==(const CClaimValue& other) const
@@ -91,22 +89,22 @@ public:
     }
 };
 
-class CSupportValue
+struct CSupportValue
 {
-public:
     COutPoint outPoint;
     uint160 supportedClaimId;
     CAmount nAmount;
     int nHeight;
     int nValidAtHeight;
 
-    CSupportValue() {};
-    CSupportValue(COutPoint outPoint, uint160 supportedClaimId,
-                  CAmount nAmount, int nHeight, int nValidAtHeight)
-                  : outPoint(outPoint), supportedClaimId(supportedClaimId)
-                  , nAmount(nAmount), nHeight(nHeight)
-                  , nValidAtHeight(nValidAtHeight)
-    {}
+    CSupportValue()
+    {
+    }
+
+    CSupportValue(const COutPoint& outPoint, const uint160& supportedClaimId, CAmount nAmount, int nHeight, int nValidAtHeight)
+        : outPoint(outPoint), supportedClaimId(supportedClaimId), nAmount(nAmount), nHeight(nHeight), nValidAtHeight(nValidAtHeight)
+    {
+    }
 
     CSupportValue(CSupportValue&&) = default;
     CSupportValue(const CSupportValue&) = default;
@@ -116,7 +114,8 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(outPoint);
         READWRITE(supportedClaimId);
         READWRITE(nAmount);
@@ -135,90 +134,77 @@ public:
     }
 };
 
-class CClaimTrieNode;
-class CClaimTrie;
+typedef std::vector<CClaimValue> claimEntryType;
+typedef std::vector<CSupportValue> supportEntryType;
 
-typedef std::vector<CSupportValue> supportMapEntryType;
-typedef std::map<unsigned char, CClaimTrieNode*> nodeMapType;
-
-class CClaimTrieNode
+struct CClaimTrieData
 {
-public:
-    CClaimTrieNode() : nHeightOfLastTakeover(0) {}
-    CClaimTrieNode(uint256 hash) : hash(hash), nHeightOfLastTakeover(0) {}
-    CClaimTrieNode(const CClaimTrieNode&) = default;
-    CClaimTrieNode(CClaimTrieNode&& other)
-    {
-        hash = std::move(other.hash);
-        claims = std::move(other.claims);
-        children = std::move(other.children);
-        nHeightOfLastTakeover = other.nHeightOfLastTakeover;
-    }
-
-    CClaimTrieNode& operator=(const CClaimTrieNode&) = default;
-    CClaimTrieNode& operator=(CClaimTrieNode&& other)
-    {
-        if (this != &other)
-        {
-            hash = std::move(other.hash);
-            claims = std::move(other.claims);
-            children = std::move(other.children);
-            nHeightOfLastTakeover = other.nHeightOfLastTakeover;
-        }
-        return *this;
-    }
-
     uint256 hash;
-    nodeMapType children;
-    int nHeightOfLastTakeover;
-    std::vector<CClaimValue> claims;
+    claimEntryType claims;
+    int nHeightOfLastTakeover = 0;
 
-    bool insertClaim(CClaimValue claim);
+    CClaimTrieData() = default;
+    CClaimTrieData(CClaimTrieData&&) = default;
+    CClaimTrieData(const CClaimTrieData&) = default;
+    CClaimTrieData& operator=(CClaimTrieData&&) = default;
+    CClaimTrieData& operator=(const CClaimTrieData& d) = default;
+
+    bool insertClaim(const CClaimValue& claim);
     bool removeClaim(const COutPoint& outPoint, CClaimValue& claim);
     bool getBestClaim(CClaimValue& claim) const;
-    bool empty() const {return children.empty() && claims.empty();}
     bool haveClaim(const COutPoint& outPoint) const;
-    void reorderClaims(supportMapEntryType& supports);
+    void reorderClaims(const supportEntryType& support);
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(hash);
+
+        if (ser_action.ForRead()) {
+            if (s.eof()) {
+                claims.clear();
+                nHeightOfLastTakeover = 0;
+                return;
+            }
+        }
+        else if (claims.empty())
+            return;
+
         READWRITE(claims);
         READWRITE(nHeightOfLastTakeover);
     }
 
-    bool operator==(const CClaimTrieNode& other) const
+    bool operator==(const CClaimTrieData& other) const
     {
-        return hash == other.hash && claims == other.claims;
+        return hash == other.hash && nHeightOfLastTakeover == other.nHeightOfLastTakeover && claims == other.claims;
     }
 
-    bool operator!=(const CClaimTrieNode& other) const
+    bool operator!=(const CClaimTrieData& other) const
     {
         return !(*this == other);
     }
-};
 
-struct nodenamecompare
-{
-    bool operator() (const std::string& i, const std::string& j) const
+    bool empty() const
     {
-        if (i.size() == j.size())
-            return i < j;
-        return i.size() < j.size();
+        return claims.empty();
     }
 };
 
-struct outPointHeightType
+struct COutPointHeightType
 {
     COutPoint outPoint;
     int nHeight;
 
-    outPointHeightType() {}
+    COutPointHeightType()
+    {
+    }
 
-    outPointHeightType(COutPoint outPoint, int nHeight)
-    : outPoint(outPoint), nHeight(nHeight) {}
+    COutPointHeightType(const COutPoint& outPoint, int nHeight)
+        : outPoint(outPoint), nHeight(nHeight)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
@@ -228,19 +214,22 @@ struct outPointHeightType
         READWRITE(outPoint);
         READWRITE(nHeight);
     }
-
 };
 
-struct nameOutPointHeightType
+struct CNameOutPointHeightType
 {
     std::string name;
     COutPoint outPoint;
     int nHeight;
 
-    nameOutPointHeightType() {}
+    CNameOutPointHeightType()
+    {
+    }
 
-    nameOutPointHeightType(std::string name, COutPoint outPoint, int nHeight)
-    : name(std::move(name)), outPoint(outPoint), nHeight(nHeight) {}
+    CNameOutPointHeightType(std::string name, const COutPoint& outPoint, int nHeight)
+        : name(std::move(name)), outPoint(outPoint), nHeight(nHeight)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
@@ -253,15 +242,19 @@ struct nameOutPointHeightType
     }
 };
 
-struct nameOutPointType
+struct CNameOutPointType
 {
     std::string name;
     COutPoint outPoint;
 
-    nameOutPointType() {}
+    CNameOutPointType()
+    {
+    }
 
-    nameOutPointType(std::string name, COutPoint outPoint)
-    : name(std::move(name)), outPoint(outPoint) {}
+    CNameOutPointType(std::string name, const COutPoint& outPoint)
+        : name(std::move(name)), outPoint(outPoint)
+    {
+    }
 
     ADD_SERIALIZE_METHODS;
 
@@ -273,13 +266,13 @@ struct nameOutPointType
     }
 };
 
-class CClaimIndexElement
+struct CClaimIndexElement
 {
-  public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(name);
         READWRITE(claim);
     }
@@ -288,231 +281,62 @@ class CClaimIndexElement
     CClaimValue claim;
 };
 
-typedef std::pair<std::string, CClaimValue> claimQueueEntryType;
-
-typedef std::pair<std::string, CSupportValue> supportQueueEntryType;
-
-typedef std::map<std::string, supportMapEntryType> supportMapType;
-
-typedef std::vector<outPointHeightType> queueNameRowType;
-typedef std::map<std::string, queueNameRowType> queueNameType;
-
-typedef std::vector<nameOutPointHeightType> insertUndoType;
-
-typedef std::vector<nameOutPointType> expirationQueueRowType;
-typedef std::map<int, expirationQueueRowType> expirationQueueType;
-
-typedef std::vector<claimQueueEntryType> claimQueueRowType;
-typedef std::map<int, claimQueueRowType> claimQueueType;
-
-typedef std::vector<supportQueueEntryType> supportQueueRowType;
-typedef std::map<int, supportQueueRowType> supportQueueType;
-
-typedef std::map<std::string, CClaimTrieNode*, nodenamecompare> nodeCacheType;
-
-typedef std::map<std::string, uint256> hashMapType;
-
-typedef std::set<CClaimValue> claimIndexClaimListType;
-typedef std::vector<CClaimIndexElement> claimIndexElementListType;
-
-struct claimsForNameType
+struct CClaimsForNameType
 {
-    std::vector<CClaimValue> claims;
-    std::vector<CSupportValue> supports;
+    claimEntryType claims;
+    supportEntryType supports;
     int nLastTakeoverHeight;
     std::string name;
 
-    claimsForNameType(std::vector<CClaimValue> claims, std::vector<CSupportValue> supports,
-                      int nLastTakeoverHeight, const std::string& name)
-    : claims(std::move(claims)), supports(std::move(supports)),
-        nLastTakeoverHeight(nLastTakeoverHeight), name(name) {}
-
-    claimsForNameType(const claimsForNameType&) = default;
-    claimsForNameType(claimsForNameType&& other)
+    CClaimsForNameType(claimEntryType claims, supportEntryType supports, int nLastTakeoverHeight, const std::string& name)
+        : claims(std::move(claims)), supports(std::move(supports)), nLastTakeoverHeight(nLastTakeoverHeight), name(name)
     {
-        claims = std::move(other.claims);
-        supports = std::move(other.supports);
-        name = std::move(other.name);
-        nLastTakeoverHeight = other.nLastTakeoverHeight;
     }
 
-    claimsForNameType& operator=(const claimsForNameType&) = default;
-    claimsForNameType& operator=(claimsForNameType&& other)
-    {
-        if (this != &other)
-        {
-            claims = std::move(other.claims);
-            supports = std::move(other.supports);
-            name = std::move(other.name);
-            nLastTakeoverHeight = other.nLastTakeoverHeight;
-        }
-        return *this;
-    }
-
-    virtual ~claimsForNameType() {}
+    CClaimsForNameType(CClaimsForNameType&&) = default;
+    CClaimsForNameType(const CClaimsForNameType&) = default;
+    CClaimsForNameType& operator=(CClaimsForNameType&&) = default;
+    CClaimsForNameType& operator=(const CClaimsForNameType&) = default;
 };
 
-class CClaimTrieCacheBase;
-class CClaimTrieCacheExpirationFork;
-
-class CClaimTrie
+class CClaimTrie : public CPrefixTrie<std::string, CClaimTrieData>
 {
+    int nNextHeight = 0;
+    int nExpirationTime = 0;
+    int nProportionalDelayFactor = 0;
+    std::unique_ptr<CDBWrapper> db;
+
 public:
-    CClaimTrie(bool fMemory = false, bool fWipe = false, int nProportionalDelayFactor = 32)
-               : db(GetDataDir() / "claimtrie", 20 * 1024 * 1024, fMemory, fWipe, false)
-               , nCurrentHeight(0), nExpirationTime(Params().GetConsensus().nOriginalClaimExpirationTime)
-               , nProportionalDelayFactor(nProportionalDelayFactor)
-               , root(uint256S("0000000000000000000000000000000000000000000000000000000000000001"))
-    {}
+    CClaimTrie() = default;
+    CClaimTrie(CClaimTrie&&) = delete;
+    CClaimTrie(const CClaimTrie&) = delete;
+    CClaimTrie(bool fMemory, bool fWipe, int proportionalDelayFactor = 32);
 
-    uint256 getMerkleHash();
+    CClaimTrie& operator=(CClaimTrie&&) = delete;
+    CClaimTrie& operator=(const CClaimTrie&) = delete;
 
-    bool empty() const;
-    void clear();
-
-    bool checkConsistency() const;
-
-    bool WriteToDisk();
-    bool ReadFromDisk(bool check = false);
-
-    bool getInfoForName(const std::string& name, CClaimValue& claim) const;
-    bool getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const;
-
-    std::vector<CClaimValue> getClaimsForName(const std::string& name) const;
-
-    bool queueEmpty() const;
-    bool supportEmpty() const;
-    bool supportQueueEmpty() const;
-    bool expirationQueueEmpty() const;
-
-    void setExpirationTime(int t);
-
-    void addToClaimIndex(const std::string& name, const CClaimValue& claim);
-    void removeFromClaimIndex(const CClaimValue& claim);
-
-    bool getClaimById(const uint160 claimId, std::string& name, CClaimValue& claim) const;
-
-    bool haveClaim(const std::string& name, const COutPoint& outPoint) const;
-    bool haveClaimInQueue(const std::string& name, const COutPoint& outPoint,
-                          int& nValidAtHeight) const;
-
-    bool haveSupport(const std::string& name, const COutPoint& outPoint) const;
-    bool haveSupportInQueue(const std::string& name, const COutPoint& outPoint,
-                            int& nValidAtHeight) const;
-
-    unsigned int getTotalNamesInTrie() const;
-    unsigned int getTotalClaimsInTrie() const;
-    CAmount getTotalValueOfClaimsInTrie(bool fControllingOnly) const;
+    bool SyncToDisk();
 
     friend class CClaimTrieCacheBase;
+    friend class ClaimTrieChainFixture;
     friend class CClaimTrieCacheExpirationFork;
-
-    CDBWrapper db;
-    int nCurrentHeight;
-    int nExpirationTime;
-    int nProportionalDelayFactor;
-
-private:
-    void clear(CClaimTrieNode* current);
-
-    const CClaimTrieNode* getNodeForName(const std::string& name) const;
-
-    bool update(nodeCacheType& cache, hashMapType& hashes,
-                std::map<std::string, int>& takeoverHeights,
-                const uint256& hashBlock, claimQueueType& queueCache,
-                queueNameType& queueNameCache,
-                expirationQueueType& expirationQueueCache, int nNewHeight,
-                supportMapType& supportCache,
-                supportQueueType& supportQueueCache,
-                queueNameType& supportQueueNameCache,
-                expirationQueueType& supportExpirationQueueCache);
-    bool updateName(const std::string& name, CClaimTrieNode* updatedNode);
-    bool updateHash(const std::string& name, uint256& hash);
-    bool updateTakeoverHeight(const std::string& name, int nTakeoverHeight);
-    bool recursiveNullify(CClaimTrieNode* node, const std::string& name);
-
-    bool recursiveCheckConsistency(const CClaimTrieNode* node) const;
-
-    bool InsertFromDisk(const std::string& name, CClaimTrieNode* node);
-
-    unsigned int getTotalNamesRecursive(const CClaimTrieNode* current) const;
-    unsigned int getTotalClaimsRecursive(const CClaimTrieNode* current) const;
-    CAmount getTotalValueOfClaimsRecursive(const CClaimTrieNode* current,
-                                           bool fControllingOnly) const;
-
-    bool getQueueRow(int nHeight, claimQueueRowType& row) const;
-    bool getQueueNameRow(const std::string& name, queueNameRowType& row) const;
-    bool getExpirationQueueRow(int nHeight, expirationQueueRowType& row) const;
-    bool getSupportNode(std::string name, supportMapEntryType& node) const;
-    bool getSupportQueueRow(int nHeight, supportQueueRowType& row) const;
-    bool getSupportQueueNameRow(const std::string& name, queueNameRowType& row) const;
-    bool getSupportExpirationQueueRow(int nHeight, expirationQueueRowType& row) const;
-
-    void markNodeDirty(const std::string& name, CClaimTrieNode* node);
-    void updateQueueRow(int nHeight, claimQueueRowType& row);
-    void updateQueueNameRow(const std::string& name,
-                            queueNameRowType& row);
-    void updateExpirationRow(int nHeight, expirationQueueRowType& row);
-    void updateSupportMap(const std::string& name, supportMapEntryType& node);
-    void updateSupportQueue(int nHeight, supportQueueRowType& row);
-    void updateSupportNameQueue(const std::string& name,
-                                queueNameRowType& row);
-    void updateSupportExpirationQueue(int nHeight, expirationQueueRowType& row);
-
-    void BatchWriteNode(CDBBatch& batch, const std::string& name,
-                        const CClaimTrieNode* pNode) const;
-    void BatchWriteQueueRows(CDBBatch& batch);
-    void BatchWriteQueueNameRows(CDBBatch& batch);
-    void BatchWriteExpirationQueueRows(CDBBatch& batch);
-    void BatchWriteSupportNodes(CDBBatch& batch);
-    void BatchWriteSupportQueueRows(CDBBatch& batch);
-    void BatchWriteSupportQueueNameRows(CDBBatch& batch);
-    void BatchWriteSupportExpirationQueueRows(CDBBatch& batch);
-    template<typename K> bool keyTypeEmpty(char key, K& dummy) const;
-
-    CClaimTrieNode root;
-    uint256 hashBlock;
-
-    claimQueueType dirtyQueueRows;
-    queueNameType dirtyQueueNameRows;
-    expirationQueueType dirtyExpirationQueueRows;
-
-    supportQueueType dirtySupportQueueRows;
-    queueNameType dirtySupportQueueNameRows;
-    expirationQueueType dirtySupportExpirationQueueRows;
-
-    nodeCacheType dirtyNodes;
-    supportMapType dirtySupportNodes;
+    friend class CClaimTrieCacheNormalizationFork;
 };
 
 class CClaimTrieProofNode
 {
 public:
-    CClaimTrieProofNode() {};
-    CClaimTrieProofNode(std::vector<std::pair<unsigned char, uint256> > children,
-                        bool hasValue, uint256 valHash)
-        : children(std::move(children)), hasValue(hasValue), valHash(std::move(valHash))
-        {};
-    CClaimTrieProofNode(const CClaimTrieProofNode&) = default;
-    CClaimTrieProofNode(CClaimTrieProofNode&& other)
+    CClaimTrieProofNode(std::vector<std::pair<unsigned char, uint256>> children, bool hasValue, const uint256& valHash)
+        : children(std::move(children)), hasValue(hasValue), valHash(valHash)
     {
-        hasValue = other.hasValue;
-        valHash = std::move(other.valHash);
-        children = std::move(other.children);
-    }
-    CClaimTrieProofNode& operator=(const CClaimTrieProofNode&) = default;
-    CClaimTrieProofNode& operator=(CClaimTrieProofNode&& other)
-    {
-        if (this != &other)
-        {
-            hasValue = other.hasValue;
-            valHash = std::move(other.valHash);
-            children = std::move(other.children);
-        }
-        return *this;
     }
 
-    std::vector<std::pair<unsigned char, uint256> > children;
+    CClaimTrieProofNode(CClaimTrieProofNode&&) = default;
+    CClaimTrieProofNode(const CClaimTrieProofNode&) = default;
+    CClaimTrieProofNode& operator=(CClaimTrieProofNode&&) = default;
+    CClaimTrieProofNode& operator=(const CClaimTrieProofNode&) = default;
+
+    std::vector<std::pair<unsigned char, uint256>> children;
     bool hasValue;
     uint256 valHash;
 };
@@ -520,29 +344,19 @@ public:
 class CClaimTrieProof
 {
 public:
-    CClaimTrieProof() {};
-    CClaimTrieProof(std::vector<CClaimTrieProofNode> nodes, bool hasValue, COutPoint outPoint, int nHeightOfLastTakeover) : nodes(std::move(nodes)), hasValue(hasValue), outPoint(outPoint), nHeightOfLastTakeover(nHeightOfLastTakeover) {}
-    CClaimTrieProof(const CClaimTrieProof&) = default;
-    CClaimTrieProof(CClaimTrieProof&& other)
+    CClaimTrieProof()
     {
-        hasValue = other.hasValue;
-        outPoint = std::move(other.outPoint);
-        nodes = std::move(other.nodes);
-        nHeightOfLastTakeover = other.nHeightOfLastTakeover;
     }
 
-    CClaimTrieProof& operator=(const CClaimTrieProof&) = default;
-    CClaimTrieProof& operator=(CClaimTrieProof&& other)
+    CClaimTrieProof(std::vector<CClaimTrieProofNode> nodes, bool hasValue, const COutPoint& outPoint, int nHeightOfLastTakeover)
+        : nodes(std::move(nodes)), hasValue(hasValue), outPoint(outPoint), nHeightOfLastTakeover(nHeightOfLastTakeover)
     {
-        if (this != &other)
-        {
-            hasValue = other.hasValue;
-            outPoint = std::move(other.outPoint);
-            nodes = std::move(other.nodes);
-            nHeightOfLastTakeover = other.nHeightOfLastTakeover;
-        }
-        return *this;
     }
+
+    CClaimTrieProof(CClaimTrieProof&&) = default;
+    CClaimTrieProof(const CClaimTrieProof&) = default;
+    CClaimTrieProof& operator=(CClaimTrieProof&&) = default;
+    CClaimTrieProof& operator=(const CClaimTrieProof&) = default;
 
     std::vector<CClaimTrieProofNode> nodes;
     bool hasValue;
@@ -550,234 +364,202 @@ public:
     int nHeightOfLastTakeover;
 };
 
-struct CNodeCallback {
-    struct CRecursionInterruptionException : public std::exception {
-        const bool success;
-        explicit CRecursionInterruptionException(bool success) : success(success) {}
-    };
+typedef std::pair<std::string, CClaimValue> claimQueueEntryType;
+typedef std::vector<claimQueueEntryType> claimQueueRowType;
+typedef std::map<int, claimQueueRowType> claimQueueType;
 
-    virtual ~CNodeCallback()
-    {
-    }
+typedef std::pair<std::string, CSupportValue> supportQueueEntryType;
+typedef std::vector<supportQueueEntryType> supportQueueRowType;
+typedef std::map<int, supportQueueRowType> supportQueueType;
 
-    /**
-     * Callback to be called on every trie node
-     * @param[in] name      full name of the node
-     * @param[in] node      pointer to node itself
-     *
-     * To breakout early throw an exception.
-     * Throwing CRecursionInterruptionException will allow you to set the return value of iterateTrie.
-     */
-    virtual void visit(const std::string& name, const CClaimTrieNode* node) = 0;
-};
+typedef std::vector<COutPointHeightType> queueNameRowType;
+typedef std::map<std::string, queueNameRowType> queueNameType;
+
+typedef std::vector<CNameOutPointHeightType> insertUndoType;
+
+typedef std::vector<CNameOutPointType> expirationQueueRowType;
+typedef std::map<int, expirationQueueRowType> expirationQueueType;
+
+typedef std::set<CClaimValue> claimIndexClaimListType;
+typedef std::vector<CClaimIndexElement> claimIndexElementListType;
 
 class CClaimTrieCacheBase
 {
 public:
-    CClaimTrieCacheBase(CClaimTrie* base, bool fRequireTakeoverHeights = true)
-      : base(base), fRequireTakeoverHeights(fRequireTakeoverHeights)
-    {
-        assert(base);
-        nCurrentHeight = base->nCurrentHeight;
-    }
+    explicit CClaimTrieCacheBase(CClaimTrie* base, bool fRequireTakeoverHeights = true);
+    virtual ~CClaimTrieCacheBase() = default;
 
-    uint256 getMerkleHash(bool forceCompute = false) const;
+    uint256 getMerkleHash();
+    bool checkConsistency(int minimumHeight = 1) const;
 
-    bool empty() const;
+    bool getClaimById(const uint160& claimId, std::string& name, CClaimValue& claim) const;
+
     bool flush();
-    bool dirty() const { return !dirtyHashes.empty(); }
+    bool empty() const;
+    bool ReadFromDisk(const CBlockIndex* tip);
 
-    CClaimTrieNode* getRoot() const
-    {
-        const auto iter = cache.find("");
-        return iter == cache.end() ? &(base->root) : iter->second;
-    }
+    bool haveClaim(const std::string& name, const COutPoint& outPoint) const;
+    bool haveClaimInQueue(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight);
 
-    bool addClaim(const std::string& name, const COutPoint& outPoint,
-                  uint160 claimId, CAmount nAmount, int nHeight) const;
-    bool undoAddClaim(const std::string& name, const COutPoint& outPoint, int nHeight) const;
-    bool spendClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight) const;
-    bool undoSpendClaim(const std::string& name, const COutPoint& outPoint,
-                        uint160 claimId, CAmount nAmount, int nHeight,
-                        int nValidAtHeight) const;
+    bool haveSupport(const std::string& name, const COutPoint& outPoint) const;
+    bool haveSupportInQueue(const std::string& name, const COutPoint& outPoint, int& nValidAtHeight);
 
-    bool addSupport(const std::string& name, const COutPoint& outPoint,
-                    CAmount nAmount, uint160 supportedClaimId,
-                    int nHeight) const;
-    bool undoAddSupport(const std::string& name, const COutPoint& outPoint,
-                        int nHeight) const;
-    bool spendSupport(const std::string& name, const COutPoint& outPoint,
-                      int nHeight, int& nValidAtHeight) const;
-    bool undoSpendSupport(const std::string& name, const COutPoint& outPoint,
-                          uint160 supportedClaimId, CAmount nAmount,
-                          int nHeight, int nValidAtHeight) const;
+    std::size_t getTotalNamesInTrie() const;
+    std::size_t getTotalClaimsInTrie() const;
+    CAmount getTotalValueOfClaimsInTrie(bool fControllingOnly) const;
 
-    uint256 getBestBlock();
-    void setBestBlock(const uint256& hashBlock);
+    bool addClaim(const std::string& name, const COutPoint& outPoint, const uint160& claimId, CAmount nAmount, int nHeight);
+    bool undoAddClaim(const std::string& name, const COutPoint& outPoint, int nHeight);
+
+    bool spendClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight);
+    bool undoSpendClaim(const std::string& name, const COutPoint& outPoint, const uint160& claimId, CAmount nAmount, int nHeight, int nValidAtHeight);
+
+    bool addSupport(const std::string& name, const COutPoint& outPoint, CAmount nAmount, const uint160& supportedClaimId, int nHeight);
+    bool undoAddSupport(const std::string& name, const COutPoint& outPoint, int nHeight);
+
+    bool spendSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight);
+    bool undoSpendSupport(const std::string& name, const COutPoint& outPoint, const uint160& supportedClaimId, CAmount nAmount, int nHeight, int nValidAtHeight);
 
     virtual bool incrementBlock(insertUndoType& insertUndo,
-                                claimQueueRowType& expireUndo,
-                                insertUndoType& insertSupportUndo,
-                                supportQueueRowType& expireSupportUndo,
-                                std::vector<std::pair<std::string, int> >& takeoverHeightUndo);
+        claimQueueRowType& expireUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo,
+        std::vector<std::pair<std::string, int>>& takeoverHeightUndo);
+
     virtual bool decrementBlock(insertUndoType& insertUndo,
-                                claimQueueRowType& expireUndo,
-                                insertUndoType& insertSupportUndo,
-                                supportQueueRowType& expireSupportUndo,
-                                std::vector<std::pair<std::string, int> >& takeoverHeightUndo);
+        claimQueueRowType& expireUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo);
 
-    virtual ~CClaimTrieCacheBase() { clear(); }
-
-    virtual bool getProofForName(const std::string& name, CClaimTrieProof& proof) const;
+    virtual bool getProofForName(const std::string& name, CClaimTrieProof& proof);
     virtual bool getInfoForName(const std::string& name, CClaimValue& claim) const;
 
-    bool finalizeDecrement() const;
+    bool finalizeDecrement(std::vector<std::pair<std::string, int>>& takeoverHeightUndo);
 
-    bool iterateTrie(CNodeCallback& callback) const;
+    virtual CClaimsForNameType getClaimsForName(const std::string& name) const;
 
-    virtual claimsForNameType getClaimsForName(const std::string& name) const;
+    CAmount getEffectiveAmountForClaim(const std::string& name, const uint160& claimId, std::vector<CSupportValue>* supports = nullptr) const;
+    CAmount getEffectiveAmountForClaim(const CClaimsForNameType& claims, const uint160& claimId, std::vector<CSupportValue>* supports = nullptr) const;
 
-    CAmount getEffectiveAmountForClaim(const std::string& name, const uint160& claimId,
-                                       std::vector<CSupportValue>* supports = nullptr) const;
-    CAmount getEffectiveAmountForClaim(const claimsForNameType& claims, const uint160& claimId,
-                                       std::vector<CSupportValue>* supports = nullptr) const;
+    void setExpirationTime(int time);
+    int expirationTime();
+
+    CClaimTrie::const_iterator begin() const;
+    CClaimTrie::const_iterator end() const;
+    CClaimTrie::const_iterator find(const std::string& name) const;
+
+    void dumpToLog(CClaimTrie::const_iterator it, bool diffFromBase = true) const;
 
 protected:
-    // Should be private: Do not use unless you know what you're doing.
-    CClaimTrieNode* addNodeToCache(const std::string& position, CClaimTrieNode* original) const;
-    bool recursiveComputeMerkleHash(CClaimTrieNode* tnCurrent,
-                                    const std::string& sPos,
-                                    bool forceCompute = false) const;
-    bool recursivePruneName(CClaimTrieNode* tnCurrent, unsigned int nPos, const std::string& sName, bool* pfNullified = nullptr) const;
-    void checkNamesForTakeover(insertUndoType& insertUndo, insertUndoType& insertSupportUndo,
-                               std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const;
+    CClaimTrie* base;
+    CClaimTrie cache;
+    std::unordered_set<std::string> namesToCheckForTakeover;
 
-    virtual bool insertClaimIntoTrie(const std::string& name, CClaimValue claim,
-                                     bool fCheckTakeover = false) const;
-    virtual bool removeClaimFromTrie(const std::string& name, const COutPoint& outPoint,
-                                     CClaimValue& claim,
-                                     bool fCheckTakeover = false) const;
+    uint256 recursiveComputeMerkleHash(CClaimTrie::iterator& it);
 
-    virtual bool insertSupportIntoMap(const std::string& name,
-                                      CSupportValue support,
-                                      bool fCheckTakeover) const;
-    virtual bool removeSupportFromMap(const std::string& name, const COutPoint& outPoint,
-                                      CSupportValue& support,
-                                      bool fCheckTakeover) const;
+    virtual bool insertClaimIntoTrie(const std::string& name, const CClaimValue& claim, bool fCheckTakeover);
+    virtual bool removeClaimFromTrie(const std::string& name, const COutPoint& outPoint, CClaimValue& claim, bool fCheckTakeover);
 
-    virtual void addClaimToQueues(const std::string& name, CClaimValue& claim) const;
-    virtual bool addSupportToQueues(const std::string& name, CSupportValue& support) const;
+    virtual bool insertSupportIntoMap(const std::string& name, const CSupportValue& support, bool fCheckTakeover);
+    virtual bool removeSupportFromMap(const std::string& name, const COutPoint& outPoint, CSupportValue& support, bool fCheckTakeover);
+
+    virtual bool addClaimToQueues(const std::string& name, const CClaimValue& claim);
+
+    virtual bool addSupportToQueues(const std::string& name, const CSupportValue& support);
+    virtual bool removeSupportFromQueue(const std::string& name, const COutPoint& outPoint, CSupportValue& support);
+
     virtual std::string adjustNameForValidHeight(const std::string& name, int validHeight) const;
 
-    void addToExpirationQueue(int nExpirationHeight, nameOutPointType& entry) const;
-    void removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint,
-                                   int nHeight) const;
+    void addToExpirationQueue(int nExpirationHeight, CNameOutPointType& entry);
+    void removeFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight);
 
-    void addSupportToExpirationQueue(int nExpirationHeight,
-                                     nameOutPointType& entry) const;
-    void removeSupportFromExpirationQueue(const std::string& name,
-                                          const COutPoint& outPoint,
-                                          int nHeight) const;
+    void addSupportToExpirationQueue(int nExpirationHeight, CNameOutPointType& entry);
+    void removeSupportFromExpirationQueue(const std::string& name, const COutPoint& outPoint, int nHeight);
 
-    bool getSupportsForName(const std::string& name,
-                            supportMapEntryType& supports) const;
+    supportEntryType getSupportsForName(const std::string& name) const;
 
-    virtual int getDelayForName(const std::string& name, const uint160& claimId) const;
+    int getDelayForName(const std::string& name);
+    virtual int getDelayForName(const std::string& name, const uint160& claimId);
 
-    mutable nodeCacheType cache;
-    CClaimTrie* base;
-    mutable int nCurrentHeight; // Height of the block that is being worked on, which is
-    // one greater than the height of the chain's tip
+    CClaimTrie::iterator cacheData(const std::string& name, bool create = true);
+
+    bool getLastTakeoverForName(const std::string& name, uint160& claimId, int& takeoverHeight) const;
+
+    int getNumBlocksOfContinuousOwnership(const std::string& name);
+
+    expirationQueueType expirationQueueCache;
+    expirationQueueType supportExpirationQueueCache;
+
+    int nNextHeight; // Height of the block that is being worked on, which is
+                     // one greater than the height of the chain's tip
 
 private:
+    uint256 hashBlock;
+
+    std::unordered_map<std::string, std::pair<uint160, int>> takeoverCache;
 
     bool fRequireTakeoverHeights;
 
-    mutable nodeCacheType block_originals;
-    mutable std::set<std::string> dirtyHashes;
-    mutable hashMapType cacheHashes;
-    mutable claimQueueType claimQueueCache;
-    mutable queueNameType claimQueueNameCache;
-    mutable expirationQueueType expirationQueueCache;
-    mutable supportMapType supportCache;
-    mutable supportQueueType supportQueueCache;
-    mutable queueNameType supportQueueNameCache;
-    mutable expirationQueueType supportExpirationQueueCache;
-    mutable std::set<std::string> namesToCheckForTakeover;
-    mutable std::map<std::string, int> cacheTakeoverHeights;
-    mutable claimIndexElementListType claimsToAdd;
-    mutable claimIndexClaimListType claimsToDelete;
+    claimQueueType claimQueueCache;
+    queueNameType claimQueueNameCache;
+    supportQueueType supportQueueCache;
+    queueNameType supportQueueNameCache;
+    claimIndexElementListType claimsToAdd;
+    claimIndexClaimListType claimsToDelete;
 
-    uint256 hashBlock;
+    std::unordered_map<std::string, supportEntryType> cacheSupports;
+    std::unordered_set<std::string> nodesToDelete;
+    std::unordered_set<std::string> alreadyCachedNodes;
+    std::unordered_map<std::string, bool> takeoverWorkaround;
+    std::unordered_set<std::string> removalWorkaround;
 
-    bool reorderTrieNode(const std::string& name, bool fCheckTakeover) const;
+    bool shouldUseTakeoverWorkaround(const std::string& key) const;
+    void addTakeoverWorkaroundPotential(const std::string& key);
+    void confirmTakeoverWorkaroundNeeded(const std::string& key);
 
-    bool clear() const;
+    bool clear();
 
-    // generally the opposite of addClaimToQueues, but they aren't perfectly symmetrical:
-    bool removeClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover) const;
-    bool removeClaimFromQueue(const std::string& name, const COutPoint& outPoint,
-                              CClaimValue& claim) const;
+    void markAsDirty(const std::string& name, bool fCheckTakeover);
+    bool removeSupport(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover);
+    bool removeClaim(const std::string& name, const COutPoint& outPoint, int nHeight, int& nValidAtHeight, bool fCheckTakeover);
+    bool removeClaimFromQueue(const std::string& name, const COutPoint& outPoint, CClaimValue& claim);
 
-    claimQueueType::iterator getQueueCacheRow(int nHeight,
-                                              bool createIfNotExists) const;
-    queueNameType::iterator getQueueCacheNameRow(const std::string& name,
-                                                 bool createIfNotExists) const;
-    expirationQueueType::iterator getExpirationQueueCacheRow(int nHeight,
-                                                             bool createIfNotExists) const;
+    typename claimQueueType::value_type* getQueueCacheRow(int nHeight, bool createIfNotExists = false);
+    typename queueNameType::value_type* getQueueCacheNameRow(const std::string& name, bool createIfNotExists = false);
+    typename expirationQueueType::value_type* getExpirationQueueCacheRow(int nHeight, bool createIfNotExists = false);
+    typename supportQueueType::value_type* getSupportQueueCacheRow(int nHeight, bool createIfNotExists = false);
+    typename queueNameType::value_type* getSupportQueueCacheNameRow(const std::string& name, bool createIfNotExists = false);
+    typename expirationQueueType::value_type* getSupportExpirationQueueCacheRow(int nHeight, bool createIfNotExists = false);
 
-    bool removeSupport(const std::string& name, const COutPoint& outPoint,
-                       int nHeight, int& nValidAtHeight,
-                       bool fCheckTakeover) const;
-
-    supportQueueType::iterator getSupportQueueCacheRow(int nHeight,
-                                                       bool createIfNotExists) const;
-    queueNameType::iterator getSupportQueueCacheNameRow(const std::string& name,
-                                                        bool createIfNotExists) const;
-    expirationQueueType::iterator getSupportExpirationQueueCacheRow(int nHeight,
-                                                                    bool createIfNotExists) const;
-
-    bool removeSupportFromQueue(const std::string& name, const COutPoint& outPoint,
-                                CSupportValue& support) const;
-
-    bool getLastTakeoverForName(const std::string& name, int& lastTakeoverHeight) const;
-
-    int getDelayForName(const std::string& name) const;
-
-    uint256 getLeafHashForProof(const std::string& currentPosition, const CClaimTrieNode* currentNode) const;
-
-    bool getOriginalInfoForName(const std::string& name, CClaimValue& claim) const;
-
-    int getNumBlocksOfContinuousOwnership(const std::string& name) const;
-
-    void recursiveIterateTrie(std::string& name, const CClaimTrieNode* current, CNodeCallback& callback) const;
-
-    const CClaimTrieNode* getNodeForName(const std::string& name) const;
+    // for unit test
+    friend class ClaimTrieChainFixture;
+    friend class CClaimTrieCacheTest;
 };
 
-class CClaimTrieCacheExpirationFork: public CClaimTrieCacheBase {
-  public:
-    CClaimTrieCacheExpirationFork(CClaimTrie* base, bool fRequireTakeoverHeights = true)
-        : CClaimTrieCacheBase(base, fRequireTakeoverHeights) {}
+class CClaimTrieCacheExpirationFork : public CClaimTrieCacheBase
+{
+public:
+    explicit CClaimTrieCacheExpirationFork(CClaimTrie* base, bool fRequireTakeoverHeights = true)
+        : CClaimTrieCacheBase(base, fRequireTakeoverHeights)
+    {
+    }
 
-    virtual ~CClaimTrieCacheExpirationFork() {}
-
-    bool forkForExpirationChange(bool increment) const;
+    bool forkForExpirationChange(bool increment);
 
     // TODO: move the expiration fork code from main.cpp to overrides of increment/decrement block
 
 private:
-    void removeAndAddSupportToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const;
-    void removeAndAddToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const;
+    void removeAndAddSupportToExpirationQueue(expirationQueueRowType& row, int height, bool increment);
+    void removeAndAddToExpirationQueue(expirationQueueRowType& row, int height, bool increment);
 };
 
-class CClaimTrieCacheNormalizationFork: public CClaimTrieCacheExpirationFork {
-  public:
-    CClaimTrieCacheNormalizationFork(CClaimTrie* base, bool fRequireTakeoverHeights = true)
-        : CClaimTrieCacheExpirationFork(base, fRequireTakeoverHeights),
-        overrideInsertNormalization(false), overrideRemoveNormalization(false) {}
-
-    virtual ~CClaimTrieCacheNormalizationFork() {}
+class CClaimTrieCacheNormalizationFork : public CClaimTrieCacheExpirationFork
+{
+public:
+    explicit CClaimTrieCacheNormalizationFork(CClaimTrie* base, bool fRequireTakeoverHeights = true)
+        : CClaimTrieCacheExpirationFork(base, fRequireTakeoverHeights), overrideInsertNormalization(false), overrideRemoveNormalization(false)
+    {
+    }
 
     bool shouldNormalize() const;
 
@@ -785,40 +567,44 @@ class CClaimTrieCacheNormalizationFork: public CClaimTrieCacheExpirationFork {
     // see: https://unicode.org/reports/tr15/#Norm_Forms
     std::string normalizeClaimName(const std::string& name, bool force = false) const; // public only for validating name field on update op
 
-    virtual bool incrementBlock(insertUndoType& insertUndo,
-                                claimQueueRowType& expireUndo,
-                                insertUndoType& insertSupportUndo,
-                                supportQueueRowType& expireSupportUndo,
-                                std::vector<std::pair<std::string, int> >& takeoverHeightUndo);
-    virtual bool decrementBlock(insertUndoType& insertUndo,
-                                claimQueueRowType& expireUndo,
-                                insertUndoType& insertSupportUndo,
-                                supportQueueRowType& expireSupportUndo,
-                                std::vector<std::pair<std::string, int> >& takeoverHeightUndo);
+    bool incrementBlock(insertUndoType& insertUndo,
+        claimQueueRowType& expireUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo,
+        std::vector<std::pair<std::string, int>>& takeoverHeightUndo) override;
 
-    virtual bool getProofForName(const std::string& name, CClaimTrieProof& proof) const;
-    virtual bool getInfoForName(const std::string& name, CClaimValue& claim) const;
-    virtual claimsForNameType getClaimsForName(const std::string& name) const;
+    bool decrementBlock(insertUndoType& insertUndo,
+        claimQueueRowType& expireUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo) override;
+
+    bool getProofForName(const std::string& name, CClaimTrieProof& proof) override;
+    bool getInfoForName(const std::string& name, CClaimValue& claim) const override;
+    CClaimsForNameType getClaimsForName(const std::string& name) const override;
 
 protected:
-    virtual bool insertClaimIntoTrie(const std::string& name, CClaimValue claim, bool fCheckTakeover = false) const;
-    virtual bool removeClaimFromTrie(const std::string& name, const COutPoint& outPoint,
-                                     CClaimValue& claim, bool fCheckTakeover = false) const;
+    bool insertClaimIntoTrie(const std::string& name, const CClaimValue& claim, bool fCheckTakeover = false) override;
+    bool removeClaimFromTrie(const std::string& name, const COutPoint& outPoint, CClaimValue& claim, bool fCheckTakeover = false) override;
 
-    virtual bool insertSupportIntoMap(const std::string& name, CSupportValue support, bool fCheckTakeover) const;
-    virtual bool removeSupportFromMap(const std::string& name, const COutPoint& outPoint,
-                                      CSupportValue& support, bool fCheckTakeover) const;
-    virtual int getDelayForName(const std::string& name, const uint160& claimId) const;
+    bool insertSupportIntoMap(const std::string& name, const CSupportValue& support, bool fCheckTakeover) override;
+    bool removeSupportFromMap(const std::string& name, const COutPoint& outPoint, CSupportValue& support, bool fCheckTakeover) override;
 
-    virtual void addClaimToQueues(const std::string& name, CClaimValue& claim) const;
-    virtual bool addSupportToQueues(const std::string& name, CSupportValue& support) const;
-    virtual std::string adjustNameForValidHeight(const std::string& name, int validHeight) const;
+    int getDelayForName(const std::string& name, const uint160& claimId) override;
+
+    bool addClaimToQueues(const std::string& name, const CClaimValue& claim) override;
+    bool addSupportToQueues(const std::string& name, const CSupportValue& support) override;
+
+    std::string adjustNameForValidHeight(const std::string& name, int validHeight) const override;
 
 private:
-    bool overrideInsertNormalization, overrideRemoveNormalization;
-    bool normalizeAllNamesInTrieIfNecessary(insertUndoType& insertUndo, claimQueueRowType& removeUndo,
-                                            insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo,
-                                            std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const;
+    bool overrideInsertNormalization;
+    bool overrideRemoveNormalization;
+
+    bool normalizeAllNamesInTrieIfNecessary(insertUndoType& insertUndo,
+        claimQueueRowType& removeUndo,
+        insertUndoType& insertSupportUndo,
+        supportQueueRowType& expireSupportUndo,
+        std::vector<std::pair<std::string, int>>& takeoverHeightUndo);
 };
 
 typedef CClaimTrieCacheNormalizationFork CClaimTrieCache;

--- a/src/claimtrieforks.cpp
+++ b/src/claimtrieforks.cpp
@@ -2,40 +2,36 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
+#include <boost/locale.hpp>
 #include <boost/locale/conversion.hpp>
 #include <boost/locale/localization_backend.hpp>
-#include <boost/locale.hpp>
 #include <boost/scope_exit.hpp>
 
-void CClaimTrieCacheExpirationFork::removeAndAddToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const
+void CClaimTrieCacheExpirationFork::removeAndAddToExpirationQueue(expirationQueueRowType& row, int height, bool increment)
 {
-    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e)
-    {
+    for (auto e = row.begin(); e != row.end(); ++e) {
         // remove and insert with new expiration time
         removeFromExpirationQueue(e->name, e->outPoint, height);
         int extend_expiration = Params().GetConsensus().nExtendedClaimExpirationTime - Params().GetConsensus().nOriginalClaimExpirationTime;
         int new_expiration_height = increment ? height + extend_expiration : height - extend_expiration;
-        nameOutPointType entry(e->name, e->outPoint);
+        CNameOutPointType entry(e->name, e->outPoint);
         addToExpirationQueue(new_expiration_height, entry);
     }
-
 }
 
-void CClaimTrieCacheExpirationFork::removeAndAddSupportToExpirationQueue(expirationQueueRowType &row, int height, bool increment) const
+void CClaimTrieCacheExpirationFork::removeAndAddSupportToExpirationQueue(expirationQueueRowType& row, int height, bool increment)
 {
-    for (expirationQueueRowType::iterator e = row.begin(); e != row.end(); ++e)
-    {
+    for (auto e = row.begin(); e != row.end(); ++e) {
         // remove and insert with new expiration time
         removeSupportFromExpirationQueue(e->name, e->outPoint, height);
         int extend_expiration = Params().GetConsensus().nExtendedClaimExpirationTime - Params().GetConsensus().nOriginalClaimExpirationTime;
         int new_expiration_height = increment ? height + extend_expiration : height - extend_expiration;
-        nameOutPointType entry(e->name, e->outPoint);
+        CNameOutPointType entry(e->name, e->outPoint);
         addSupportToExpirationQueue(new_expiration_height, entry);
     }
-
 }
 
-bool CClaimTrieCacheExpirationFork::forkForExpirationChange(bool increment) const
+bool CClaimTrieCacheExpirationFork::forkForExpirationChange(bool increment)
 {
     /*
     If increment is True, we have forked to extend the expiration time, thus items in the expiration queue
@@ -45,75 +41,40 @@ bool CClaimTrieCacheExpirationFork::forkForExpirationChange(bool increment) cons
     will have their expiration extension removed.
     */
 
-    // look through dirty expiration queues
-    std::set<int> dirtyHeights;
-    for (expirationQueueType::const_iterator i = base->dirtyExpirationQueueRows.begin(); i != base->dirtyExpirationQueueRows.end(); ++i)
-    {
-        int height = i->first;
-        dirtyHeights.insert(height);
-        expirationQueueRowType row = i->second;
-        removeAndAddToExpirationQueue(row, height, increment);
-    }
-
-    std::set<int> dirtySupportHeights;
-    for (expirationQueueType::const_iterator i = base->dirtySupportExpirationQueueRows.begin(); i != base->dirtySupportExpirationQueueRows.end(); ++i)
-    {
-        int height = i->first;
-        dirtySupportHeights.insert(height);
-        expirationQueueRowType row = i->second;
-        removeAndAddSupportToExpirationQueue(row, height, increment);
-    }
-
-
     //look through db for expiration queues, if we haven't already found it in dirty expiration queue
-    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&base->db)->NewIterator());
-    pcursor->SeekToFirst();
-    while (pcursor->Valid())
-    {
-        std::pair<char, int> key;
-        if (pcursor->GetKey(key))
-        {
-            int height = key.second;
-            // if we've looked through this in dirtyExprirationQueueRows, don't use it
-            // because its stale
-            if ((key.first == EXP_QUEUE_ROW) & (dirtyHeights.count(height) == 0))
-            {
-                expirationQueueRowType row;
-                if (pcursor->GetValue(row))
-                {
-                    removeAndAddToExpirationQueue(row, height, increment);
-                }
-                else
-                {
-                    return error("%s(): error reading expiration queue rows from disk", __func__);
-                }
+    boost::scoped_ptr<CDBIterator> pcursor(base->db->NewIterator());
+    for (pcursor->SeekToFirst(); pcursor->Valid(); pcursor->Next()) {
+        std::pair<uint8_t, int> key;
+        if (!pcursor->GetKey(key))
+            continue;
+        int height = key.second;
+        if (key.first == EXP_QUEUE_ROW) {
+            expirationQueueRowType row;
+            if (pcursor->GetValue(row)) {
+                removeAndAddToExpirationQueue(row, height, increment);
+            } else {
+                return error("%s(): error reading expiration queue rows from disk", __func__);
             }
-            else if ((key.first == SUPPORT_EXP_QUEUE_ROW) & (dirtySupportHeights.count(height) == 0))
-            {
-                expirationQueueRowType row;
-                if (pcursor->GetValue(row))
-                {
-                    removeAndAddSupportToExpirationQueue(row, height, increment);
-                }
-                else
-                {
-                    return error("%s(): error reading support expiration queue rows from disk", __func__);
-                }
+        } else if (key.first == SUPPORT_EXP_QUEUE_ROW) {
+            expirationQueueRowType row;
+            if (pcursor->GetValue(row)) {
+                removeAndAddSupportToExpirationQueue(row, height, increment);
+            } else {
+                return error("%s(): error reading support expiration queue rows from disk", __func__);
             }
-
         }
-        pcursor->Next();
     }
 
     return true;
 }
 
-
-bool CClaimTrieCacheNormalizationFork::shouldNormalize() const {
-    return nCurrentHeight > Params().GetConsensus().nNormalizedNameForkHeight;
+bool CClaimTrieCacheNormalizationFork::shouldNormalize() const
+{
+    return nNextHeight > Params().GetConsensus().nNormalizedNameForkHeight;
 }
 
-std::string CClaimTrieCacheNormalizationFork::normalizeClaimName(const std::string& name, bool force) const {
+std::string CClaimTrieCacheNormalizationFork::normalizeClaimName(const std::string& name, bool force) const
+{
     if (!force && !shouldNormalize())
         return name;
 
@@ -121,7 +82,7 @@ std::string CClaimTrieCacheNormalizationFork::normalizeClaimName(const std::stri
     static bool initialized = false;
     if (!initialized) {
         static boost::locale::localization_backend_manager manager =
-                boost::locale::localization_backend_manager::global();
+            boost::locale::localization_backend_manager::global();
         manager.select("icu");
 
         static boost::locale::generator curLocale(manager);
@@ -131,7 +92,6 @@ std::string CClaimTrieCacheNormalizationFork::normalizeClaimName(const std::stri
 
     std::string normalized;
     try {
-
         // Check if it is a valid utf-8 string. If not, it will throw a
         // boost::locale::conv::conversion_error exception which we catch later
         normalized = boost::locale::conv::to_utf<char>(name, "UTF-8", boost::locale::conv::stop);
@@ -141,15 +101,12 @@ std::string CClaimTrieCacheNormalizationFork::normalizeClaimName(const std::stri
         // these methods supposedly only use the "UTF8" portion of the locale object:
         normalized = boost::locale::normalize(normalized, boost::locale::norm_nfd, utf8);
         normalized = boost::locale::fold_case(normalized, utf8);
-    }
-    catch (const boost::locale::conv::conversion_error& e){
+    } catch (const boost::locale::conv::conversion_error& e) {
         return name;
-    }
-    catch (const std::bad_cast& e) {
+    } catch (const std::bad_cast& e) {
         LogPrintf("%s() is invalid or dependencies are missing: %s\n", __func__, e.what());
         throw;
-    }
-    catch (const std::exception& e) { // TODO: change to use ... with current_exception() in c++11
+    } catch (const std::exception& e) { // TODO: change to use ... with current_exception() in c++11
         LogPrintf("%s() had an unexpected exception: %s\n", __func__, e.what());
         return name;
     }
@@ -157,144 +114,121 @@ std::string CClaimTrieCacheNormalizationFork::normalizeClaimName(const std::stri
     return normalized;
 }
 
-bool CClaimTrieCacheNormalizationFork::insertClaimIntoTrie(const std::string& name, CClaimValue claim,
-                                bool fCheckTakeover) const {
+bool CClaimTrieCacheNormalizationFork::insertClaimIntoTrie(const std::string& name, const CClaimValue& claim, bool fCheckTakeover)
+{
     return CClaimTrieCacheExpirationFork::insertClaimIntoTrie(normalizeClaimName(name, overrideInsertNormalization), claim, fCheckTakeover);
 }
 
-bool CClaimTrieCacheNormalizationFork::removeClaimFromTrie(const std::string& name, const COutPoint& outPoint,
-                                CClaimValue& claim, bool fCheckTakeover) const {
+bool CClaimTrieCacheNormalizationFork::removeClaimFromTrie(const std::string& name, const COutPoint& outPoint, CClaimValue& claim, bool fCheckTakeover)
+{
     return CClaimTrieCacheExpirationFork::removeClaimFromTrie(normalizeClaimName(name, overrideRemoveNormalization), outPoint, claim, fCheckTakeover);
 }
 
-bool CClaimTrieCacheNormalizationFork::insertSupportIntoMap(const std::string& name, CSupportValue support,
-                                bool fCheckTakeover) const {
+bool CClaimTrieCacheNormalizationFork::insertSupportIntoMap(const std::string& name, const CSupportValue& support, bool fCheckTakeover)
+{
     return CClaimTrieCacheExpirationFork::insertSupportIntoMap(normalizeClaimName(name, overrideInsertNormalization), support, fCheckTakeover);
 }
-bool CClaimTrieCacheNormalizationFork::removeSupportFromMap(const std::string& name, const COutPoint& outPoint,
-                                CSupportValue& support, bool fCheckTakeover) const {
+
+bool CClaimTrieCacheNormalizationFork::removeSupportFromMap(const std::string& name, const COutPoint& outPoint, CSupportValue& support, bool fCheckTakeover)
+{
     return CClaimTrieCacheExpirationFork::removeSupportFromMap(normalizeClaimName(name, overrideRemoveNormalization), outPoint, support, fCheckTakeover);
 }
 
-struct claimsForNormalization: public claimsForNameType {
-    std::string normalized;
-    claimsForNormalization(const std::vector<CClaimValue>& claims, const std::vector<CSupportValue>& supports,
-        int nLastTakeoverHeight, const std::string& name, const std::string& normalized)
-    : claimsForNameType(claims, supports, nLastTakeoverHeight, name), normalized(normalized) {}
-};
+bool CClaimTrieCacheNormalizationFork::normalizeAllNamesInTrieIfNecessary(insertUndoType& insertUndo, claimQueueRowType& removeUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int>>& takeoverHeightUndo)
+{
+    if (nNextHeight != Params().GetConsensus().nNormalizedNameForkHeight)
+        return false;
 
-bool CClaimTrieCacheNormalizationFork::normalizeAllNamesInTrieIfNecessary(insertUndoType& insertUndo, claimQueueRowType& removeUndo,
-                                                             insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo,
-                                                             std::vector<std::pair<std::string, int> >& takeoverHeightUndo) const {
+    // run the one-time upgrade of all names that need to change
+    // it modifies the (cache) trie as it goes, so we need to grab everything to be modified first
 
-    struct CNameChangeDetector: public CNodeCallback {
-        std::vector<claimsForNormalization> hits;
-        const CClaimTrieCacheNormalizationFork* owner;
-        CNameChangeDetector(const CClaimTrieCacheNormalizationFork* owner): owner(owner) {}
-        void visit(const std::string& name, const CClaimTrieNode* node) {
-            if (node->claims.empty()) return;
-            const std::string normalized = owner->normalizeClaimName(name, true);
-            if (normalized == name) return;
+    for (auto it = base->begin(); it != base->end(); ++it) {
+        const std::string normalized = normalizeClaimName(it.key(), true);
+        if (normalized == it.key())
+            continue;
 
-            supportMapEntryType supports;
-            owner->getSupportsForName(name, supports);
-            const claimsForNormalization cfn(node->claims, supports, node->nHeightOfLastTakeover, name, normalized);
-            hits.push_back(cfn);
+        auto supports = getSupportsForName(it.key());
+        for (auto& support : supports) {
+            // if it's already going to expire just skip it
+            if (support.nHeight + base->nExpirationTime <= nNextHeight)
+                continue;
+
+            CSupportValue removed;
+            assert(removeSupportFromMap(it.key(), support.outPoint, removed, false));
+            expireSupportUndo.emplace_back(it.key(), removed);
+            assert(insertSupportIntoMap(normalized, support, false));
+            insertSupportUndo.emplace_back(it.key(), support.outPoint, -1);
         }
-    };
 
-    if (nCurrentHeight == Params().GetConsensus().nNormalizedNameForkHeight) {
+        namesToCheckForTakeover.insert(normalized);
 
-        // run the one-time upgrade of all names that need to change
-        // it modifies the (cache) trie as it goes, so we need to grab
-        // everything to be modified first
-        CNameChangeDetector detector(this);
-        iterateTrie(detector);
+        auto cached = cacheData(it.key(), false);
+        if (!cached || cached->claims.empty())
+            continue;
 
-        for (std::vector<claimsForNormalization>::iterator it = detector.hits.begin(); it != detector.hits.end(); ++it) {
-            BOOST_FOREACH(CSupportValue support, it->supports) {
-                // if it's already going to expire just skip it
-                if (support.nHeight + base->nExpirationTime <= nCurrentHeight)
-                    continue;
+        for (auto& claim : it->claims) {
+            if (claim.nHeight + base->nExpirationTime <= nNextHeight)
+                continue;
 
-                bool success = removeSupportFromMap(it->name, support.outPoint, support, false);
-                assert(success);
-                expireSupportUndo.push_back(std::make_pair(it->name, support));
-                success = insertSupportIntoMap(it->normalized, support, false);
-                assert(success);
-                insertSupportUndo.push_back(nameOutPointHeightType(it->name, support.outPoint, -1));
-            }
-
-            BOOST_FOREACH(CClaimValue claim, it->claims) {
-                if (claim.nHeight + base->nExpirationTime <= nCurrentHeight)
-                    continue;
-
-                bool success = removeClaimFromTrie(it->name, claim.outPoint, claim, false);
-                assert(success);
-                removeUndo.push_back(std::make_pair(it->name, claim));
-
-                success = insertClaimIntoTrie(it->normalized, claim, true);
-                assert(success);
-                insertUndo.push_back(nameOutPointHeightType(it->name, claim.outPoint, -1));
-            }
-
-            takeoverHeightUndo.push_back(std::make_pair(it->name, it->nLastTakeoverHeight));
+            CClaimValue removed;
+            assert(removeClaimFromTrie(it.key(), claim.outPoint, removed, false));
+            removeUndo.emplace_back(it.key(), removed);
+            assert(insertClaimIntoTrie(normalized, claim, false));
+            insertUndo.emplace_back(it.key(), claim.outPoint, -1);
         }
-        return true;
+
+        takeoverHeightUndo.emplace_back(it.key(), it->nHeightOfLastTakeover);
     }
-    return false;
+    return true;
 }
 
-bool CClaimTrieCacheNormalizationFork::incrementBlock(insertUndoType& insertUndo,
-                            claimQueueRowType& expireUndo,
-                            insertUndoType& insertSupportUndo,
-                            supportQueueRowType& expireSupportUndo,
-                            std::vector<std::pair<std::string, int> >& takeoverHeightUndo) {
-    overrideInsertNormalization = normalizeAllNamesInTrieIfNecessary(insertUndo, expireUndo, insertSupportUndo,
-            expireSupportUndo, takeoverHeightUndo);
-    BOOST_SCOPE_EXIT(&overrideInsertNormalization) { overrideInsertNormalization = false; } BOOST_SCOPE_EXIT_END
-    return CClaimTrieCacheExpirationFork::incrementBlock(insertUndo, expireUndo, insertSupportUndo,
-            expireSupportUndo, takeoverHeightUndo);
+bool CClaimTrieCacheNormalizationFork::incrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo, std::vector<std::pair<std::string, int>>& takeoverHeightUndo)
+{
+    overrideInsertNormalization = normalizeAllNamesInTrieIfNecessary(insertUndo, expireUndo, insertSupportUndo, expireSupportUndo, takeoverHeightUndo);
+    BOOST_SCOPE_EXIT(&overrideInsertNormalization) { overrideInsertNormalization = false; }
+    BOOST_SCOPE_EXIT_END
+    return CClaimTrieCacheExpirationFork::incrementBlock(insertUndo, expireUndo, insertSupportUndo, expireSupportUndo, takeoverHeightUndo);
 }
 
-bool CClaimTrieCacheNormalizationFork::decrementBlock(insertUndoType& insertUndo,
-                            claimQueueRowType& expireUndo,
-                            insertUndoType& insertSupportUndo,
-                            supportQueueRowType& expireSupportUndo,
-                            std::vector<std::pair<std::string, int> >& takeoverHeightUndo) {
-
+bool CClaimTrieCacheNormalizationFork::decrementBlock(insertUndoType& insertUndo, claimQueueRowType& expireUndo, insertUndoType& insertSupportUndo, supportQueueRowType& expireSupportUndo)
+{
     overrideRemoveNormalization = shouldNormalize();
-    BOOST_SCOPE_EXIT(&overrideRemoveNormalization) { overrideRemoveNormalization = false; } BOOST_SCOPE_EXIT_END
-    return CClaimTrieCacheExpirationFork::decrementBlock(insertUndo, expireUndo, insertSupportUndo,
-            expireSupportUndo, takeoverHeightUndo);
+    BOOST_SCOPE_EXIT(&overrideRemoveNormalization) { overrideRemoveNormalization = false; }
+    BOOST_SCOPE_EXIT_END
+    return CClaimTrieCacheExpirationFork::decrementBlock(insertUndo, expireUndo, insertSupportUndo, expireSupportUndo);
 }
 
-bool CClaimTrieCacheNormalizationFork::getProofForName(const std::string& name, CClaimTrieProof& proof) const {
+bool CClaimTrieCacheNormalizationFork::getProofForName(const std::string& name, CClaimTrieProof& proof)
+{
     return CClaimTrieCacheExpirationFork::getProofForName(normalizeClaimName(name), proof);
 }
 
-bool CClaimTrieCacheNormalizationFork::getInfoForName(const std::string& name, CClaimValue& claim) const {
+bool CClaimTrieCacheNormalizationFork::getInfoForName(const std::string& name, CClaimValue& claim) const
+{
     return CClaimTrieCacheExpirationFork::getInfoForName(normalizeClaimName(name), claim);
 }
 
-claimsForNameType CClaimTrieCacheNormalizationFork::getClaimsForName(const std::string& name) const {
+CClaimsForNameType CClaimTrieCacheNormalizationFork::getClaimsForName(const std::string& name) const
+{
     return CClaimTrieCacheExpirationFork::getClaimsForName(normalizeClaimName(name));
 }
 
-int CClaimTrieCacheNormalizationFork::getDelayForName(const std::string& name, const uint160& claimId) const {
+int CClaimTrieCacheNormalizationFork::getDelayForName(const std::string& name, const uint160& claimId)
+{
     return CClaimTrieCacheExpirationFork::getDelayForName(normalizeClaimName(name), claimId);
 }
 
-void CClaimTrieCacheNormalizationFork::addClaimToQueues(const std::string& name, CClaimValue& claim) const {
-    return CClaimTrieCacheExpirationFork::addClaimToQueues(normalizeClaimName(name,
-            claim.nValidAtHeight > Params().GetConsensus().nNormalizedNameForkHeight), claim);
+bool CClaimTrieCacheNormalizationFork::addClaimToQueues(const std::string& name, const CClaimValue& claim)
+{
+    return CClaimTrieCacheExpirationFork::addClaimToQueues(normalizeClaimName(name, claim.nValidAtHeight > Params().GetConsensus().nNormalizedNameForkHeight), claim);
 }
 
-bool CClaimTrieCacheNormalizationFork::addSupportToQueues(const std::string& name, CSupportValue& support) const {
-    return CClaimTrieCacheExpirationFork::addSupportToQueues(normalizeClaimName(name,
-            support.nValidAtHeight > Params().GetConsensus().nNormalizedNameForkHeight), support);
+bool CClaimTrieCacheNormalizationFork::addSupportToQueues(const std::string& name, const CSupportValue& support)
+{
+    return CClaimTrieCacheExpirationFork::addSupportToQueues(normalizeClaimName(name, support.nValidAtHeight > Params().GetConsensus().nNormalizedNameForkHeight), support);
 }
 
-std::string CClaimTrieCacheNormalizationFork::adjustNameForValidHeight(const std::string& name, int validHeight) const {
+std::string CClaimTrieCacheNormalizationFork::adjustNameForValidHeight(const std::string& name, int validHeight) const
+{
     return normalizeClaimName(name, validHeight > Params().GetConsensus().nNormalizedNameForkHeight);
 }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -77,6 +77,10 @@ struct Params {
     int nAllowMinDiffMinHeight;
     int nAllowMinDiffMaxHeight;
     int nNormalizedNameForkHeight;
+
+    int nMinTakeoverWorkaroundHeight;
+    int nMaxTakeoverWorkaroundHeight;
+
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
     /** how long it took claims to expire before the hard fork */

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -100,8 +100,9 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
 static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
-    options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
-    options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
+    auto write_cache = std::min(nCacheSize / 4, size_t(16) << 20U); // cap write_cache at 16MB (4x default)
+    options.block_cache = leveldb::NewLRUCache(nCacheSize - write_cache * 2);
+    options.write_buffer_size = write_cache; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1503,12 +1503,6 @@ bool AppInitMain()
                     break;
                 }
 
-                if (!pclaimTrie->ReadFromDisk(true))
-                {
-                    strLoadError = _("Error loading the claim trie from disk");
-                    break;
-                }
-
                 // At this point we're either in reindex or we've loaded a useful
                 // block tree into mapBlockIndex!
 
@@ -1539,6 +1533,13 @@ bool AppInitMain()
                         break;
                     }
                     assert(chainActive.Tip() != nullptr);
+                }
+
+                CClaimTrieCache trieCache(pclaimTrie);
+                if (!trieCache.ReadFromDisk(chainActive.Tip()))
+                {
+                    strLoadError = _("Error loading the claim trie from disk");
+                    break;
                 }
 
                 if (!fReset) {
@@ -1702,7 +1703,7 @@ bool AppInitMain()
     LogPrintf("nBestHeight = %d\n", chain_active_height);
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
-    pclaimTrie->setExpirationTime(consensusParams.GetExpirationTime(chain_active_height));
+    CClaimTrieCache(pclaimTrie).setExpirationTime(consensusParams.GetExpirationTime(chain_active_height));
 
     if (gArgs.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl();

--- a/src/prefixtrie.cpp
+++ b/src/prefixtrie.cpp
@@ -1,0 +1,492 @@
+
+#include "prefixtrie.h"
+#include "claimtrie.h"
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+CPrefixTrie<TKey, TData>::Iterator<IsConst>::Iterator(const TKey& name, const std::shared_ptr<Node>& node) noexcept : name(name), node(node)
+{
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+template <bool C>
+typename CPrefixTrie<TKey, TData>::template Iterator<IsConst>& CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator=(const CPrefixTrie<TKey, TData>::Iterator<C>& o) noexcept
+{
+    name = o.name;
+    node = o.node;
+    stack.clear();
+    stack.reserve(o.stack.size());
+    for (auto& i : o.stack)
+        stack.push_back(Bookmark{i.name, i.parent, i.it, i.end});
+    return *this;
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+bool CPrefixTrie<TKey, TData>::Iterator<IsConst>::hasNext() const
+{
+    auto shared = node.lock();
+    if (!shared) return false;
+    if (!shared->children.empty()) return true;
+    for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
+        auto mark = *it; // copy
+        if (++mark.it != mark.end)
+            return true;
+    }
+    return false;
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+typename CPrefixTrie<TKey, TData>::template Iterator<IsConst>& CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator++()
+{
+    auto shared = node.lock();
+    assert(shared);
+    // going in pre-order (NLR). See https://en.wikipedia.org/wiki/Tree_traversal
+    // if there are any children we have to go there first
+    if (!shared->children.empty()) {
+        auto& children = shared->children;
+        auto it = children.begin();
+        stack.emplace_back(Bookmark{name, shared, it, children.end()});
+        auto& postfix = it->first;
+        name.insert(name.end(), postfix.begin(), postfix.end());
+        node = it->second;
+        return *this;
+    }
+
+    // move to next sibling:
+    while (!stack.empty()) {
+        auto& back = stack.back();
+        if (++back.it != back.end) {
+            name = back.name;
+            auto& postfix = back.it->first;
+            name.insert(name.end(), postfix.begin(), postfix.end());
+            node = back.it->second;
+            return *this;
+        }
+        stack.pop_back();
+    }
+
+    // must be at the end:
+    node.reset();
+    name = TKey();
+    return *this;
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+typename CPrefixTrie<TKey, TData>::template Iterator<IsConst> CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator++(int x)
+{
+    auto ret = *this;
+    ++(*this);
+    return ret;
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator bool() const
+{
+    return !node.expired();
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+bool CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator==(const Iterator& o) const
+{
+    return node.lock() == o.node.lock();
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+bool CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator!=(const Iterator& o) const
+{
+    return !(*this == o);
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+typename CPrefixTrie<TKey, TData>::template Iterator<IsConst>::reference CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator*() const
+{
+    assert(!node.expired());
+    return TPair(name, *(node.lock()->data));
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+typename CPrefixTrie<TKey, TData>::template Iterator<IsConst>::pointer CPrefixTrie<TKey, TData>::Iterator<IsConst>::operator->() const
+{
+    assert(!node.expired());
+    return node.lock()->data.get();
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+const TKey& CPrefixTrie<TKey, TData>::Iterator<IsConst>::key() const
+{
+    return name;
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+TData& CPrefixTrie<TKey, TData>::Iterator<IsConst>::data()
+{
+    assert(!node.expired());
+    return *(node.lock()->data);
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+const TData& CPrefixTrie<TKey, TData>::Iterator<IsConst>::data() const
+{
+    assert(!node.expired());
+    return *(node.lock()->data);
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+std::size_t CPrefixTrie<TKey, TData>::Iterator<IsConst>::depth() const
+{
+    return stack.size();
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+bool CPrefixTrie<TKey, TData>::Iterator<IsConst>::hasChildren() const
+{
+    auto shared = node.lock();
+    return shared && !shared->children.empty();
+}
+
+template <typename TKey, typename TData>
+template <bool IsConst>
+std::vector<typename CPrefixTrie<TKey, TData>::template Iterator<IsConst>> CPrefixTrie<TKey, TData>::Iterator<IsConst>::children() const
+{
+    auto shared = node.lock();
+    if (!shared) return {};
+    std::vector<Iterator<IsConst>> ret;
+    ret.reserve(shared->children.size());
+    for (auto& child : shared->children) {
+        auto key = name;
+        key.insert(key.end(), child.first.begin(), child.first.end());
+        ret.emplace_back(key, child.second);
+    }
+    return ret;
+}
+
+template <typename TKey>
+static std::size_t match(const TKey& a, const TKey& b)
+{
+    std::size_t count = 0;
+    auto ait = a.cbegin(), aend = a.cend();
+    auto bit = b.cbegin(), bend = b.cend();
+    while (ait != aend && bit != bend) {
+        if (*ait != *bit) break;
+        ++count;
+        ++ait;
+        ++bit;
+    }
+    return count;
+}
+
+template <typename TKey, typename TData>
+template <typename TIterator, typename TNode>
+TIterator CPrefixTrie<TKey, TData>::find(const TKey& key, TNode node, TIterator end)
+{
+    TIterator it(key, TNode());
+    using CBType = callback<TNode>;
+    CBType cb = [&it](const TKey&, TNode node) {
+        it.node = node;
+    };
+    return find(key, node, cb) ? it : end;
+}
+
+template <typename TKey, typename TData>
+template <typename TNode>
+bool CPrefixTrie<TKey, TData>::find(const TKey& key, TNode node, const callback<TNode>& cb)
+{
+    auto& children = node->children;
+    if (children.empty()) return false;
+    auto it = children.lower_bound(key);
+    if (it != children.end() && it->first == key) {
+        cb(key, it->second);
+        return true;
+    }
+    if (it != children.begin()) --it;
+    const auto count = match(key, it->first);
+    if (count != it->first.size()) return false;
+    if (count == key.size()) return false;
+    cb(it->first, it->second);
+    return find(TKey(key.begin() + count, key.end()), it->second, cb);
+}
+
+template <typename TKey, typename TData>
+std::shared_ptr<typename CPrefixTrie<TKey, TData>::Node>& CPrefixTrie<TKey, TData>::insert(const TKey& key, std::shared_ptr<typename CPrefixTrie<TKey, TData>::Node>& node)
+{
+    std::size_t count = 0;
+    auto& children = node->children;
+    auto it = children.lower_bound(key);
+    if (it != children.end()) {
+        if (it->first == key)
+            return it->second;
+        count = match(key, it->first);
+    }
+    if (count == 0 && it != children.begin()) {
+        --it;
+        count = match(key, it->first);
+    }
+    if (count == 0) {
+        ++size;
+        it = children.emplace(key, std::make_shared<Node>()).first;
+        it->second->data = std::make_shared<TData>();
+        return it->second;
+    }
+    if (count < it->first.size()) {
+        const TKey prefix(key.begin(), key.begin() + count);
+        const TKey postfix(it->first.begin() + count, it->first.end());
+        auto nodes = std::move(it->second);
+        children.erase(it);
+        ++size;
+        it = children.emplace(prefix, std::make_shared<Node>()).first;
+        it->second->children.emplace(postfix, std::move(nodes));
+        it->second->data = std::make_shared<TData>();
+        if (key.size() == count)
+            return it->second;
+    }
+    return insert(TKey(key.begin() + count, key.end()), it->second);
+}
+
+template <typename TKey, typename TData>
+void CPrefixTrie<TKey, TData>::erase(const TKey& key, std::shared_ptr<Node>& node)
+{
+    std::vector<typename TChildren::value_type> nodes;
+    nodes.emplace_back(TKey(), node);
+    using CBType = callback<std::shared_ptr<Node>>;
+    CBType cb = [&nodes](const TKey& k, std::shared_ptr<Node> n) {
+        nodes.emplace_back(k, n);
+    };
+    if (!find(key, node, cb))
+        return;
+
+    nodes.back().second->data = std::make_shared<TData>();
+    for (; nodes.size() > 1; nodes.pop_back()) {
+        // if we have only one child and no data ourselves, bring them up to our level
+        auto& cNode = nodes.back().second;
+        auto onlyOneChild = cNode->children.size() == 1;
+        auto noData = cNode->data->empty();
+        if (onlyOneChild && noData) {
+            auto child = cNode->children.begin();
+            auto& prefix = nodes.back().first;
+            auto newKey = prefix;
+            auto& postfix = child->first;
+            newKey.insert(newKey.end(), postfix.begin(), postfix.end());
+            auto& pNode = nodes[nodes.size() - 2].second;
+            pNode->children.emplace(newKey, std::move(child->second));
+            pNode->children.erase(prefix);
+            --size;
+            continue;
+        }
+
+        auto noChildren = cNode->children.empty();
+        if (noChildren && noData) {
+            auto& pNode = nodes[nodes.size() - 2].second;
+            pNode->children.erase(nodes.back().first);
+            --size;
+            continue;
+        }
+        break;
+    }
+}
+
+template <typename TKey, typename TData>
+CPrefixTrie<TKey, TData>::CPrefixTrie() : size(0), root(std::make_shared<Node>())
+{
+    root->data = std::make_shared<TData>();
+}
+
+template <typename TKey, typename TData>
+template <typename TDataUni>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::insert(const TKey& key, TDataUni&& data)
+{
+    auto& node = key.empty() ? root : insert(key, root);
+    node->data = std::make_shared<TData>(std::forward<TDataUni>(data));
+    return key.empty() ? begin() : iterator{key, node};
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::copy(CPrefixTrie<TKey, TData>::const_iterator it)
+{
+    auto& key = it.key();
+    auto& node = key.empty() ? root : insert(key, root);
+    node->data = it.node.lock()->data;
+    return key.empty() ? begin() : iterator{key, node};
+}
+
+template <typename TKey, typename TData>
+template <typename TDataUni>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::insert(CPrefixTrie<TKey, TData>::iterator& it, const TKey& key, TDataUni&& data)
+{
+    auto shared = it.node.lock();
+    assert(shared);
+    auto copy = it;
+    if (!key.empty()) {
+        auto name = it.key();
+        name.insert(name.end(), key.begin(), key.end());
+        auto& node = insert(key, shared);
+        copy = iterator{name, node};
+    }
+    copy.node.lock()->data = std::make_shared<TData>(std::forward<TDataUni>(data));
+    return copy;
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::find(const TKey& key)
+{
+    if (empty()) return end();
+    if (key.empty()) return {key, root};
+    return find(key, root, end());
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::const_iterator CPrefixTrie<TKey, TData>::find(const TKey& key) const
+{
+    if (empty()) return end();
+    if (key.empty()) return {key, root};
+    return find(key, root, end());
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::find(CPrefixTrie<TKey, TData>::iterator& it, const TKey& key)
+{
+    if (key.empty()) return it;
+    auto shared = it.node.lock();
+    assert(shared);
+    return find(key, shared, end());
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::const_iterator CPrefixTrie<TKey, TData>::find(CPrefixTrie<TKey, TData>::const_iterator& it, const TKey& key) const
+{
+    if (key.empty()) return it;
+    auto shared = it.node.lock();
+    assert(shared);
+    return find(key, shared, end());
+}
+
+template <typename TKey, typename TData>
+bool CPrefixTrie<TKey, TData>::contains(const TKey& key) const
+{
+    return find(key) != end();
+}
+
+template <typename TKey, typename TData>
+TData& CPrefixTrie<TKey, TData>::at(const TKey& key)
+{
+    return find(key).data();
+}
+
+template <typename TKey, typename TData>
+std::vector<typename CPrefixTrie<TKey, TData>::iterator> CPrefixTrie<TKey, TData>::nodes(const TKey& key) const
+{
+    std::vector<iterator> ret;
+    if (empty()) return ret;
+    ret.reserve(1 + key.size());
+    ret.emplace_back(TKey{}, root);
+    if (key.empty()) return ret;
+    TKey name;
+    using CBType = callback<std::shared_ptr<Node>>;
+    CBType cb = [&name, &ret](const TKey& key, std::shared_ptr<Node> node) {
+        name.insert(name.end(), key.begin(), key.end());
+        ret.emplace_back(name, node);
+    };
+    find(key, root, cb);
+    return ret;
+}
+
+template <typename TKey, typename TData>
+bool CPrefixTrie<TKey, TData>::erase(const TKey& key)
+{
+    auto size_was = height();
+    if (key.empty()) {
+        root->data = std::make_shared<TData>();
+    } else {
+        erase(key, root);
+    }
+    return size_was != height();
+}
+
+template <typename TKey, typename TData>
+void CPrefixTrie<TKey, TData>::clear()
+{
+    size = 0;
+    root->data = std::make_shared<TData>();
+    root->children.clear();
+}
+
+template <typename TKey, typename TData>
+bool CPrefixTrie<TKey, TData>::empty() const
+{
+    return height() == 0;
+}
+
+template <typename TKey, typename TData>
+std::size_t CPrefixTrie<TKey, TData>::height() const
+{
+    return size + (root->data->empty() ? 0 : 1);
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::begin()
+{
+    return find(TKey());
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::end()
+{
+    return iterator{TKey(), std::shared_ptr<Node>{}};
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::const_iterator CPrefixTrie<TKey, TData>::cbegin()
+{
+    return find(TKey());
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::const_iterator CPrefixTrie<TKey, TData>::cend()
+{
+    return const_iterator{TKey(), std::shared_ptr<Node>{}};
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::const_iterator CPrefixTrie<TKey, TData>::begin() const
+{
+    return find(TKey());
+}
+
+template <typename TKey, typename TData>
+typename CPrefixTrie<TKey, TData>::const_iterator CPrefixTrie<TKey, TData>::end() const
+{
+    return const_iterator{TKey(), std::shared_ptr<Node>{}};
+}
+
+using Key = std::string;
+using Data = CClaimTrieData;
+using Trie = CPrefixTrie<Key, Data>;
+using iterator = Trie::iterator;
+using const_iterator = Trie::const_iterator;
+
+template class CPrefixTrie<Key, Data>;
+
+template class Trie::Iterator<true>;
+template class Trie::Iterator<false>;
+
+template const_iterator& const_iterator::operator=<>(const iterator&) noexcept;
+
+template iterator Trie::insert<>(const Key&, Data&);
+template iterator Trie::insert<>(const Key&, Data&&);
+template iterator Trie::insert<>(const Key&, const Data&);
+template iterator Trie::insert<>(iterator&, const Key&, Data&);
+template iterator Trie::insert<>(iterator&, const Key&, Data&&);
+template iterator Trie::insert<>(iterator&, const Key&, const Data&);

--- a/src/prefixtrie.h
+++ b/src/prefixtrie.h
@@ -1,0 +1,196 @@
+#ifndef BITCOIN_PREFIXTRIE_H
+#define BITCOIN_PREFIXTRIE_H
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+template <typename TKey, typename TData>
+class CPrefixTrie
+{
+    class Node
+    {
+        template <bool>
+        friend class Iterator;
+        friend class CPrefixTrie<TKey, TData>;
+        std::map<TKey, std::shared_ptr<Node>> children;
+
+    public:
+        Node() = default;
+        Node(const Node&) = delete;
+        Node(Node&& o) noexcept = default;
+        Node& operator=(Node&& o) noexcept = default;
+        Node& operator=(const Node&) = delete;
+        std::shared_ptr<TData> data;
+    };
+
+    using TChildren = decltype(Node::children);
+
+    template <bool IsConst>
+    class Iterator
+    {
+        template <bool>
+        friend class Iterator;
+        friend class CPrefixTrie<TKey, TData>;
+
+        using TKeyRef = std::reference_wrapper<const TKey>;
+        using TDataRef = std::reference_wrapper<TData>;
+        using TPair = std::pair<TKeyRef, TDataRef>;
+
+        TKey name;
+        std::weak_ptr<Node> node;
+
+        struct Bookmark {
+            TKey name;
+            std::weak_ptr<Node> parent;
+            typename TChildren::iterator it;
+            typename TChildren::iterator end;
+        };
+
+        std::vector<Bookmark> stack;
+
+    public:
+        // Iterator traits
+        using value_type = TPair;
+        using pointer = typename std::conditional<IsConst, const TData* const, TData* const>::type;
+        using reference = typename std::conditional<IsConst, const TPair, TPair>::type;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        Iterator() = delete;
+        Iterator(const Iterator&) = default;
+        Iterator(Iterator&& o) noexcept = default;
+        Iterator(const TKey& name, const std::shared_ptr<Node>& node) noexcept;
+        template <bool C>
+        inline Iterator(const Iterator<C>& o) noexcept
+        {
+            *this = o;
+        }
+
+        Iterator& operator=(const Iterator&) = default;
+        Iterator& operator=(Iterator&& o) = default;
+        template <bool C>
+        Iterator& operator=(const Iterator<C>& o) noexcept;
+
+        bool hasNext() const;
+        Iterator& operator++();
+        Iterator operator++(int);
+
+        operator bool() const;
+
+        bool operator==(const Iterator& o) const;
+        bool operator!=(const Iterator& o) const;
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        const TKey& key() const;
+
+        TData& data();
+        const TData& data() const;
+
+        std::size_t depth() const;
+
+        bool hasChildren() const;
+        std::vector<Iterator> children() const;
+    };
+
+    size_t size;
+    std::shared_ptr<Node> root;
+
+    template <typename TNode>
+    using callback = std::function<void(const TKey&, TNode)>;
+
+    template <typename TIterator, typename TNode>
+    static TIterator find(const TKey& key, TNode node, TIterator end);
+
+    template <typename TNode>
+    static bool find(const TKey& key, TNode node, const callback<TNode>& cb);
+
+    std::shared_ptr<Node>& insert(const TKey& key, std::shared_ptr<Node>& node);
+    void erase(const TKey& key, std::shared_ptr<Node>& node);
+
+public:
+    using iterator = Iterator<false>;
+    using const_iterator = Iterator<true>;
+
+    CPrefixTrie();
+
+    template <typename TDataUni>
+    iterator insert(const TKey& key, TDataUni&& data);
+    template <typename TDataUni>
+    iterator insert(iterator& it, const TKey& key, TDataUni&& data);
+
+    iterator copy(const_iterator it);
+
+    iterator find(const TKey& key);
+    const_iterator find(const TKey& key) const;
+    iterator find(iterator& it, const TKey& key);
+    const_iterator find(const_iterator& it, const TKey& key) const;
+
+    bool contains(const TKey& key) const;
+
+    TData& at(const TKey& key);
+
+    std::vector<iterator> nodes(const TKey& key) const;
+
+    bool erase(const TKey& key);
+
+    void clear();
+    bool empty() const;
+
+    size_t height() const;
+
+    iterator begin();
+    iterator end();
+
+    const_iterator cbegin();
+    const_iterator cend();
+
+    const_iterator begin() const;
+    const_iterator end() const;
+};
+
+template <typename T, typename O>
+inline bool operator==(const std::reference_wrapper<T>& ref, const O& obj)
+{
+    return ref.get() == obj;
+}
+
+template <typename T, typename O>
+inline bool operator!=(const std::reference_wrapper<T>& ref, const O& obj)
+{
+    return !(ref == obj);
+}
+
+template <typename T>
+inline bool operator==(const std::reference_wrapper<std::shared_ptr<T>>& ref, const T& obj)
+{
+    auto ptr = ref.get();
+    return ptr && *ptr == obj;
+}
+
+template <typename T>
+inline bool operator!=(const std::reference_wrapper<std::shared_ptr<T>>& ref, const T& obj)
+{
+    return !(ref == obj);
+}
+
+template <typename T>
+inline bool operator==(const std::reference_wrapper<std::unique_ptr<T>>& ref, const T& obj)
+{
+    auto ptr = ref.get();
+    return ptr && *ptr == obj;
+}
+
+template <typename T>
+inline bool operator!=(const std::reference_wrapper<std::unique_ptr<T>>& ref, const T& obj)
+{
+    return !(ref == obj);
+}
+
+#endif // BITCOIN_PREFIXTRIE_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -521,7 +521,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:9245/\n";
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -275,7 +275,7 @@ struct StringContentsSerializer {
 
 BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
-    char buf[10];
+    char buf[12];
 
     fs::path ph = SetDataDir("iterator_string_ordering");
     CDBWrapper dbw(ph, (1 << 20), true, false, false);

--- a/src/test/prefixtrie_tests.cpp
+++ b/src/test/prefixtrie_tests.cpp
@@ -1,0 +1,221 @@
+#include <claimtrie.h>
+#include <prefixtrie.h>
+
+#include <boost/test/unit_test.hpp>
+#include <test/test_bitcoin.h>
+
+#include <chrono>
+#include <random>
+
+std::vector<std::string> random_strings(std::size_t count)
+{
+    static auto& chrs = "0123456789"
+                        "abcdefghijklmnopqrstuvwxyz"
+                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    std::mt19937 rg(42);
+    std::uniform_int_distribution<std::string::size_type> pick(1, sizeof(chrs) - 2);
+
+    std::unordered_set<std::string> strings;
+    strings.reserve(count);
+
+    while(strings.size() < count) {
+        auto length = pick(rg);
+
+        std::string s;
+        s.reserve(length);
+
+        while (length--)
+            s += chrs[pick(rg)];
+
+        strings.emplace(s);
+    }
+
+    std::vector<std::string> ret(strings.begin(), strings.end());
+    std::shuffle(ret.begin(), ret.end(), rg);
+    return ret;
+}
+
+using namespace std;
+
+BOOST_FIXTURE_TEST_SUITE(prefixtrie_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(insert_erase_test)
+{
+    CPrefixTrie<std::string, CClaimTrieData> root;
+
+    BOOST_CHECK(root.empty());
+    BOOST_CHECK_EQUAL(root.height(), 0);
+
+    CClaimTrieData data;
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("abc", std::move(data)) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 1);
+
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("abd", std::move(data)) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 3);
+
+    // test expanding on ab
+    BOOST_CHECK(root.find("ab") != root.end());
+
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("a", std::move(data)) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 4);
+
+    // test ab again
+    BOOST_CHECK(root.find("ab") != root.end());
+
+    BOOST_CHECK(root.erase("abd"));
+    BOOST_CHECK(root.find("abd") == root.end());
+    BOOST_CHECK_EQUAL(root.height(), 2);
+
+    // collapsing of ab-c to abc so ab does not present any more
+    BOOST_CHECK(root.find("ab") == root.end());
+
+    // a has children so only data is erased
+    BOOST_CHECK(root.erase("a"));
+    BOOST_CHECK(root.find("a") == root.end());
+
+    // erasing abc will erase all node refers to a
+    BOOST_CHECK(root.erase("abc"));
+    BOOST_CHECK(root.empty());
+    BOOST_CHECK_EQUAL(root.height(), 0);
+    BOOST_CHECK(root.find("a") == root.end());
+    BOOST_CHECK(root.find("ab") == root.end());
+    BOOST_CHECK(root.find("abc") == root.end());
+    BOOST_CHECK(root.find("abd") == root.end());
+}
+
+BOOST_AUTO_TEST_CASE(iterate_test)
+{
+    CPrefixTrie<std::string, CClaimTrieData> root;
+
+    BOOST_CHECK(root.empty());
+    BOOST_CHECK_EQUAL(root.height(), 0);
+
+    BOOST_CHECK(root.insert("abc", CClaimTrieData{}) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 1);
+
+    BOOST_CHECK(root.insert("abd", CClaimTrieData{}) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 3);
+
+    BOOST_CHECK(root.insert("tdb", CClaimTrieData{}) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 4);
+
+    for (auto it = root.begin(); it != root.end(); ++it) {
+        auto& key = it.key();
+        if (key.empty() ||
+            key == "ab" ||
+            key == "abc" ||
+            key == "abd" ||
+            key == "tdb") {
+        } else {
+            BOOST_CHECK(false); // should not happen
+        }
+    }
+
+    auto nodes = root.nodes("abd");
+    BOOST_CHECK_EQUAL(nodes.size(), 3);
+
+    BOOST_CHECK_EQUAL(nodes[0].key(), "");
+    BOOST_CHECK(nodes[0].hasChildren());
+    BOOST_CHECK_EQUAL(nodes[0].children().size(), 2);
+
+    // children of ""
+    for (auto& child : nodes[0].children()) {
+        auto& key = child.key();
+        if (key == "ab" || key == "tdb") {
+        } else {
+            BOOST_CHECK(false); // should not happen
+        }
+    }
+
+    BOOST_CHECK_EQUAL(nodes[1].key(), "ab");
+    BOOST_CHECK(nodes[1].hasChildren());
+    BOOST_CHECK_EQUAL(nodes[1].children().size(), 2);
+
+    // children of "ab"
+    for (auto& child : nodes[1].children()) {
+        auto& key = child.key();
+        if (key == "abc" || key == "abd") {
+        } else {
+            BOOST_CHECK(false); // should not happen
+        }
+    }
+
+    BOOST_CHECK_EQUAL(nodes[2].key(), "abd");
+    BOOST_CHECK(!nodes[2].hasChildren());
+    BOOST_CHECK_EQUAL(nodes[2].children().size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(erase_cleanup_test)
+{
+    CPrefixTrie<std::string, CClaimTrieData> root;
+
+    CClaimTrieData data;
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("a", std::move(data)) != root.end());
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("adata", std::move(data)) != root.end());
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("adata2", std::move(data)) != root.end());
+    data.insertClaim(CClaimValue{});
+    BOOST_CHECK(root.insert("adota", std::move(data)) != root.end());
+    BOOST_CHECK_EQUAL(root.height(), 5);
+    BOOST_CHECK(root.erase("adata"));
+    BOOST_CHECK(root.erase("adata2"));
+    BOOST_CHECK_EQUAL(root.height(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(add_many_nodes) {
+    // this if for testing performance and making sure erasure goes all the way to zero
+    CPrefixTrie<std::string, CClaimTrieData> trie;
+    std::size_t count = 100000; // bump this up to 1M for a better test
+    auto strings = random_strings(count);
+
+    auto s1 = std::chrono::high_resolution_clock::now();
+    for (std::size_t i = 0; i < count; i++) {
+        CClaimTrieData d; d.nHeightOfLastTakeover = i;
+        trie.insert(strings[i], std::move(d));
+    }
+
+    auto s2 = std::chrono::high_resolution_clock::now();
+
+    auto nodes = trie.height();
+    // run with --log_level=message to see these:
+    BOOST_TEST_MESSAGE("Nodes:" + std::to_string(nodes));
+    BOOST_TEST_MESSAGE("Insertion sec: " + std::to_string(std::chrono::duration_cast<std::chrono::duration<float> >(s2 - s1).count()));
+
+    auto s3 = std::chrono::high_resolution_clock::now();
+
+    for (std::size_t i = 0; i < count; i++) {
+        auto& value = trie.at(strings[i]);
+        BOOST_CHECK_EQUAL(value.nHeightOfLastTakeover, i);
+    }
+
+    auto s4 = std::chrono::high_resolution_clock::now();
+    BOOST_TEST_MESSAGE("Lookup sec: " + std::to_string(std::chrono::duration_cast<std::chrono::duration<float> >(s4 - s3).count()));
+
+    auto s5 = std::chrono::high_resolution_clock::now();
+
+    for (std::size_t i = 0; i < count; i++) {
+        auto value = trie.nodes(strings[i]);
+        BOOST_CHECK(!value.empty());
+    }
+
+    auto s6 = std::chrono::high_resolution_clock::now();
+    BOOST_TEST_MESSAGE("Parents sec: " + std::to_string(std::chrono::duration_cast<std::chrono::duration<float> >(s6 - s5).count()));
+
+    auto s7 = std::chrono::high_resolution_clock::now();
+    for (std::size_t i = 0; i < count; i++) {
+        trie.erase(strings[i]);
+    }
+
+    BOOST_CHECK_EQUAL(trie.height(), 0);
+
+    auto s8 = std::chrono::high_resolution_clock::now();
+    BOOST_TEST_MESSAGE("Deletion sec: " + std::to_string(std::chrono::duration_cast<std::chrono::duration<float> >(s8 - s7).count()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -60,9 +60,9 @@ std::ostream& operator<<(std::ostream& os, const COutPoint& point)
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const CClaimTrieNode& node)
+std::ostream& operator<<(std::ostream& os, const CClaimTrieData& data)
 {
-    os << node.hash.ToString();
+    os << data.hash.ToString();
     return os;
 }
 
@@ -74,6 +74,16 @@ std::ostream& operator<<(std::ostream& os, const CClaimValue& claim)
        << ", " << claim.nEffectiveAmount
        << ", " << claim.nHeight
        << ", " << claim.nValidAtHeight << ')';
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CSupportValue& support)
+{
+    os << "support(" << support.outPoint.ToString()
+    << ", " << support.supportedClaimId.ToString()
+    << ", " << support.nAmount
+    << ", " << support.nHeight
+    << ", " << support.nValidAtHeight << ')';
     return os;
 }
 

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -137,7 +137,10 @@ std::ostream& operator<<(std::ostream& os, const COutPoint& point);
 class CClaimValue;
 std::ostream& operator<<(std::ostream& os, const CClaimValue& claim);
 
-class CClaimTrieNode;
-std::ostream& operator<<(std::ostream& os, const CClaimTrieNode& node);
+class CSupportValue;
+std::ostream& operator<<(std::ostream& os, const CSupportValue& support);
+
+class CClaimTrieData;
+std::ostream& operator<<(std::ostream& os, const CClaimTrieData& data);
 
 #endif

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -34,7 +34,7 @@ static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
 //! min. -dbcache (MiB)
 static const int64_t nMinDbCache = 4;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)
-static const int64_t nMaxBlockDBCache = 2;
+static const int64_t nMaxBlockDBCache = 8;
 //! Max memory allocated to block tree DB specific cache, if -txindex (MiB)
 // Unlike for the UTXO database, for the txindex scenario the leveldb cache make
 // a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -35,14 +35,14 @@ class HelpTest(BitcoinTestFramework):
         return out, err
 
     def run_test(self):
-        self.log.info("Start bitcoin with -h for help text")
+        self.log.info("Start lbrycrd with -h for help text")
         self.nodes[0].start(extra_args=['-h'])
         # Node should exit immediately and output help to stdout.
         output, _ = self.get_node_output(ret_code_expected=0)
         assert b'Options' in output
         self.log.info("Help text received: {} (...)".format(output[0:60]))
 
-        self.log.info("Start bitcoin with -version for version information")
+        self.log.info("Start lbrycrd with -version for version information")
         self.nodes[0].start(extra_args=['-version'])
         # Node should exit immediately and output version to stdout.
         output, _ = self.get_node_output(ret_code_expected=0)
@@ -50,7 +50,7 @@ class HelpTest(BitcoinTestFramework):
         self.log.info("Version text received: {} (...)".format(output[0:60]))
 
         # Test that arguments not in the help results in an error
-        self.log.info("Start bitcoind with -fakearg to make sure it does not start")
+        self.log.info("Start lbrycrd with -fakearg to make sure it does not start")
         self.nodes[0].start(extra_args=['-fakearg'])
         # Node should exit immediately and output an error to stderr
         _, output = self.get_node_output(ret_code_expected=1)


### PR DESCRIPTION
This PR addresses the following issues:

Fixes #106 (Reimplement claimtrie without so many empty nodes, save RAM)
Fixes #108 (Separate data structure and data operations)
Fixes #133 (Trie serialization failure)
Fixes #138 (Rename nCurrentHeight)
Fixes #145 (Rename CClaimTrieCache)
Fixes #158 (Properly delete CClaimTrieNode)

It also includes these enhancements:
1. BLOCK_HASH is no longer needlessly stored in the claimtrie DB. I had a theory that this was masking places that we should have been comparing the claimTrieHash, which theory proved correct.
2. An issue with takeover height computation was detected and (temporarily) worked around.
3. cachedTakeoverHeights was removed; we now use the takeoverHeight field on the nodes in the cache.
4. The getQueue* functions now re-use code.
5. effectiveAmount is updated when reading from disk (we should now ensure that it's not being needlessly computed elsewhere).

Although the commits have been squashed, much of this work was done by @bvbfan .

We experimented with keeping empty nodes truly empty -- allocating claim space for them as needed. This saved less than 10MB of RAM and complicated the code a bit; we ditched it. We also experimented with a similar approach where empty node hashes were kept in a separate map. This also was too complicated to get right.