### PR TITLE
[WIP] Unify and extend rpc methods to bid and sequence

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -155,6 +155,7 @@ BITCOIN_CORE_H = \
   reverse_iterator.h \
   reverselock.h \
   rpc/blockchain.h \
+  rpc/claimrpchelp.h \
   rpc/client.h \
   rpc/mining.h \
   rpc/protocol.h \

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -629,6 +629,9 @@ private:
     bool validateTrieConsistency(const CBlockIndex* tip);
 
     template <typename T>
+    void insertRowsFromQueue(std::vector<T>& result, const std::string& name) const;
+
+    template <typename T>
     std::vector<queueEntryType<T>>* getQueueCacheRow(int nHeight, bool createIfNotExists);
 
     template <typename T>

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -348,8 +348,12 @@ struct CClaimSupportToName
 
     const CClaimNsupports& find(const std::string& partialId) const
     {
-        auto it = std::find_if(claimsNsupports.begin(), claimsNsupports.end(), [&partialId](const CClaimNsupports& value) {
-            return value.claim.claimId.GetHex().find(partialId) == 0;
+        std::string lowered(partialId);
+        for (auto& c: lowered)
+            c = std::tolower(c);
+
+        auto it = std::find_if(claimsNsupports.begin(), claimsNsupports.end(), [&lowered](const CClaimNsupports& value) {
+            return value.claim.claimId.GetHex().find(lowered) == 0;
         });
         return it != claimsNsupports.end() ? *it : invalid;
     }

--- a/src/rpc/claimrpchelp.h
+++ b/src/rpc/claimrpchelp.h
@@ -100,7 +100,7 @@ S3("        ", T_AMOUNT, "             (numeric) the amount of the support") \
 S1("    ]") \
 S3("    ", T_LASTTAKEOVERHEIGHT, "     (numeric) the last height at which ownership of the name changed") \
 S3("    ", T_BID, "                    (numeric) lower value means a higher bid rate, ordered by effective amount") \
-S3("    ", T_SEQUENCE, "               (numeric) lower value means latest in sequence, ordered by height of insertion")
+S3("    ", T_SEQUENCE, "               (numeric) lower value means an older one in sequence, ordered by height of insertion")
 
 #define PROOF_OUTPUT \
 S3("    ", T_NODES, ": [               (array of object, pre-fork) full nodes\n" \
@@ -194,7 +194,7 @@ S3("            ", T_VALIDATHEIGHT, "  (numeric) the height at which the support
 S3("            ", T_AMOUNT, "         (numeric) the amount of the support")
 S1("        ]")
 S3("        ", T_BID, "                (numeric) lower value means a higher bid rate, ordered by effective amount")
-S3("        ", T_SEQUENCE, "           (numeric) lower value means latest in sequence, ordered by height of insertion")
+S3("        ", T_SEQUENCE, "           (numeric) lower value means an older one in sequence, ordered by height of insertion")
 S1("    ]")
 S3("    ", T_LASTTAKEOVERHEIGHT, "     (numeric) the last height at which ownership of the name changed")
 S3("    ", T_SUPPORTSWITHOUTCLAIM, ": [")

--- a/src/rpc/claimrpchelp.h
+++ b/src/rpc/claimrpchelp.h
@@ -1,0 +1,290 @@
+
+#include <string>
+
+// always keep defines T_ + value in upper case
+#define T_NORMALIZEDNAME                "normalizedName"
+#define T_BLOCKHASH                     "blockhash"
+#define T_CLAIMS                        "claims"
+#define T_CLAIMID                       "claimId"
+#define T_TXID                          "txId"
+#define T_N                             "n"
+#define T_AMOUNT                        "amount"
+#define T_HEIGHT                        "height"
+#define T_VALUE                         "value"
+#define T_NAME                          "name"
+#define T_VALIDATHEIGHT                 "validAtHeight"
+#define T_NAMES                         "names"
+#define T_EFFECTIVEAMOUNT               "effectiveAmount"
+#define T_LASTTAKEOVERHEIGHT            "lastTakeoverHeight"
+#define T_SUPPORTS                      "supports"
+#define T_SUPPORTSWITHOUTCLAIM          "supportsWithoutClaim"
+#define T_TOTALNAMES                    "totalNames"
+#define T_TOTALCLAIMS                   "totalClaims"
+#define T_TOTALVALUE                    "totalValue"
+#define T_CONTROLLINGONLY               "controllingOnly"
+#define T_CLAIMTYPE                     "claimType"
+#define T_DEPTH                         "depth"
+#define T_INCLAIMTRIE                   "inClaimTrie"
+#define T_ISCONTROLLING                 "isControlling"
+#define T_INSUPPORTMAP                  "inSupportMap"
+#define T_INQUEUE                       "inQueue"
+#define T_BLOCKSTOVALID                 "blocksToValid"
+#define T_NODES                         "nodes"
+#define T_CHILDREN                      "children"
+#define T_CHARACTER                     "character"
+#define T_NODEHASH                      "nodeHash"
+#define T_VALUEHASH                     "valueHash"
+#define T_PAIRS                         "pairs"
+#define T_ODD                           "odd"
+#define T_HASH                          "hash"
+
+enum {
+    GETCLAIMSINTRIE = 0,
+    GETNAMESINTRIE,
+    GETVALUEFORNAME,
+    GETCLAIMSFORNAME,
+    GETCLAIMBYID,
+    GETTOTALCLAIMEDNAMES,
+    GETTOTALCLAIMS,
+    GETTOTALVALUEOFCLAIMS,
+    GETCLAIMSFORTX,
+    GETNAMEPROOF,
+    CHECKNORMALIZATION,
+};
+
+static const char* const rpc_help[] = {
+
+// GETCLAIMSINTRIE
+R"(getclaimsintrie
+Return all claims in the name trie. Deprecated
+Arguments:
+1. ")" T_BLOCKHASH R"("               (string, optional) get claims in the trie
+                                                  at the block specified
+                                                  by this block hash.
+                                                  If none is given,
+                                                  the latest active
+                                                  block will be used.
+Result: [
+    ")" T_NORMALIZEDNAME R"("         (string) the name of the claim(s) (after normalization)
+    ")" T_CLAIMS R"(": [              (array of object) the claims for this name
+        ")" T_NAME R"("               (string) the original name of this claim (before normalization)
+        ")" T_VALUE R"("              (string) the value of this claim
+        ")" T_CLAIMID R"("            (string) the claimId of the claim
+        ")" T_TXID R"("               (string) the txid of the claim
+        ")" T_N R"("                  (numeric) the index of the claim in the transaction's list of outputs
+        ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
+        ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the claim became/becomes valid
+        ")" T_AMOUNT R"("             (numeric) the amount of the claim
+    ]
+])",
+
+// GETNAMESINTRIE
+R"(getnamesintrie
+Return all claim names in the trie.
+Arguments:
+1. ")" T_BLOCKHASH R"("               (string, optional) get claims in the trie
+                                                  at the block specified
+                                                  by this block hash.
+                                                  If none is given,
+                                                  the latest active
+                                                  block will be used.
+Result: [
+    ")" T_NAMES R"("                  all names in the trie that have claims
+])",
+
+// GETVALUEFORNAME
+R"(getvalueforname
+Return the winning or specified by claimId value associated with a name
+Arguments:
+1. ")" T_NAME R"("                    (string) the name to look up
+2. ")" T_BLOCKHASH R"("               (string, optional) get the value
+                                                associated with the name
+                                                at the block specified
+                                                by this block hash.
+                                                If none is given,
+                                                the latest active
+                                                block will be used.
+3. ")" T_CLAIMID R"("                 (string, optional) can be partial one
+Result: [
+    ")" T_NORMALIZEDNAME R"("         (string) the name of the claim(s) (after normalization)
+    ")" T_NAME R"("                   (string) the original name of this claim (before normalization)
+    ")" T_VALUE R"("                  (string) the value of this claim
+    ")" T_CLAIMID R"("                (string) the claimId of the claim
+    ")" T_TXID R"("                   (string) the txid of the claim
+    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
+    ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
+    ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the support became/becomes valid
+    ")" T_AMOUNT R"("                 (numeric) the amount of the claim
+    ")" T_EFFECTIVEAMOUNT R"("        (numeric) the amount plus amount from all supports associated with the claim
+    ")" T_SUPPORTS R"(": [            (array of object) supports for this claim
+        ")" T_VALUE R"("              (string) the metadata of the support if any
+        ")" T_TXID R"("               (string) the txid of the support
+        ")" T_N R"("                  (numeric) the index of the support in the transaction's list of outputs
+        ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
+        ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the support became/becomes valid
+        ")" T_AMOUNT R"("             (numeric) the amount of the support
+    ]
+    ")" T_LASTTAKEOVERHEIGHT R"("     (numeric) the last height at which ownership of the name changed
+])",
+
+// GETCLAIMSFORNAME
+R"(getclaimsforname
+Return all claims and supports for a name
+Arguments:
+1. ")" T_NAME R"("                        (string) the name to look up
+2. ")" T_BLOCKHASH R"("                   (string, optional) get claims in the trie
+                                                    at the block specified
+                                                    by this block hash.
+                                                    If none is given,
+                                                    the latest active
+                                                    block will be used.
+Result: [
+    ")" T_NORMALIZEDNAME R"("             (string) the name of the claim(s) (after normalization)
+    ")" T_CLAIMS R"(": [                  (array of object) the claims for this name
+        ")" T_NAME R"("                   (string) the original name of this claim (before normalization)
+        ")" T_VALUE R"("                  (string) the value of this claim
+        ")" T_CLAIMID R"("                (string) the claimId of the claim
+        ")" T_TXID R"("                   (string) the txid of the claim
+        ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
+        ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
+        ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the claim became/becomes valid
+        ")" T_AMOUNT R"("                 (numeric) the amount of the claim
+        ")" T_EFFECTIVEAMOUNT R"("        (numeric) the amount plus amount from all supports associated with the claim
+        ")" T_SUPPORTS R"(": [            (array of object) supports for this claim
+            ")" T_VALUE R"("              (string) the metadata of the support if any
+            ")" T_TXID R"("               (string) the txid of the support
+            ")" T_N R"("                  (numeric) the index of the support in the transaction's list of outputs
+            ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
+            ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the support became/becomes valid
+            ")" T_AMOUNT R"("             (numeric) the amount of the support
+        ]
+    ]
+    ")" T_LASTTAKEOVERHEIGHT R"("         (numeric) the last height at which ownership of the name changed
+    ")" T_SUPPORTSWITHOUTCLAIM R"(": [
+        ")" T_TXID R"("                   (string) the txid of the support
+        ")" T_N R"("                      (numeric) the index of the support in the transaction's list of outputs
+        ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
+        ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the support became/becomes valid
+        ")" T_AMOUNT R"("                 (numeric) the amount of the support
+    ]
+])",
+
+// GETCLAIMBYID
+R"(getclaimbyid
+Get a claim by claim id
+Arguments:
+1. ")" T_CLAIMID R"("                 (string) the claimId of this claim or patial id (at least 3 chars)
+Result: [
+    ")" T_NORMALIZEDNAME R"("         (string) the name of the claim(s) (after normalization)
+    ")" T_NAME R"("                   (string) the original name of this claim (before normalization)
+    ")" T_VALUE R"("                  (string) the value of this claim
+    ")" T_CLAIMID R"("                (string) the claimId of the claim
+    ")" T_TXID R"("                   (string) the txid of the claim
+    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
+    ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
+    ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the support became/becomes valid
+    ")" T_AMOUNT R"("                 (numeric) the amount of the claim
+    ")" T_EFFECTIVEAMOUNT R"("        (numeric) the amount plus amount from all supports associated with the claim
+    ")" T_SUPPORTS R"(": [            (array of object) supports for this claim
+        ")" T_VALUE R"("              (string) the metadata of the support if any
+        ")" T_TXID R"("               (string) the txid of the support
+        ")" T_N R"("                  (numeric) the index of the support in the transaction's list of outputs
+        ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
+        ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the support became/becomes valid
+        ")" T_AMOUNT R"("             (numeric) the amount of the support
+    ]
+    ")" T_LASTTAKEOVERHEIGHT R"("     (numeric) the last height at which ownership of the name changed
+])",
+
+// GETTOTALCLAIMEDNAMES
+
+R"(gettotalclaimednames
+Return the total number of names that have been
+Arguments:
+Result:
+    ")" T_TOTALNAMES R"("             (numeric) the total number of names in the trie
+)",
+
+// GETTOTALCLAIMS
+R"(gettotalclaims
+Return the total number of active claims in the trie
+Arguments:
+Result:
+    ")" T_TOTALCLAIMS R"("            (numeric) the total number of active claims
+)",
+
+// GETTOTALVALUEOFCLAIMS
+R"(gettotalvalueofclaims
+Return the total value of the claims in the trie
+Arguments:
+1. ")" T_CONTROLLINGONLY R"("         (boolean) only include the value of controlling claims
+Result:
+    ")" T_TOTALVALUE R"("             (numeric) the total value of the claims in the trie
+)",
+
+// GETCLAIMSFORTX
+R"(getclaimsfortx
+Return any claims or supports found in a transaction
+Arguments:
+1.  ")" T_TXID R"("                   (string) the txid of the transaction to check for unspent claims
+Result: [
+    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
+    ")" T_CLAIMTYPE R"("              (string) claim or support
+    ")" T_NAME R"("                   (string) the name claimed or supported
+    ")" T_CLAIMID R"("                (string) if a claim, its ID
+    ")" T_VALUE R"("                  (string) if a claim, its value
+    ")" T_DEPTH R"("                  (numeric) the depth of the transaction in the main chain
+    ")" T_INCLAIMTRIE R"("            (boolean) if a name claim, whether the claim is active, i.e. has made it into the trie
+    ")" T_ISCONTROLLING R"("          (boolean) if a name claim, whether the claim is the current controlling claim for the name
+    ")" T_INSUPPORTMAP R"("           (boolean) if a support, whether the support is active, i.e. has made it into the support map
+    ")" T_INQUEUE R"("                (boolean) whether the claim is in a queue waiting to be inserted into the trie or support map
+    ")" T_BLOCKSTOVALID R"("          (numeric) if in a queue, the number of blocks until it's inserted into the trie or support map
+])",
+
+// GETNAMEPROOF
+R"(getnameproof
+Return the cryptographic proof that a name maps to a value or doesn't.
+Arguments:
+1. ")" T_NAME R"("                    (string) the name to look up
+2. ")" T_BLOCKHASH R"("               (string, optional) get the value
+                                                associated with the name
+                                                at the block specified
+                                                by this block hash.
+                                                If none is given,
+                                                the latest active
+                                                block will be used.
+3. ")" T_CLAIMID R"("                 (string, optional, post-fork) for validating a specific claim
+                                                can be partial one
+Result: [
+    ")" T_NODES R"(": [               (array of object, pre-fork) full nodes
+                                                (i.e. those which lead to the requested name)
+        ")" T_CHILDREN R"(": [        (array of object) the children of the node
+            ")" T_CHARACTER R"("      (string) the character which leads from the parent
+                                                to this child node
+            ")" T_NODEHASH R"("       (string, if exists) the hash of the node if this is a leaf node
+        ]
+        ")" T_VALUEHASH R"("          (string, if exists) the hash of this node's value, if
+                                                it has one. If this is the requested name this
+                                                will not exist whether the node has a value or not
+    ]
+    ")" T_PAIRS R"(": [               (array of pairs, post-fork) hash can be validated by
+                                                hashing claim from the bottom up
+        ")" T_ODD R"("                (boolean) this value goes on the right of hash
+        ")" T_HASH R"("               (string) the hash to be mixed in
+    ]
+    ")" T_TXID R"("                   (string, if exists) the txid of the claim which controls
+                                                this name, if there is one.
+    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
+    ")" T_LASTTAKEOVERHEIGHT R"("     (numeric) the last height at which ownership of the name changed
+])",
+
+// CHECKNORMALIZATION
+R"(checknormalization
+Given an unnormalized name of a claim, return normalized version of it
+Arguments:
+1. ")" T_NAME R"("                    (string) the name to normalize
+Result:
+")" T_NORMALIZEDNAME R"("             (string) normalized name
+)",
+
+};

--- a/src/rpc/claimrpchelp.h
+++ b/src/rpc/claimrpchelp.h
@@ -45,6 +45,7 @@
 #define T_CLAIMSREMOVED                 "claimsRemoved"
 #define T_SUPPORTSREMOVED               "supportsRemoved"
 #define T_ADDRESS                       "address"
+#define T_PENDINGAMOUNT                 "pendingAmount"
 
 enum {
     GETCLAIMSINTRIE = 0,
@@ -89,6 +90,7 @@ S3("    ", T_HEIGHT, "                 (numeric) the height of the block in whic
 S3("    ", T_VALIDATHEIGHT, "          (numeric) the height at which the support became/becomes valid") \
 S3("    ", T_AMOUNT, "                 (numeric) the amount of the claim") \
 S3("    ", T_EFFECTIVEAMOUNT, "        (numeric) the amount plus amount from all supports associated with the claim") \
+S3("    ", T_PENDINGAMOUNT, "          (numeric) expected amount when claim and its support got valid") \
 S3("    ", T_SUPPORTS, ": [            (array of object) supports for this claim") \
 S3("        ", T_VALUE, "              (string) the metadata of the support if any") \
 S3("        ", T_ADDRESS, "            (string) the destination address of the support") \
@@ -184,6 +186,7 @@ S3("        ", T_HEIGHT, "             (numeric) the height of the block in whic
 S3("        ", T_VALIDATHEIGHT, "      (numeric) the height at which the claim became/becomes valid")
 S3("        ", T_AMOUNT, "             (numeric) the amount of the claim")
 S3("        ", T_EFFECTIVEAMOUNT, "    (numeric) the amount plus amount from all supports associated with the claim")
+S3("        ", T_PENDINGAMOUNT, "      (numeric) expected amount when claim and its support got valid")
 S3("        ", T_SUPPORTS, ": [        (array of object) supports for this claim")
 S3("            ", T_VALUE, "          (string) the metadata of the support if any")
 S3("            ", T_ADDRESS, "        (string) the destination address of the support")

--- a/src/rpc/claimrpchelp.h
+++ b/src/rpc/claimrpchelp.h
@@ -1,5 +1,6 @@
 
-#include <string>
+#ifndef CLAIMRPCHELP_H
+#define CLAIMRPCHELP_H
 
 // always keep defines T_ + value in upper case
 #define T_NORMALIZEDNAME                "normalizedName"
@@ -37,6 +38,13 @@
 #define T_PAIRS                         "pairs"
 #define T_ODD                           "odd"
 #define T_HASH                          "hash"
+#define T_BID                           "bid"
+#define T_SEQUENCE                      "sequence"
+#define T_CLAIMSADDEDORUPDATED          "claimsAddedOrUpdated"
+#define T_SUPPORTSADDEDORUPDATED        "supportsAddedOrUpdated"
+#define T_CLAIMSREMOVED                 "claimsRemoved"
+#define T_SUPPORTSREMOVED               "supportsRemoved"
+#define T_ADDRESS                       "address"
 
 enum {
     GETCLAIMSINTRIE = 0,
@@ -50,241 +58,284 @@ enum {
     GETCLAIMSFORTX,
     GETNAMEPROOF,
     CHECKNORMALIZATION,
+    GETCLAIMBYBID,
+    GETCLAIMBYSEQ,
+    GETCLAIMPROOFBYID,
+    GETCLAIMPROOFBYSEQ,
+    GETCHANGESINBLOCK,
 };
+
+#define S3_(pre, name, def) pre "\"" name "\"" def "\n"
+#define S3(pre, name, def) S3_(pre, name, def)
+#define S1(str)  str "\n"
+
+#define NAME_TEXT      "                    (string) the name to look up"
+#define BLOCKHASH_TEXT "               (string, optional) get claims in the trie\n" \
+"                                                  at the block specified\n" \
+"                                                  by this block hash.\n" \
+"                                                  If none is given,\n" \
+"                                                  the latest active\n" \
+"                                                  block will be used."
+
+#define CLAIM_OUTPUT    \
+S3("    ", T_NORMALIZEDNAME, "         (string) the name of the claim (after normalization)") \
+S3("    ", T_NAME, "                   (string) the original name of this claim (before normalization)") \
+S3("    ", T_VALUE, "                  (string) the value of this claim") \
+S3("    ", T_ADDRESS, "                (string) the destination address of this claim") \
+S3("    ", T_CLAIMID, "                (string) the claimId of the claim") \
+S3("    ", T_TXID, "                   (string) the txid of the claim") \
+S3("    ", T_N, "                      (numeric) the index of the claim in the transaction's list of outputs") \
+S3("    ", T_HEIGHT, "                 (numeric) the height of the block in which this transaction is located") \
+S3("    ", T_VALIDATHEIGHT, "          (numeric) the height at which the support became/becomes valid") \
+S3("    ", T_AMOUNT, "                 (numeric) the amount of the claim") \
+S3("    ", T_EFFECTIVEAMOUNT, "        (numeric) the amount plus amount from all supports associated with the claim") \
+S3("    ", T_SUPPORTS, ": [            (array of object) supports for this claim") \
+S3("        ", T_VALUE, "              (string) the metadata of the support if any") \
+S3("        ", T_ADDRESS, "            (string) the destination address of the support") \
+S3("        ", T_TXID, "               (string) the txid of the support") \
+S3("        ", T_N, "                  (numeric) the index of the support in the transaction's list of outputs") \
+S3("        ", T_HEIGHT, "             (numeric) the height of the block in which this transaction is located") \
+S3("        ", T_VALIDATHEIGHT, "      (numeric) the height at which the support became/becomes valid") \
+S3("        ", T_AMOUNT, "             (numeric) the amount of the support") \
+S1("    ]") \
+S3("    ", T_LASTTAKEOVERHEIGHT, "     (numeric) the last height at which ownership of the name changed") \
+S3("    ", T_BID, "                    (numeric) lower value means a higher bid rate, ordered by effective amount") \
+S3("    ", T_SEQUENCE, "               (numeric) lower value means latest in sequence, ordered by height of insertion")
+
+#define PROOF_OUTPUT \
+S3("    ", T_NODES, ": [               (array of object, pre-fork) full nodes\n" \
+"                                                (i.e. those which lead to the requested name)") \
+S3("        ", T_CHILDREN, ": [        (array of object) the children of the node") \
+S3("            ", T_CHARACTER, "      (string) the character which leads from the parent to this child node") \
+S3("            ", T_NODEHASH, "       (string, if exists) the hash of the node if this is a leaf node") \
+S1("        ]") \
+S3("       ", T_VALUEHASH, "           (string, if exists) the hash of this node's value, if" \
+"                                                it has one. If this is the requested name this\n" \
+"                                                will not exist whether the node has a value or not") \
+S1("    ]") \
+S3("    ", T_PAIRS, ": [               (array of pairs, post-fork) hash can be validated by" \
+"                                                hashing claim from the bottom up") \
+S3("        ", T_ODD, "                (boolean) this value goes on the right of hash") \
+S3("        ", T_HASH, "               (string) the hash to be mixed in") \
+S1("    ]") \
+S3("    ", T_TXID, "                   (string, if exists) the txid of the claim which controls" \
+"                                                this name, if there is one.") \
+S3("    ", T_N, "                      (numeric) the index of the claim in the transaction's list of outputs") \
+S3("    ", T_LASTTAKEOVERHEIGHT, "     (numeric) the last height at which ownership of the name changed")
 
 static const char* const rpc_help[] = {
 
 // GETCLAIMSINTRIE
-R"(getclaimsintrie
+S1(R"(getclaimsintrie
 Return all claims in the name trie. Deprecated
-Arguments:
-1. ")" T_BLOCKHASH R"("               (string, optional) get claims in the trie
-                                                  at the block specified
-                                                  by this block hash.
-                                                  If none is given,
-                                                  the latest active
-                                                  block will be used.
-Result: [
-    ")" T_NORMALIZEDNAME R"("         (string) the name of the claim(s) (after normalization)
-    ")" T_CLAIMS R"(": [              (array of object) the claims for this name
-        ")" T_NAME R"("               (string) the original name of this claim (before normalization)
-        ")" T_VALUE R"("              (string) the value of this claim
-        ")" T_CLAIMID R"("            (string) the claimId of the claim
-        ")" T_TXID R"("               (string) the txid of the claim
-        ")" T_N R"("                  (numeric) the index of the claim in the transaction's list of outputs
-        ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
-        ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the claim became/becomes valid
-        ")" T_AMOUNT R"("             (numeric) the amount of the claim
-    ]
-])",
+Arguments:)")
+S3("1. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+S3("    ", T_NORMALIZEDNAME, "         (string) the name of the claim(s) (after normalization)")
+S3("    ", T_CLAIMS, ": [              (array of object) the claims for this name")
+S3("        ", T_NAME, "               (string) the original name of this claim (before normalization)")
+S3("        ", T_VALUE, "              (string) the value of this claim")
+S3("        ", T_ADDRESS, "            (string) the destination address of this claim")
+S3("        ", T_CLAIMID, "            (string) the claimId of the claim")
+S3("        ", T_TXID, "               (string) the txid of the claim")
+S3("        ", T_N, "                  (numeric) the index of the claim in the transaction's list of outputs")
+S3("        ", T_HEIGHT, "             (numeric) the height of the block in which this transaction is located")
+S3("        ", T_VALIDATHEIGHT, "      (numeric) the height at which the claim became/becomes valid")
+S3("        ", T_AMOUNT, "             (numeric) the amount of the claim")
+S1("    ]")
+"]",
 
 // GETNAMESINTRIE
-R"(getnamesintrie
+S1(R"(getnamesintrie
 Return all claim names in the trie.
-Arguments:
-1. ")" T_BLOCKHASH R"("               (string, optional) get claims in the trie
-                                                  at the block specified
-                                                  by this block hash.
-                                                  If none is given,
-                                                  the latest active
-                                                  block will be used.
-Result: [
-    ")" T_NAMES R"("                  all names in the trie that have claims
-])",
+Arguments:)")
+S3("1. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+S3("    ", T_NAMES, "                  all names in the trie that have claims")
+"]",
 
 // GETVALUEFORNAME
-R"(getvalueforname
+S1(R"(getvalueforname
 Return the winning or specified by claimId value associated with a name
-Arguments:
-1. ")" T_NAME R"("                    (string) the name to look up
-2. ")" T_BLOCKHASH R"("               (string, optional) get the value
-                                                associated with the name
-                                                at the block specified
-                                                by this block hash.
-                                                If none is given,
-                                                the latest active
-                                                block will be used.
-3. ")" T_CLAIMID R"("                 (string, optional) can be partial one
-Result: [
-    ")" T_NORMALIZEDNAME R"("         (string) the name of the claim(s) (after normalization)
-    ")" T_NAME R"("                   (string) the original name of this claim (before normalization)
-    ")" T_VALUE R"("                  (string) the value of this claim
-    ")" T_CLAIMID R"("                (string) the claimId of the claim
-    ")" T_TXID R"("                   (string) the txid of the claim
-    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
-    ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
-    ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the support became/becomes valid
-    ")" T_AMOUNT R"("                 (numeric) the amount of the claim
-    ")" T_EFFECTIVEAMOUNT R"("        (numeric) the amount plus amount from all supports associated with the claim
-    ")" T_SUPPORTS R"(": [            (array of object) supports for this claim
-        ")" T_VALUE R"("              (string) the metadata of the support if any
-        ")" T_TXID R"("               (string) the txid of the support
-        ")" T_N R"("                  (numeric) the index of the support in the transaction's list of outputs
-        ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
-        ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the support became/becomes valid
-        ")" T_AMOUNT R"("             (numeric) the amount of the support
-    ]
-    ")" T_LASTTAKEOVERHEIGHT R"("     (numeric) the last height at which ownership of the name changed
-])",
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S3("3. ", T_CLAIMID, "                 (string, optional) can be partial one")
+S1("Result: [")
+CLAIM_OUTPUT
+"]",
 
 // GETCLAIMSFORNAME
-R"(getclaimsforname
+S1(R"(getclaimsforname
 Return all claims and supports for a name
-Arguments:
-1. ")" T_NAME R"("                        (string) the name to look up
-2. ")" T_BLOCKHASH R"("                   (string, optional) get claims in the trie
-                                                    at the block specified
-                                                    by this block hash.
-                                                    If none is given,
-                                                    the latest active
-                                                    block will be used.
-Result: [
-    ")" T_NORMALIZEDNAME R"("             (string) the name of the claim(s) (after normalization)
-    ")" T_CLAIMS R"(": [                  (array of object) the claims for this name
-        ")" T_NAME R"("                   (string) the original name of this claim (before normalization)
-        ")" T_VALUE R"("                  (string) the value of this claim
-        ")" T_CLAIMID R"("                (string) the claimId of the claim
-        ")" T_TXID R"("                   (string) the txid of the claim
-        ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
-        ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
-        ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the claim became/becomes valid
-        ")" T_AMOUNT R"("                 (numeric) the amount of the claim
-        ")" T_EFFECTIVEAMOUNT R"("        (numeric) the amount plus amount from all supports associated with the claim
-        ")" T_SUPPORTS R"(": [            (array of object) supports for this claim
-            ")" T_VALUE R"("              (string) the metadata of the support if any
-            ")" T_TXID R"("               (string) the txid of the support
-            ")" T_N R"("                  (numeric) the index of the support in the transaction's list of outputs
-            ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
-            ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the support became/becomes valid
-            ")" T_AMOUNT R"("             (numeric) the amount of the support
-        ]
-    ]
-    ")" T_LASTTAKEOVERHEIGHT R"("         (numeric) the last height at which ownership of the name changed
-    ")" T_SUPPORTSWITHOUTCLAIM R"(": [
-        ")" T_TXID R"("                   (string) the txid of the support
-        ")" T_N R"("                      (numeric) the index of the support in the transaction's list of outputs
-        ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
-        ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the support became/becomes valid
-        ")" T_AMOUNT R"("                 (numeric) the amount of the support
-    ]
-])",
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+S3("    ", T_NORMALIZEDNAME, "         (string) the name of the claim(s) (after normalization)")
+S3("    ", T_CLAIMS, ": [              (array of object) the claims for this name")
+S3("        ", T_NAME, "               (string) the original name of this claim (before normalization)")
+S3("        ", T_VALUE, "              (string) the value of this claim")
+S3("        ", T_ADDRESS, "            (string) the destination address of this claim")
+S3("        ", T_CLAIMID, "            (string) the claimId of the claim")
+S3("        ", T_TXID, "               (string) the txid of the claim")
+S3("        ", T_N, "                  (numeric) the index of the claim in the transaction's list of outputs")
+S3("        ", T_HEIGHT, "             (numeric) the height of the block in which this transaction is located")
+S3("        ", T_VALIDATHEIGHT, "      (numeric) the height at which the claim became/becomes valid")
+S3("        ", T_AMOUNT, "             (numeric) the amount of the claim")
+S3("        ", T_EFFECTIVEAMOUNT, "    (numeric) the amount plus amount from all supports associated with the claim")
+S3("        ", T_SUPPORTS, ": [        (array of object) supports for this claim")
+S3("            ", T_VALUE, "          (string) the metadata of the support if any")
+S3("            ", T_ADDRESS, "        (string) the destination address of the support")
+S3("            ", T_TXID, "           (string) the txid of the support")
+S3("            ", T_N, "              (numeric) the index of the support in the transaction's list of outputs")
+S3("            ", T_HEIGHT, "         (numeric) the height of the block in which this transaction is located")
+S3("            ", T_VALIDATHEIGHT, "  (numeric) the height at which the support became/becomes valid")
+S3("            ", T_AMOUNT, "         (numeric) the amount of the support")
+S1("        ]")
+S3("        ", T_BID, "                (numeric) lower value means a higher bid rate, ordered by effective amount")
+S3("        ", T_SEQUENCE, "           (numeric) lower value means latest in sequence, ordered by height of insertion")
+S1("    ]")
+S3("    ", T_LASTTAKEOVERHEIGHT, "     (numeric) the last height at which ownership of the name changed")
+S3("    ", T_SUPPORTSWITHOUTCLAIM, ": [")
+S3("        ", T_TXID, "               (string) the txid of the support")
+S3("        ", T_N, "                  (numeric) the index of the support in the transaction's list of outputs")
+S3("        ", T_HEIGHT, "             (numeric) the height of the block in which this transaction is located")
+S3("        ", T_VALIDATHEIGHT, "      (numeric) the height at which the support became/becomes valid")
+S3("        ", T_AMOUNT, "             (numeric) the amount of the support")
+S1("    ]")
+"]",
 
 // GETCLAIMBYID
-R"(getclaimbyid
+S1(R"(getclaimbyid
 Get a claim by claim id
-Arguments:
-1. ")" T_CLAIMID R"("                 (string) the claimId of this claim or patial id (at least 3 chars)
-Result: [
-    ")" T_NORMALIZEDNAME R"("         (string) the name of the claim(s) (after normalization)
-    ")" T_NAME R"("                   (string) the original name of this claim (before normalization)
-    ")" T_VALUE R"("                  (string) the value of this claim
-    ")" T_CLAIMID R"("                (string) the claimId of the claim
-    ")" T_TXID R"("                   (string) the txid of the claim
-    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
-    ")" T_HEIGHT R"("                 (numeric) the height of the block in which this transaction is located
-    ")" T_VALIDATHEIGHT R"("          (numeric) the height at which the support became/becomes valid
-    ")" T_AMOUNT R"("                 (numeric) the amount of the claim
-    ")" T_EFFECTIVEAMOUNT R"("        (numeric) the amount plus amount from all supports associated with the claim
-    ")" T_SUPPORTS R"(": [            (array of object) supports for this claim
-        ")" T_VALUE R"("              (string) the metadata of the support if any
-        ")" T_TXID R"("               (string) the txid of the support
-        ")" T_N R"("                  (numeric) the index of the support in the transaction's list of outputs
-        ")" T_HEIGHT R"("             (numeric) the height of the block in which this transaction is located
-        ")" T_VALIDATHEIGHT R"("      (numeric) the height at which the support became/becomes valid
-        ")" T_AMOUNT R"("             (numeric) the amount of the support
-    ]
-    ")" T_LASTTAKEOVERHEIGHT R"("     (numeric) the last height at which ownership of the name changed
-])",
+Arguments:)")
+S3("1. ", T_CLAIMID, "                 (string) the claimId of this claim or patial id (at least 3 chars)")
+S1("Result: [")
+CLAIM_OUTPUT
+"]",
 
 // GETTOTALCLAIMEDNAMES
-
-R"(gettotalclaimednames
+S1(R"(gettotalclaimednames
 Return the total number of names that have been
-Arguments:
-Result:
-    ")" T_TOTALNAMES R"("             (numeric) the total number of names in the trie
-)",
+Arguments:)")
+S1("Result:")
+S3("    ", T_TOTALNAMES, "             (numeric) the total number of names in the trie")
+,
 
 // GETTOTALCLAIMS
-R"(gettotalclaims
+S1(R"(gettotalclaims
 Return the total number of active claims in the trie
-Arguments:
-Result:
-    ")" T_TOTALCLAIMS R"("            (numeric) the total number of active claims
-)",
+Arguments:)")
+S1("Result:")
+S3("    ", T_TOTALCLAIMS, "            (numeric) the total number of active claims")
+,
 
 // GETTOTALVALUEOFCLAIMS
-R"(gettotalvalueofclaims
+S1(R"(gettotalvalueofclaims
 Return the total value of the claims in the trie
-Arguments:
-1. ")" T_CONTROLLINGONLY R"("         (boolean) only include the value of controlling claims
-Result:
-    ")" T_TOTALVALUE R"("             (numeric) the total value of the claims in the trie
-)",
+Arguments:)")
+S3("1. ", T_CONTROLLINGONLY, "         (boolean) only include the value of controlling claims")
+S1("Result:")
+S3("    ", T_TOTALVALUE, "             (numeric) the total value of the claims in the trie")
+,
 
 // GETCLAIMSFORTX
-R"(getclaimsfortx
+S1(R"(getclaimsfortx
 Return any claims or supports found in a transaction
-Arguments:
-1.  ")" T_TXID R"("                   (string) the txid of the transaction to check for unspent claims
-Result: [
-    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
-    ")" T_CLAIMTYPE R"("              (string) claim or support
-    ")" T_NAME R"("                   (string) the name claimed or supported
-    ")" T_CLAIMID R"("                (string) if a claim, its ID
-    ")" T_VALUE R"("                  (string) if a claim, its value
-    ")" T_DEPTH R"("                  (numeric) the depth of the transaction in the main chain
-    ")" T_INCLAIMTRIE R"("            (boolean) if a name claim, whether the claim is active, i.e. has made it into the trie
-    ")" T_ISCONTROLLING R"("          (boolean) if a name claim, whether the claim is the current controlling claim for the name
-    ")" T_INSUPPORTMAP R"("           (boolean) if a support, whether the support is active, i.e. has made it into the support map
-    ")" T_INQUEUE R"("                (boolean) whether the claim is in a queue waiting to be inserted into the trie or support map
-    ")" T_BLOCKSTOVALID R"("          (numeric) if in a queue, the number of blocks until it's inserted into the trie or support map
-])",
+Arguments:)")
+S3("1.  ", T_TXID, "                   (string) the txid of the transaction to check for unspent claims")
+S1("Result: [")
+S3("    ", T_N, "                      (numeric) the index of the claim in the transaction's list of outputs")
+S3("    ", T_CLAIMTYPE, "              (string) claim or support")
+S3("    ", T_NAME, "                   (string) the name claimed or supported")
+S3("    ", T_CLAIMID, "                (string) if a claim, its ID")
+S3("    ", T_VALUE, "                  (string) if a claim, its value")
+S3("    ", T_DEPTH, "                  (numeric) the depth of the transaction in the main chain")
+S3("    ", T_INCLAIMTRIE, "            (boolean) if a name claim, whether the claim is active, i.e. has made it into the trie")
+S3("    ", T_ISCONTROLLING, "          (boolean) if a name claim, whether the claim is the current controlling claim for the name")
+S3("    ", T_INSUPPORTMAP, "           (boolean) if a support, whether the support is active, i.e. has made it into the support map")
+S3("    ", T_INQUEUE, "                (boolean) whether the claim is in a queue waiting to be inserted into the trie or support map")
+S3("    ", T_BLOCKSTOVALID, "          (numeric) if in a queue, the number of blocks until it's inserted into the trie or support map")
+"]",
 
 // GETNAMEPROOF
-R"(getnameproof
+S1(R"(getnameproof
 Return the cryptographic proof that a name maps to a value or doesn't.
-Arguments:
-1. ")" T_NAME R"("                    (string) the name to look up
-2. ")" T_BLOCKHASH R"("               (string, optional) get the value
-                                                associated with the name
-                                                at the block specified
-                                                by this block hash.
-                                                If none is given,
-                                                the latest active
-                                                block will be used.
-3. ")" T_CLAIMID R"("                 (string, optional, post-fork) for validating a specific claim
-                                                can be partial one
-Result: [
-    ")" T_NODES R"(": [               (array of object, pre-fork) full nodes
-                                                (i.e. those which lead to the requested name)
-        ")" T_CHILDREN R"(": [        (array of object) the children of the node
-            ")" T_CHARACTER R"("      (string) the character which leads from the parent
-                                                to this child node
-            ")" T_NODEHASH R"("       (string, if exists) the hash of the node if this is a leaf node
-        ]
-        ")" T_VALUEHASH R"("          (string, if exists) the hash of this node's value, if
-                                                it has one. If this is the requested name this
-                                                will not exist whether the node has a value or not
-    ]
-    ")" T_PAIRS R"(": [               (array of pairs, post-fork) hash can be validated by
-                                                hashing claim from the bottom up
-        ")" T_ODD R"("                (boolean) this value goes on the right of hash
-        ")" T_HASH R"("               (string) the hash to be mixed in
-    ]
-    ")" T_TXID R"("                   (string, if exists) the txid of the claim which controls
-                                                this name, if there is one.
-    ")" T_N R"("                      (numeric) the index of the claim in the transaction's list of outputs
-    ")" T_LASTTAKEOVERHEIGHT R"("     (numeric) the last height at which ownership of the name changed
-])",
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S3("3. ", T_CLAIMID, R"(                 (string, optional, post-fork) for validating a specific claim
+                                                can be partial one)")
+S1("Result: [")
+PROOF_OUTPUT
+"]",
 
 // CHECKNORMALIZATION
-R"(checknormalization
+S1(R"(checknormalization
 Given an unnormalized name of a claim, return normalized version of it
-Arguments:
-1. ")" T_NAME R"("                    (string) the name to normalize
-Result:
-")" T_NORMALIZEDNAME R"("             (string) normalized name
-)",
+Arguments:)")
+S3("1. ", T_NAME, "                    (string) the name to normalize")
+S1("Result:")
+S3("    ", T_NORMALIZEDNAME,  "        (string) normalized name")
+,
+
+// GETCLAIMBYBID
+S1(R"(getclaimbybid
+Get a claim by bid
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_BID, "                     (numeric) bid number")
+S3("3. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+CLAIM_OUTPUT
+"]",
+
+// GETCLAIMBYSEQ
+S1(R"(getclaimbyseq
+Get a claim by sequence
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_SEQUENCE, "                (numeric) sequence number")
+S3("3. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+CLAIM_OUTPUT
+"]",
+
+// GETCLAIMPROOFBYID
+S1(R"(getclaimproofbyid
+Return the cryptographic proof that a name maps to a value or doesn't by a bid.
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_BID, "                     (numeric) bid number")
+S3("3. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+PROOF_OUTPUT
+"]",
+
+// GETCLAIMPROOFBYSEQ
+S1(R"(getclaimproofbyseq
+Return the cryptographic proof that a name maps to a value or doesn't by a sequence.
+Arguments:)")
+S3("1. ", T_NAME, NAME_TEXT)
+S3("2. ", T_SEQUENCE, "                (numeric) sequence number")
+S3("3. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+PROOF_OUTPUT
+"]",
+
+// GETCHANGESINBLOCK
+S1(R"(getchangesinblock
+Return the list of claims added, updated, and removed in a block or doesn't."
+Arguments:)")
+S3("1. ", T_BLOCKHASH, BLOCKHASH_TEXT)
+S1("Result: [")
+S3("    ", T_CLAIMSADDEDORUPDATED, "   (array of string) claimIDs added or updated in the trie")
+S3("    ", T_CLAIMSREMOVED, "          (array of string) claimIDs that were removed from the trie")
+S3("    ", T_SUPPORTSADDEDORUPDATED, " (array of string) IDs of supports added or updated")
+S3("    ", T_SUPPORTSREMOVED, "        (array of string) IDs that were removed from the trie")
+"]",
 
 };
+
+#endif // CLAIMRPCHELP_H

--- a/src/rpc/claimrpchelp.h
+++ b/src/rpc/claimrpchelp.h
@@ -61,7 +61,7 @@ enum {
     CHECKNORMALIZATION,
     GETCLAIMBYBID,
     GETCLAIMBYSEQ,
-    GETCLAIMPROOFBYID,
+    GETCLAIMPROOFBYBID,
     GETCLAIMPROOFBYSEQ,
     GETCHANGESINBLOCK,
 };
@@ -90,7 +90,7 @@ S3("    ", T_HEIGHT, "                 (numeric) the height of the block in whic
 S3("    ", T_VALIDATHEIGHT, "          (numeric) the height at which the support became/becomes valid") \
 S3("    ", T_AMOUNT, "                 (numeric) the amount of the claim") \
 S3("    ", T_EFFECTIVEAMOUNT, "        (numeric) the amount plus amount from all supports associated with the claim") \
-S3("    ", T_PENDINGAMOUNT, "          (numeric) expected amount when claim and its support got valid") \
+S3("    ", T_PENDINGAMOUNT, "          (numeric) expected amount when claim and its supports are all valid") \
 S3("    ", T_SUPPORTS, ": [            (array of object) supports for this claim") \
 S3("        ", T_VALUE, "              (string) the metadata of the support if any") \
 S3("        ", T_ADDRESS, "            (string) the destination address of the support") \
@@ -305,7 +305,7 @@ S1("Result: [")
 CLAIM_OUTPUT
 "]",
 
-// GETCLAIMPROOFBYID
+// GETCLAIMPROOFBYBID
 S1(R"(getclaimproofbyid
 Return the cryptographic proof that a name maps to a value or doesn't by a bid.
 Arguments:)")
@@ -329,7 +329,8 @@ PROOF_OUTPUT
 
 // GETCHANGESINBLOCK
 S1(R"(getchangesinblock
-Return the list of claims added, updated, and removed in a block or doesn't."
+Return the list of claims added, updated, and removed as pulled from the queued work for that block."
+Use this method to determine which claims or supports went live on a given block."
 Arguments:)")
 S3("1. ", T_BLOCKHASH, BLOCKHASH_TEXT)
 S1("Result: [")

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -3,6 +3,7 @@
 #include <core_io.h>
 #include <logging.h>
 #include <nameclaim.h>
+#include <rpc/claimrpchelp.h>
 #include <rpc/server.h>
 #include <shutdown.h>
 #include <txdb.h>
@@ -24,6 +25,8 @@ void ParseClaimtrieId(const UniValue& v, std::string& partialId, uint160& claimI
         strHex = v.get_str();
     if (!IsHex(strHex))
         throw JSONRPCError(RPC_INVALID_PARAMETER, strName + " must be a hexadecimal string");
+    if (strHex.length() > claimIdHexLength)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strName + " must be max 20-character hexadecimal string");
     if (strHex.length() == claimIdHexLength)
         claimId.SetHex(strHex);
     else
@@ -173,18 +176,18 @@ UniValue claimToJSON(const CCoinsViewCache& coinsCache, const CClaimValue& claim
 
     std::string targetName;
     if (getClaimById(claim.claimId, targetName))
-        result.pushKV("name", escapeNonUtf8(targetName));
+        result.pushKV(T_NAME, escapeNonUtf8(targetName));
 
     std::string sValue;
     if (getValueForOutPoint(coinsCache, claim.outPoint, sValue))
-        result.pushKV("value", sValue);
+        result.pushKV(T_VALUE, sValue);
 
-    result.pushKV("claimId", claim.claimId.GetHex());
-    result.pushKV("txId", claim.outPoint.hash.GetHex());
-    result.pushKV("n", (int)claim.outPoint.n);
-    result.pushKV("height", claim.nHeight);
-    result.pushKV("validAtHeight", claim.nValidAtHeight);
-    result.pushKV("amount", claim.nAmount);
+    result.pushKV(T_CLAIMID, claim.claimId.GetHex());
+    result.pushKV(T_TXID, claim.outPoint.hash.GetHex());
+    result.pushKV(T_N, (int)claim.outPoint.n);
+    result.pushKV(T_HEIGHT, claim.nHeight);
+    result.pushKV(T_VALIDATHEIGHT, claim.nValidAtHeight);
+    result.pushKV(T_AMOUNT, claim.nAmount);
 
     return result;
 }
@@ -195,13 +198,13 @@ UniValue supportToJSON(const CCoinsViewCache& coinsCache, const CSupportValue& s
 
     std::string value;
     if (getValueForOutPoint(coinsCache, support.outPoint, value))
-        ret.pushKV("value", value);
+        ret.pushKV(T_VALUE, value);
 
-    ret.pushKV("txId", support.outPoint.hash.GetHex());
-    ret.pushKV("n", (int)support.outPoint.n);
-    ret.pushKV("height", support.nHeight);
-    ret.pushKV("validAtHeight", support.nValidAtHeight);
-    ret.pushKV("amount", support.nAmount);
+    ret.pushKV(T_TXID, support.outPoint.hash.GetHex());
+    ret.pushKV(T_N, (int)support.outPoint.n);
+    ret.pushKV(T_HEIGHT, support.nHeight);
+    ret.pushKV(T_VALIDATHEIGHT, support.nValidAtHeight);
+    ret.pushKV(T_AMOUNT, support.nAmount);
 
     return ret;
 }
@@ -212,17 +215,14 @@ UniValue claimAndSupportsToJSON(const CCoinsViewCache& coinsCache, const CClaimN
     auto& supports = claimNsupports.supports;
 
     auto result = claimToJSON(coinsCache, claim);
-    result.pushKV("effectiveAmount", claimNsupports.effectiveAmount);
-
-    if (claim.nEffectiveAmount > claimNsupports.effectiveAmount)
-        result.pushKV("pendingEffectiveAmount", claim.nEffectiveAmount);
+    result.pushKV(T_EFFECTIVEAMOUNT, claimNsupports.effectiveAmount);
 
     UniValue supportObjs(UniValue::VARR);
     for (auto& support : supports)
         supportObjs.push_back(supportToJSON(coinsCache, support));
 
     if (!supportObjs.empty())
-        result.pushKV("supports", supportObjs);
+        result.pushKV(T_SUPPORTS, supportObjs);
 
     return result;
 }
@@ -233,48 +233,25 @@ bool validParams(const UniValue& params, uint8_t required, uint8_t optional)
     return count >= required && count <= required + optional;
 }
 
+void validateRequest(const JSONRPCRequest& request, int findex, uint8_t required, uint8_t optional)
+{
+    if (request.fHelp || !validParams(request.params, required, optional))
+        throw std::runtime_error(rpc_help[findex]);
+}
+
 static UniValue getclaimsintrie(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() > 1)
-        throw std::runtime_error(
-            "getclaimsintrie\n"
-            "Return all claims in the name trie. Deprecated.\n"
-            "Arguments:\n"
-            "1. \"blockhash\"     (string, optional) get claims in the trie\n"
-            "                                        at the block specified\n"
-            "                                        by this block hash.\n"
-            "                                        If none is given,\n"
-            "                                        the latest active\n"
-            "                                        block will be used.\n"
-            "Result: \n"
-            "[\n"
-            "  {\n"
-            "    \"normalized_name\"    (string) the name of these claims (after normalization)\n"
-            "    \"claims\": [          (array of object) the claims for this name\n"
-            "      {\n"
-            "        \"claimId\"        (string) the claimId of the claim\n"
-            "        \"txid\"           (string) the txid of the claim\n"
-            "        \"n\"              (numeric) the vout value of the claim\n"
-            "        \"amount\"         (numeric) txout amount\n"
-            "        \"height\"         (numeric) the height of the block in which this transaction is located\n"
-            "        \"value\"          (string) the value of this claim\n"
-            "        \"name\"           (string) the original name of this claim (before normalization)\n"
-            "      }\n"
-            "    ]\n"
-            "  }\n"
-            "]\n");
+    validateRequest(request, GETCLAIMSINTRIE, 0, 1);
 
     if (!IsDeprecatedRPCEnabled("getclaimsintrie")) {
         const auto msg = "getclaimsintrie is deprecated and will be removed in v0.18. To use this command, start with -deprecatedrpc=getclaimsintrie";
-        if (request.fHelp) {
+        if (request.fHelp)
             throw std::runtime_error(msg);
-        }
         throw JSONRPCError(RPC_METHOD_DEPRECATED, msg);
     }
 
     UniValue ret(UniValue::VARR);
     LOCK(cs_main);
-
     CCoinsViewCache coinsCache(pcoinsTip.get());
     CClaimTrieCache trieCache(pclaimTrie);
 
@@ -297,8 +274,8 @@ static UniValue getclaimsintrie(const JSONRPCRequest& request)
             claims.push_back(claimToJSON(coinsCache, claim));
 
         UniValue nodeObj(UniValue::VOBJ);
-        nodeObj.pushKV("normalized_name", escapeNonUtf8(name));
-        nodeObj.pushKV("claims", claims);
+        nodeObj.pushKV(T_NORMALIZEDNAME, escapeNonUtf8(name));
+        nodeObj.pushKV(T_CLAIMS, claims);
         ret.push_back(nodeObj);
     });
     return ret;
@@ -312,22 +289,9 @@ static UniValue getclaimtrie(const JSONRPCRequest& request)
 
 static UniValue getnamesintrie(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 0, 1))
-        throw std::runtime_error(
-            "getnamesintrie\n"
-            "Return all claim names in the trie.\n"
-            "Arguments:\n"
-            "1. \"blockhash\"     (string, optional) get claims in the trie\n"
-            "                                        at the block specified\n"
-            "                                        by this block hash.\n"
-            "                                        If none is given,\n"
-            "                                        the latest active\n"
-            "                                        block will be used.\n"
-            "Result: \n"
-            "\"names\"            (array) all names in the trie that have claims\n");
+    validateRequest(request, GETNAMESINTRIE, 0, 1);
 
     LOCK(cs_main);
-
     CCoinsViewCache coinsCache(pcoinsTip.get());
     CClaimTrieCache trieCache(pclaimTrie);
 
@@ -351,32 +315,9 @@ static UniValue getnamesintrie(const JSONRPCRequest& request)
 
 static UniValue getvalueforname(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 1, 2))
-        throw std::runtime_error(
-            "getvalueforname \"name\"\n"
-            "Return the winning or specified by claimId value associated with a name\n"
-            "Arguments:\n"
-            "1. \"name\"          (string) the name to look up\n"
-            "2. \"blockhash\"     (string, optional) get the value\n"
-            "                                        associated with the name\n"
-            "                                        at the block specified\n"
-            "                                        by this block hash.\n"
-            "                                        If none is given,\n"
-            "                                        the latest active\n"
-            "                                        block will be used.\n"
-            "3. \"claimId\"       (string, optional) can be partial one\n"
-            "Result: \n"
-            "\"value\"            (string) the value of the name, if it exists\n"
-            "\"claimId\"          (string) the claimId for this name claim\n"
-            "\"txid\"             (string) the hash of the transaction which successfully claimed the name\n"
-            "\"n\"                (numeric) vout value\n"
-            "\"amount\"           (numeric) txout amount\n"
-            "\"effective amount\" (numeric) txout amount plus amount from all supports associated with the claim\n"
-            "\"height\"           (numeric) the height of the block in which this transaction is located\n"
-            "\"name\"             (string) the original name of this claim (before normalization)\n");
+    validateRequest(request, GETVALUEFORNAME, 1, 2);
 
     LOCK(cs_main);
-
     CCoinsViewCache coinsCache(pcoinsTip.get());
     CClaimTrieCache trieCache(pclaimTrie);
 
@@ -404,65 +345,18 @@ static UniValue getvalueforname(const JSONRPCRequest& request)
     if (claimNsupports.IsNull())
         return ret;
 
-    ret.pushKV("normalizedName", escapeNonUtf8(res.name));
+    ret.pushKV(T_NORMALIZEDNAME, escapeNonUtf8(res.name));
     ret.pushKVs(claimAndSupportsToJSON(coinsCache, claimNsupports));
-    ret.pushKV("lastTakeoverHeight", res.nLastTakeoverHeight);
+    ret.pushKV(T_LASTTAKEOVERHEIGHT, res.nLastTakeoverHeight);
 
     return ret;
 }
 
 UniValue getclaimsforname(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 1, 1))
-        throw std::runtime_error(
-            "getclaimsforname\n"
-            "Return all claims and supports for a name\n"
-            "Arguments: \n"
-            "1.  \"name\"         (string) the name for which to get claims and supports\n"
-            "2.  \"blockhash\"    (string, optional) get claims for name\n"
-            "                                        at the block specified\n"
-            "                                        by this block hash.\n"
-            "                                        If none is given,\n"
-            "                                        the latest active\n"
-            "                                        block will be used.\n"
-            "Result:\n"
-            "{\n"
-            "  \"nLastTakeoverHeight\" (numeric) the last height at which ownership of the name changed\n"
-            "  \"normalized_name\"     (string) the name of these claims after normalization\n"
-            "  \"claims\": [      (array of object) claims for this name\n"
-            "    {\n"
-            "      \"claimId\"    (string) the claimId of this claim\n"
-            "      \"txid\"       (string) the txid of this claim\n"
-            "      \"n\"          (numeric) the index of the claim in the transaction's list of outputs\n"
-            "      \"nHeight\"    (numeric) the height at which the claim was included in the blockchain\n"
-            "      \"nValidAtHeight\" (numeric) the height at which the claim became/becomes valid\n"
-            "      \"nAmount\"    (numeric) the amount of the claim\n"
-            "      \"value\"      (string) the metadata of the claim\n"
-            "      \"nEffectiveAmount\" (numeric) the total effective amount of the claim, taking into effect whether the claim or support has reached its nValidAtHeight\n"
-            "      \"supports\" : [ (array of object) supports for this claim\n"
-            "        \"txid\"     (string) the txid of the support\n"
-            "        \"n\"        (numeric) the index of the support in the transaction's list of outputs\n"
-            "        \"nHeight\"  (numeric) the height at which the support was included in the blockchain\n"
-            "        \"nValidAtHeight\" (numeric) the height at which the support became/becomes valid\n"
-            "        \"nAmount\"  (numeric) the amount of the support\n"
-            "        \"value\"    (string) the metadata of the support if any\n"
-            "      ]\n"
-            "      \"name\"       (string) the original name of this claim before normalization\n"
-            "    }\n"
-            "  ],\n"
-            "  \"supports without claims\": [ (array of object) supports that did not match a claim for this name\n"
-            "    {\n"
-            "      \"txid\"     (string) the txid of the support\n"
-            "      \"n\"        (numeric) the index of the support in the transaction's list of outputs\n"
-            "      \"nHeight\"  (numeric) the height at which the support was included in the blockchain\n"
-            "      \"nValidAtHeight\" (numeric) the height at which the support became/becomes valid\n"
-            "      \"nAmount\"  (numeric) the amount of the support\n"
-            "    }\n"
-            "  ]\n"
-            "}\n");
+    validateRequest(request, GETCLAIMSFORNAME, 1, 1);
 
     LOCK(cs_main);
-
     CCoinsViewCache coinsCache(pcoinsTip.get());
     CClaimTrieCache trieCache(pclaimTrie);
 
@@ -475,7 +369,7 @@ UniValue getclaimsforname(const JSONRPCRequest& request)
     auto claimsForName = trieCache.getClaimsForName(name);
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("normalized_name", escapeNonUtf8(claimsForName.name));
+    result.pushKV(T_NORMALIZEDNAME, escapeNonUtf8(claimsForName.name));
 
     UniValue claimObjs(UniValue::VARR);
     for (auto& claim : claimsForName.claimsNsupports)
@@ -485,42 +379,15 @@ UniValue getclaimsforname(const JSONRPCRequest& request)
     for (auto& support : claimsForName.unmatchedSupports)
         unmatchedSupports.push_back(supportToJSON(coinsCache, support));
 
-    result.pushKV("claims", claimObjs);
-    result.pushKV("lastTakeoverHeight", claimsForName.nLastTakeoverHeight);
-    result.pushKV("supportsWithoutClaims", unmatchedSupports);
+    result.pushKV(T_CLAIMS, claimObjs);
+    result.pushKV(T_LASTTAKEOVERHEIGHT, claimsForName.nLastTakeoverHeight);
+    result.pushKV(T_SUPPORTSWITHOUTCLAIM, unmatchedSupports);
     return result;
 }
 
 UniValue getclaimbyid(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 1, 0))
-        throw std::runtime_error(
-            "getclaimbyid\n"
-            "Get a claim by claim id\n"
-            "Arguments: \n"
-            "1.  \"claimId\"           (string) the claimId of this claim or patial id (at least 3 chars)\n"
-            "Result:\n"
-            "{\n"
-            "  \"name\"                (string) the original name of the claim (before normalization)\n"
-            "  \"normalized_name\"     (string) the name of this claim (after normalization)\n"
-            "  \"value\"               (string) metadata of the claim\n"
-            "  \"claimId\"             (string) the claimId of this claim\n"
-            "  \"txid\"                (string) the hash of the transaction which has successfully claimed this name\n"
-            "  \"n\"                   (numeric) vout value\n"
-            "  \"amount\"              (numeric) txout value\n"
-            "  \"effective amount\"    (numeric) txout amount plus amount from all supports associated with the claim\n"
-            "  \"supports\"            (array of object) supports for this claim\n"
-            "  [\n"
-            "    \"txid\"              (string) the txid of the support\n"
-            "    \"n\"                 (numeric) the index of the support in the transaction's list of outputs\n"
-            "    \"height\"            (numeric) the height at which the support was included in the blockchain\n"
-            "    \"valid at height\"   (numeric) the height at which the support is valid\n"
-            "    \"amount\"            (numeric) the amount of the support\n"
-            "    \"value\"             (string) the metadata of the support if any\n"
-            "  ]\n"
-            "  \"height\"              (numeric) the height of the block in which this claim transaction is located\n"
-            "  \"valid at height\"     (numeric) the height at which the claim is valid\n"
-            "}\n");
+    validateRequest(request, GETCLAIMBYID, 1, 0);
 
     LOCK(cs_main);
     CClaimTrieCache trieCache(pclaimTrie);
@@ -540,9 +407,9 @@ UniValue getclaimbyid(const JSONRPCRequest& request)
         auto res = trieCache.getClaimsForName(name);
         auto& claimNsupports = !claimId.IsNull() ? res.find(claimId) : res.find(partialId);
         if (!claimNsupports.IsNull()) {
-            claim.pushKV("normalizedName", escapeNonUtf8(res.name));
+            claim.pushKV(T_NORMALIZEDNAME, escapeNonUtf8(res.name));
             claim.pushKVs(claimAndSupportsToJSON(coinsCache, claimNsupports));
-            claim.pushKV("lastTakeoverHeight", res.nLastTakeoverHeight);
+            claim.pushKV(T_LASTTAKEOVERHEIGHT, res.nLastTakeoverHeight);
         }
     }
     return claim;
@@ -550,16 +417,8 @@ UniValue getclaimbyid(const JSONRPCRequest& request)
 
 UniValue gettotalclaimednames(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 0, 0))
-        throw std::runtime_error(
-            "gettotalclaimednames\n"
-            "Return the total number of names that have been\n"
-            "successfully claimed, and therefore exist in the trie\n"
-            "Arguments:\n"
-            "Result:\n"
-            "\"total names\"                (numeric) the total number of\n"
-            "                                         names in the trie\n"
-        );
+    validateRequest(request, GETTOTALCLAIMEDNAMES, 0, 0);
+
     LOCK(cs_main);
     auto num_names = pclaimTrie->getTotalNamesInTrie();
     return int(num_names);
@@ -567,15 +426,8 @@ UniValue gettotalclaimednames(const JSONRPCRequest& request)
 
 UniValue gettotalclaims(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 0, 0))
-        throw std::runtime_error(
-            "gettotalclaims\n"
-            "Return the total number of active claims in the trie\n"
-            "Arguments:\n"
-            "Result:\n"
-            "\"total claims\"             (numeric) the total number\n"
-            "                                       of active claims\n"
-        );
+    validateRequest(request, GETTOTALCLAIMS, 0, 0);
+
     LOCK(cs_main);
     auto num_claims = pclaimTrie->getTotalClaimsInTrie();
     return int(num_claims);
@@ -583,17 +435,8 @@ UniValue gettotalclaims(const JSONRPCRequest& request)
 
 UniValue gettotalvalueofclaims(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 0, 1))
-        throw std::runtime_error(
-            "gettotalvalueofclaims\n"
-            "Return the total value of the claims in the trie\n"
-            "Arguments:\n"
-            "1. \"controlling_only\"         (boolean) only include the value\n"
-            "                                          of controlling claims\n"
-            "Result:\n"
-            "\"total value\"                 (numeric) the total value of the\n"
-            "                                          claims in the trie\n"
-        );
+    validateRequest(request, GETTOTALVALUEOFCLAIMS, 0, 1);
+
     LOCK(cs_main);
     bool controlling_only = false;
     if (request.params.size() == 1)
@@ -604,31 +447,7 @@ UniValue gettotalvalueofclaims(const JSONRPCRequest& request)
 
 UniValue getclaimsfortx(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 1, 0))
-        throw std::runtime_error(
-            "getclaimsfortx\n"
-            "Return any claims or supports found in a transaction\n"
-            "Arguments:\n"
-            "1.  \"txid\"         (string) the txid of the transaction to check for unspent claims\n"
-            "Result:\n"
-            "[\n"
-            "  {\n"
-            "    \"nOut\"                   (numeric) the index of the claim or support in the transaction's list of outputs\n"
-            "    \"claim type\"             (string) 'claim' or 'support'\n"
-            "    \"name\"                   (string) the name claimed or supported\n"
-            "    \"claimId\"                (string) if a claim, its ID\n"
-            "    \"value\"                  (string) if a name claim, the value of the claim\n"
-            "    \"supported txid\"         (string) if a support, the txid of the supported claim\n"
-            "    \"supported nout\"         (numeric) if a support, the index of the supported claim in its transaction\n"
-            "    \"depth\"                  (numeric) the depth of the transaction in the main chain\n"
-            "    \"in claim trie\"          (boolean) if a name claim, whether the claim is active, i.e. has made it into the trie\n"
-            "    \"is controlling\"         (boolean) if a name claim, whether the claim is the current controlling claim for the name\n"
-            "    \"in support map\"         (boolean) if a support, whether the support is active, i.e. has made it into the support map\n"
-            "    \"in queue\"               (boolean) whether the claim is in a queue waiting to be inserted into the trie or support map\n"
-            "    \"blocks to valid\"        (numeric) if in a queue, the number of blocks until it's inserted into the trie or support map\n"
-            "  }\n"
-            "]\n"
-        );
+    validateRequest(request, GETCLAIMSFORTX, 1, 0);
 
     LOCK(cs_main);
     uint256 hash = ParseHashV(request.params[0], "txid (parameter 1)");
@@ -643,102 +462,66 @@ UniValue getclaimsfortx(const JSONRPCRequest& request)
     std::vector<CTxOut> txouts{ coin.out };
     int nHeight = coin.nHeight;
 
-    for (unsigned int i = 0; i < txouts.size(); ++i)
-    {
-        if (!txouts[i].IsNull())
-        {
-            vvchParams.clear();
-            const CTxOut& txout = txouts[i];
-            UniValue o(UniValue::VOBJ);
-            if (DecodeClaimScript(txout.scriptPubKey, op, vvchParams))
-            {
-                o.pushKV("nOut", static_cast<int64_t>(i));
-                std::string sName(vvchParams[0].begin(), vvchParams[0].end());
-                o.pushKV("name", escapeNonUtf8(sName));
-                if (op == OP_CLAIM_NAME)
-                {
-                    uint160 claimId = ClaimIdHash(hash, i);
-                    o.pushKV("claimId", claimId.GetHex());
-                    o.pushKV("value", HexStr(vvchParams[1].begin(), vvchParams[1].end()));
-                }
-                else if (op == OP_UPDATE_CLAIM)
-                {
-                    uint160 claimId(vvchParams[1]);
-                    o.pushKV("claimId", claimId.GetHex());
-                    o.pushKV("value", HexStr(vvchParams[2].begin(), vvchParams[2].end()));
-                }
-                else if (op == OP_SUPPORT_CLAIM)
-                {
-                    uint160 supportedClaimId(vvchParams[1]);
-                    o.pushKV("supported claimId", supportedClaimId.GetHex());
-                    if (vvchParams.size() > 2)
-                        o.pushKV("supported value", HexStr(vvchParams[2].begin(), vvchParams[2].end()));
-                }
-                if (nHeight > 0)
-                {
-                    o.pushKV("depth", chainActive.Height() - nHeight);
-                    if (op == OP_CLAIM_NAME || op == OP_UPDATE_CLAIM)
-                    {
-                        bool inClaimTrie = trieCache.haveClaim(sName, COutPoint(hash, i));
-                        o.pushKV("in claim trie", inClaimTrie);
-                        if (inClaimTrie)
-                        {
-                            CClaimValue claim;
-                            if (!trieCache.getInfoForName(sName, claim))
-                            {
-                                LogPrintf("HaveClaim was true but getInfoForName returned false.");
-                            }
-                            o.pushKV("is controlling", (claim.outPoint.hash == hash && claim.outPoint.n == i));
-                        }
-                        else
-                        {
-                            int nValidAtHeight;
-                            if (trieCache.haveClaimInQueue(sName, COutPoint(hash, i), nValidAtHeight))
-                            {
-                                o.pushKV("in queue", true);
-                                o.pushKV("blocks to valid", nValidAtHeight - chainActive.Height());
-                            }
-                            else
-                            {
-                                o.pushKV("in queue", false);
-                            }
-                        }
-                    }
-                    else if (op == OP_SUPPORT_CLAIM)
-                    {
-                        bool inSupportMap = trieCache.haveSupport(sName, COutPoint(hash, i));
-                        o.pushKV("in support map", inSupportMap);
-                        if (!inSupportMap)
-                        {
-                            int nValidAtHeight;
-                            if (trieCache.haveSupportInQueue(sName, COutPoint(hash, i), nValidAtHeight))
-                            {
-                                o.pushKV("in queue", true);
-                                o.pushKV("blocks to valid", nValidAtHeight - chainActive.Height());
-                            }
-                            else
-                            {
-                                o.pushKV("in queue", false);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    o.pushKV("depth", 0);
-                    if (op == OP_CLAIM_NAME || op == OP_UPDATE_CLAIM)
-                    {
-                        o.pushKV("in claim trie", false);
-                    }
-                    else if (op == OP_SUPPORT_CLAIM)
-                    {
-                        o.pushKV("in support map", false);
-                    }
-                    o.pushKV("in queue", false);
-                }
-                ret.push_back(o);
-            }
+    for (unsigned int i = 0; i < txouts.size(); ++i) {
+        if (txouts[i].IsNull())
+            continue;
+        vvchParams.clear();
+        const CTxOut& txout = txouts[i];
+        if (!DecodeClaimScript(txout.scriptPubKey, op, vvchParams))
+            continue;
+        UniValue o(UniValue::VOBJ);
+        o.pushKV(T_N, static_cast<int64_t>(i));
+        std::string sName(vvchParams[0].begin(), vvchParams[0].end());
+        o.pushKV(T_NAME, escapeNonUtf8(sName));
+        if (op == OP_CLAIM_NAME) {
+            uint160 claimId = ClaimIdHash(hash, i);
+            o.pushKV(T_CLAIMID, claimId.GetHex());
+            o.pushKV(T_VALUE, HexStr(vvchParams[1].begin(), vvchParams[1].end()));
+        } else if (op == OP_UPDATE_CLAIM || op == OP_SUPPORT_CLAIM) {
+            uint160 claimId(vvchParams[1]);
+            o.pushKV(T_CLAIMID, claimId.GetHex());
+            if (vvchParams.size() > 2)
+                o.pushKV(T_VALUE, HexStr(vvchParams[2].begin(), vvchParams[2].end()));
         }
+        if (nHeight > 0) {
+            o.pushKV(T_DEPTH, chainActive.Height() - nHeight);
+            if (op == OP_CLAIM_NAME || op == OP_UPDATE_CLAIM) {
+                bool inClaimTrie = trieCache.haveClaim(sName, COutPoint(hash, i));
+                o.pushKV(T_INCLAIMTRIE, inClaimTrie);
+                if (inClaimTrie) {
+                    CClaimValue claim;
+                    if (!trieCache.getInfoForName(sName, claim))
+                        LogPrintf("HaveClaim was true but getInfoForName returned false.");
+                    o.pushKV(T_ISCONTROLLING, (claim.outPoint.hash == hash && claim.outPoint.n == i));
+                } else {
+                    int nValidAtHeight;
+                    if (trieCache.haveClaimInQueue(sName, COutPoint(hash, i), nValidAtHeight)) {
+                        o.pushKV(T_INQUEUE, true);
+                        o.pushKV(T_BLOCKSTOVALID, nValidAtHeight - chainActive.Height());
+                    } else
+                        o.pushKV(T_INQUEUE, false);
+                    }
+            } else if (op == OP_SUPPORT_CLAIM) {
+                bool inSupportMap = trieCache.haveSupport(sName, COutPoint(hash, i));
+                o.pushKV(T_INSUPPORTMAP, inSupportMap);
+                if (!inSupportMap) {
+                    int nValidAtHeight;
+                    if (trieCache.haveSupportInQueue(sName, COutPoint(hash, i), nValidAtHeight)) {
+                        o.pushKV(T_INQUEUE, true);
+                        o.pushKV(T_BLOCKSTOVALID, nValidAtHeight - chainActive.Height());
+                    } else
+                        o.pushKV(T_INQUEUE, false);
+                }
+            }
+        } else {
+            o.pushKV(T_DEPTH, 0);
+            if (op == OP_CLAIM_NAME || op == OP_UPDATE_CLAIM)
+                o.pushKV(T_INCLAIMTRIE, false);
+            else if (op == OP_SUPPORT_CLAIM)
+                o.pushKV(T_INSUPPORTMAP, false);
+            o.pushKV(T_INQUEUE, false);
+        }
+        ret.push_back(o);
     }
     return ret;
 }
@@ -754,111 +537,46 @@ UniValue proofToJSON(const CClaimTrieProof& proof)
 
         for (const auto& itChildren : itNode.children) {
             UniValue child(UniValue::VOBJ);
-            child.pushKV("character", itChildren.first);
+            child.pushKV(T_CHARACTER, itChildren.first);
             if (!itChildren.second.IsNull())
-                child.pushKV("nodeHash", itChildren.second.GetHex());
+                child.pushKV(T_NODEHASH, itChildren.second.GetHex());
             children.push_back(child);
         }
-
-        node.pushKV("children", children);
+        node.pushKV(T_CHILDREN, children);
 
         if (itNode.hasValue && !itNode.valHash.IsNull())
-            node.pushKV("valueHash", itNode.valHash.GetHex());
-
+            node.pushKV(T_VALUEHASH, itNode.valHash.GetHex());
         nodes.push_back(node);
     }
 
     if (!nodes.empty())
-        result.push_back(Pair("nodes", nodes));
+        result.push_back(Pair(T_NODES, nodes));
 
     UniValue pairs(UniValue::VARR);
 
     for (const auto& itPair : proof.pairs) {
         UniValue child(UniValue::VOBJ);
-        child.push_back(Pair("odd", itPair.first));
-        child.push_back(Pair("hash", itPair.second.GetHex()));
+        child.push_back(Pair(T_ODD, itPair.first));
+        child.push_back(Pair(T_HASH, itPair.second.GetHex()));
         pairs.push_back(child);
     }
 
     if (!pairs.empty())
-        result.push_back(Pair("pairs", pairs));
+        result.push_back(Pair(T_PAIRS, pairs));
 
     if (proof.hasValue) {
-        result.pushKV("txhash", proof.outPoint.hash.GetHex());
-        result.pushKV("nOut", (int)proof.outPoint.n);
-        result.pushKV("last takeover height", (int)proof.nHeightOfLastTakeover);
+        result.pushKV(T_TXID, proof.outPoint.hash.GetHex());
+        result.pushKV(T_N, (int)proof.outPoint.n);
+        result.pushKV(T_LASTTAKEOVERHEIGHT, (int)proof.nHeightOfLastTakeover);
     }
     return result;
 }
 
 UniValue getnameproof(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 1, 2))
-        throw std::runtime_error(
-            "getnameproof\n"
-            "Return the cryptographic proof that a name maps to a value\n"
-            "or doesn't.\n"
-            "Arguments:\n"
-            "1. \"name\"           (string) the name to get a proof for\n"
-            "2. \"blockhash\"      (string, optional) the hash of the block\n"
-            "                                            which is the basis\n"
-            "                                            of the proof. If\n"
-            "                                            none is given, \n"
-            "                                            the latest block\n"
-            "                                            will be used.\n"
-            "3. \"claimId\"        (string, optional, post-fork) for validating a specific claim\n"
-            "Result: \n"
-            "{\n"
-            "  \"nodes\" : [       (array of object, pre-fork) full nodes (i.e.\n"
-            "                                        those which lead to\n"
-            "                                        the requested name)\n"
-            "    \"children\" : [  (array of object) the children of\n"
-            "                                       this node\n"
-            "      \"child\" : {   (object) a child node, either leaf or\n"
-            "                               reference to a full node\n"
-            "        \"character\" : \"char\" (string) the character which\n"
-            "                                          leads from the parent\n"
-            "                                          to this child node\n"
-            "        \"nodeHash\" :  \"hash\" (string, if exists) the hash of\n"
-            "                                                     the node if\n"
-            "                                                     this is a \n"
-            "                                                     leaf node\n"
-            "        }\n"
-            "      ]\n"
-            "    \"valueHash\"     (string, if exists) the hash of this\n"
-            "                                          node's value, if\n"
-            "                                          it has one. If \n"
-            "                                          this is the\n"
-            "                                          requested name\n"
-            "                                          this will not\n"
-            "                                          exist whether\n"
-            "                                          the node has a\n"
-            "                                          value or not\n"
-            "    ]\n"
-            "  \"pairs\" : [       (array of pairs, post-fork) hash can be validated by \n"
-            "                                                  hashing claim from the bottom up\n"
-            "                {\n"
-            "                    \"odd\"      (boolean) this value goes on the right of hash\n"
-            "                    \"hash\"     (boolean) the hash to be mixed in\n"
-            "                }\n"
-            "              ]\n"
-            "  \"txhash\" : \"hash\" (string, if exists) the txid of the\n"
-            "                                            claim which controls\n"
-            "                                            this name, if there\n"
-            "                                            is one.\n"
-            "  \"nOut\" : n,         (numeric) the nOut of the claim which\n"
-            "                                  controls this name, if there\n"
-            "                                  is one.\n"
-            "  \"last takeover height\"  (numeric) the most recent height at\n"
-            "                                      which the value of a name\n"
-            "                                      changed other than through\n"
-            "                                      an update to the winning\n"
-            "                                      bid\n"
-            "  }\n"
-            "}\n");
+    validateRequest(request, GETNAMEPROOF, 1, 2);
 
     LOCK(cs_main);
-
     CCoinsViewCache coinsCache(pcoinsTip.get());
     CClaimTrieCache trieCache(pclaimTrie);
 
@@ -892,14 +610,7 @@ UniValue getnameproof(const JSONRPCRequest& request)
 
 UniValue checknormalization(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !validParams(request.params, 1, 0))
-        throw std::runtime_error(
-            "checknormalization\n"
-            "Given an unnormalized name of a claim, return normalized version of it\n"
-            "Arguments:\n"
-            "1. \"name\"           (string) the name to normalize\n"
-            "Result: \n"
-            "\"normalized\"        (string) fully normalized name\n");
+    validateRequest(request, CHECKNORMALIZATION, 1, 0);
 
     const bool force = true;
     const std::string name = request.params[0].get_str();
@@ -911,18 +622,18 @@ UniValue checknormalization(const JSONRPCRequest& request)
 static const CRPCCommand commands[] =
 { //  category              name                            actor (function)            argNames
   //  --------------------- ------------------------        -----------------------     ----------
-    { "Claimtrie",          "getclaimsintrie",              &getclaimsintrie,           { "blockhash" } },
-    { "Claimtrie",          "getnamesintrie",               &getnamesintrie,            { "blockhash" } },
+    { "Claimtrie",          "getclaimsintrie",              &getclaimsintrie,           { T_BLOCKHASH } },
+    { "Claimtrie",          "getnamesintrie",               &getnamesintrie,            { T_BLOCKHASH } },
     { "hidden",             "getclaimtrie",                 &getclaimtrie,              { } },
-    { "Claimtrie",          "getvalueforname",              &getvalueforname,           { "name","blockhash","claimId" } },
-    { "Claimtrie",          "getclaimsforname",             &getclaimsforname,          { "name","blockhash" } },
+    { "Claimtrie",          "getvalueforname",              &getvalueforname,           { T_NAME,T_BLOCKHASH,T_CLAIMID } },
+    { "Claimtrie",          "getclaimsforname",             &getclaimsforname,          { T_NAME,T_BLOCKHASH } },
     { "Claimtrie",          "gettotalclaimednames",         &gettotalclaimednames,      { "" } },
     { "Claimtrie",          "gettotalclaims",               &gettotalclaims,            { "" } },
-    { "Claimtrie",          "gettotalvalueofclaims",        &gettotalvalueofclaims,     { "controlling_only" } },
-    { "Claimtrie",          "getclaimsfortx",               &getclaimsfortx,            { "txid" } },
-    { "Claimtrie",          "getnameproof",                 &getnameproof,              { "name","blockhash","claimId"} },
-    { "Claimtrie",          "getclaimbyid",                 &getclaimbyid,              { "claimId" } },
-    { "Claimtrie",          "checknormalization",           &checknormalization,        { "name" }},
+    { "Claimtrie",          "gettotalvalueofclaims",        &gettotalvalueofclaims,     { T_CONTROLLINGONLY } },
+    { "Claimtrie",          "getclaimsfortx",               &getclaimsfortx,            { T_TXID } },
+    { "Claimtrie",          "getnameproof",                 &getnameproof,              { T_NAME,T_BLOCKHASH,T_CLAIMID} },
+    { "Claimtrie",          "getclaimbyid",                 &getclaimbyid,              { T_CLAIMID } },
+    { "Claimtrie",          "checknormalization",           &checknormalization,        { T_NAME }},
 };
 
 void RegisterClaimTrieRPCCommands(CRPCTable &tableRPC)

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -770,7 +770,7 @@ UniValue getnameproof(const JSONRPCRequest& request)
 
 UniValue getclaimproofbybid(const JSONRPCRequest& request)
 {
-    validateRequest(request, GETCLAIMPROOFBYID, 1, 2);
+    validateRequest(request, GETCLAIMPROOFBYBID, 1, 2);
 
     LOCK(cs_main);
     CCoinsViewCache coinsCache(pcoinsTip.get());

--- a/src/rpc/claimtrie.cpp
+++ b/src/rpc/claimtrie.cpp
@@ -245,6 +245,14 @@ UniValue supportToJSON(const CCoinsViewCache& coinsCache, const CSupportValue& s
     return ret;
 }
 
+CAmount amountToClaim(const CClaimNsupports& claimNsupports)
+{
+    auto fullAmount = claimNsupports.claim.nAmount;
+    for (auto& support : claimNsupports.supports)
+        fullAmount += support.nAmount;
+    return fullAmount;
+}
+
 UniValue claimAndSupportsToJSON(const CCoinsViewCache& coinsCache, const CClaimNsupports& claimNsupports)
 {
     auto& claim = claimNsupports.claim;
@@ -252,6 +260,10 @@ UniValue claimAndSupportsToJSON(const CCoinsViewCache& coinsCache, const CClaimN
 
     auto result = claimToJSON(coinsCache, claim);
     result.pushKV(T_EFFECTIVEAMOUNT, claimNsupports.effectiveAmount);
+
+    auto fullAmount = amountToClaim(claimNsupports);
+    if (fullAmount > claimNsupports.effectiveAmount)
+        result.pushKV(T_PENDINGAMOUNT, fullAmount);
 
     UniValue supportObjs(UniValue::VARR);
     for (auto& support : supports)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -174,6 +174,11 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listnameclaims", 0, "includesupports"},
     { "listnameclaims", 1, "activeonly"},
     { "listnameclaims", 2, "minconf"},
+    { "getclaimbybid", 1, "bid"},
+    { "getclaimbyseq", 1, "sequence"},
+    { "getclaimproofbybid", 1, "bid"},
+    { "getclaimproofbyseq", 1, "sequence"},
+    { "supportclaim", 4, "isTip"},
 };
 
 class CRPCConvertTable

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -13,6 +13,7 @@
 #include <pow.h>
 #include <primitives/transaction.h>
 #include <random.h>
+#include <rpc/claimrpchelp.h>
 #include <rpc/server.h>
 #include <streams.h>
 #include <test/test_bitcoin.h>
@@ -3971,15 +3972,15 @@ BOOST_AUTO_TEST_CASE(getvalueforname_test)
     req.params.push_back(UniValue(sName1));
 
     UniValue results = getvalueforname(req);
-    BOOST_CHECK_EQUAL(results["value"].get_str(), HexStr(sValue1));
-    BOOST_CHECK_EQUAL(results["amount"].get_int(), 2);
-    BOOST_CHECK_EQUAL(results["effectiveAmount"].get_int(), 5);
+    BOOST_CHECK_EQUAL(results[T_VALUE].get_str(), HexStr(sValue1));
+    BOOST_CHECK_EQUAL(results[T_AMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(results[T_EFFECTIVEAMOUNT].get_int(), 5);
 
     req.params.push_back(blockHash.GetHex());
 
     results = getvalueforname(req);
-    BOOST_CHECK_EQUAL(results["amount"].get_int(), 2);
-    BOOST_CHECK_EQUAL(results["effectiveAmount"].get_int(), 2);
+    BOOST_CHECK_EQUAL(results[T_AMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(results[T_EFFECTIVEAMOUNT].get_int(), 2);
 }
 
 BOOST_AUTO_TEST_CASE(getclaimsforname_test)
@@ -4005,31 +4006,31 @@ BOOST_AUTO_TEST_CASE(getclaimsforname_test)
     req.params.push_back(UniValue(sName1));
 
     UniValue results = getclaimsforname(req);
-    UniValue claims = results["claims"];
+    UniValue claims = results[T_CLAIMS];
     BOOST_CHECK_EQUAL(claims.size(), 1U);
-    BOOST_CHECK_EQUAL(results["lastTakeoverHeight"].get_int(), height + 1);
-    BOOST_CHECK_EQUAL(claims[0]["effectiveAmount"].get_int(), 2);
-    BOOST_CHECK_EQUAL(claims[0]["supports"].size(), 0U);
+    BOOST_CHECK_EQUAL(results[T_LASTTAKEOVERHEIGHT].get_int(), height + 1);
+    BOOST_CHECK_EQUAL(claims[0][T_EFFECTIVEAMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(claims[0][T_SUPPORTS].size(), 0U);
 
     fixture.IncrementBlocks(1);
 
     results = getclaimsforname(req);
-    claims = results["claims"];
+    claims = results[T_CLAIMS];
     BOOST_CHECK_EQUAL(claims.size(), 2U);
-    BOOST_CHECK_EQUAL(results["lastTakeoverHeight"].get_int(), height + 3);
-    BOOST_CHECK_EQUAL(claims[0]["effectiveAmount"].get_int(), 3);
-    BOOST_CHECK_EQUAL(claims[1]["effectiveAmount"].get_int(), 2);
-    BOOST_CHECK_EQUAL(claims[0]["supports"].size(), 0U);
-    BOOST_CHECK_EQUAL(claims[1]["supports"].size(), 0U);
+    BOOST_CHECK_EQUAL(results[T_LASTTAKEOVERHEIGHT].get_int(), height + 3);
+    BOOST_CHECK_EQUAL(claims[0][T_EFFECTIVEAMOUNT].get_int(), 3);
+    BOOST_CHECK_EQUAL(claims[1][T_EFFECTIVEAMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(claims[0][T_SUPPORTS].size(), 0U);
+    BOOST_CHECK_EQUAL(claims[1][T_SUPPORTS].size(), 0U);
 
     req.params.push_back(blockHash.GetHex());
 
     results = getclaimsforname(req);
-    claims = results["claims"];
+    claims = results[T_CLAIMS];
     BOOST_CHECK_EQUAL(claims.size(), 1U);
-    BOOST_CHECK_EQUAL(results["lastTakeoverHeight"].get_int(), height + 1);
-    BOOST_CHECK_EQUAL(claims[0]["effectiveAmount"].get_int(), 2);
-    BOOST_CHECK_EQUAL(claims[0]["supports"].size(), 0U);
+    BOOST_CHECK_EQUAL(results[T_LASTTAKEOVERHEIGHT].get_int(), height + 1);
+    BOOST_CHECK_EQUAL(claims[0][T_EFFECTIVEAMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(claims[0][T_SUPPORTS].size(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(claim_rpcs_rollback2_test)
@@ -4059,13 +4060,13 @@ BOOST_AUTO_TEST_CASE(claim_rpcs_rollback2_test)
     req.params.push_back(blockHash.GetHex());
 
     UniValue claimsResults = getclaimsforname(req);
-    BOOST_CHECK_EQUAL(claimsResults["lastTakeoverHeight"].get_int(), height + 5);
-    BOOST_CHECK_EQUAL(claimsResults["claims"][0]["supports"].size(), 0U);
-    BOOST_CHECK_EQUAL(claimsResults["claims"][1]["supports"].size(), 0U);
+    BOOST_CHECK_EQUAL(claimsResults[T_LASTTAKEOVERHEIGHT].get_int(), height + 5);
+    BOOST_CHECK_EQUAL(claimsResults[T_CLAIMS][0][T_SUPPORTS].size(), 0U);
+    BOOST_CHECK_EQUAL(claimsResults[T_CLAIMS][1][T_SUPPORTS].size(), 0U);
 
     UniValue valueResults = getvalueforname(req);
-    BOOST_CHECK_EQUAL(valueResults["value"].get_str(), HexStr(sValue2));
-    BOOST_CHECK_EQUAL(valueResults["amount"].get_int(), 2);
+    BOOST_CHECK_EQUAL(valueResults[T_VALUE].get_str(), HexStr(sValue2));
+    BOOST_CHECK_EQUAL(valueResults[T_AMOUNT].get_int(), 2);
 }
 
 BOOST_AUTO_TEST_CASE(claim_rpcs_rollback3_test)
@@ -4100,11 +4101,11 @@ BOOST_AUTO_TEST_CASE(claim_rpcs_rollback3_test)
     req.params.push_back(blockHash.GetHex());
 
     UniValue claimsResults = getclaimsforname(req);
-    BOOST_CHECK_EQUAL(claimsResults["lastTakeoverHeight"].get_int(), height + 1);
+    BOOST_CHECK_EQUAL(claimsResults[T_LASTTAKEOVERHEIGHT].get_int(), height + 1);
 
     UniValue valueResults = getvalueforname(req);
-    BOOST_CHECK_EQUAL(valueResults["value"].get_str(), HexStr(sValue1));
-    BOOST_CHECK_EQUAL(valueResults["amount"].get_int(), 3);
+    BOOST_CHECK_EQUAL(valueResults[T_VALUE].get_str(), HexStr(sValue1));
+    BOOST_CHECK_EQUAL(valueResults[T_AMOUNT].get_int(), 3);
 }
 
 BOOST_AUTO_TEST_CASE(update_on_support2_test)

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -4135,9 +4135,9 @@ BOOST_AUTO_TEST_CASE(update_on_support2_test)
     BOOST_CHECK_EQUAL(node.nHeightOfLastTakeover, height + 1);
 }
 
-void ValidatePairs(CClaimTrieCache& cache, const CClaimTrieProof& proof, uint256 claimHash)
+void ValidatePairs(CClaimTrieCache& cache, const std::vector<std::pair<bool, uint256>>& pairs, uint256 claimHash)
 {
-    for (auto& pair : proof.pairs)
+    for (auto& pair : pairs)
         if (pair.first) // we're on the right because we were an odd index number
             claimHash = Hash(pair.second.begin(), pair.second.end(), claimHash.begin(), claimHash.end());
         else
@@ -4182,7 +4182,7 @@ BOOST_AUTO_TEST_CASE(hash_includes_all_claims_single_test)
     BOOST_CHECK(proof.hasValue);
     BOOST_CHECK_EQUAL(proof.outPoint, outPoint);
     auto claimHash = getValueHash(outPoint, proof.nHeightOfLastTakeover);
-    ValidatePairs(fixture, proof, claimHash);
+    ValidatePairs(fixture, proof.pairs, claimHash);
 }
 
 BOOST_AUTO_TEST_CASE(hash_includes_all_claims_triple_test)
@@ -4212,7 +4212,7 @@ BOOST_AUTO_TEST_CASE(hash_includes_all_claims_triple_test)
             BOOST_CHECK(proof.hasValue);
             BOOST_CHECK_EQUAL(proof.outPoint, claim.outPoint);
             uint256 claimHash = getValueHash(claim.outPoint, proof.nHeightOfLastTakeover);
-            ValidatePairs(fixture, proof, claimHash);
+            ValidatePairs(fixture, proof.pairs, claimHash);
         }
     }
 }
@@ -4243,7 +4243,7 @@ BOOST_AUTO_TEST_CASE(hash_includes_all_claims_branched_test)
             BOOST_CHECK(proof.hasValue);
             BOOST_CHECK_EQUAL(proof.outPoint, claim.outPoint);
             uint256 claimHash = getValueHash(claim.outPoint, proof.nHeightOfLastTakeover);
-            ValidatePairs(fixture, proof, claimHash);
+            ValidatePairs(fixture, proof.pairs, claimHash);
         }
     }
 }
@@ -4278,9 +4278,186 @@ BOOST_AUTO_TEST_CASE(hash_claims_children_fuzzer_test)
             BOOST_CHECK(proof.hasValue);
             BOOST_CHECK_EQUAL(proof.outPoint, claim.outPoint);
             uint256 claimHash = getValueHash(claim.outPoint, proof.nHeightOfLastTakeover);
-            ValidatePairs(fixture, proof, claimHash);
+            ValidatePairs(fixture, proof.pairs, claimHash);
         }
     }
+}
+
+std::vector<std::pair<bool, uint256>> jsonToPairs(const UniValue& jsonPair)
+{
+    std::vector<std::pair<bool, uint256>> pairs;
+    for (std::size_t i = 0; i < jsonPair.size(); ++i) {
+        auto& jpair = jsonPair[i];
+        pairs.emplace_back(jpair[T_ODD].get_bool(), uint256S(jpair[T_HASH].get_str()));
+    }
+    return pairs;
+}
+
+BOOST_AUTO_TEST_CASE(hash_bid_seq_claim_changes_test)
+{
+    ClaimTrieChainFixture fixture;
+    fixture.setHashForkHeight(2);
+    fixture.IncrementBlocks(4);
+
+    std::string name = "toa";
+    std::string value1 = "one", value2 = "two", value3 = "tre", value4 = "for";
+
+    auto tx1 = fixture.MakeClaim(fixture.GetCoinbase(), name, value1, 1);
+    fixture.IncrementBlocks(1);
+
+    CMutableTransaction tx2 = BuildTransaction(fixture.GetCoinbase(), 0, 2);
+    tx2.vout[0].scriptPubKey = CScript() << OP_CLAIM_NAME
+                                         << std::vector<unsigned char>(name.begin(), name.end())
+                                         << std::vector<unsigned char>(value2.begin(), value2.end()) << OP_2DROP << OP_DROP << OP_TRUE;
+    tx2.vout[0].nValue = 3;
+    tx2.vout[1].scriptPubKey = CScript() << OP_CLAIM_NAME
+                                         << std::vector<unsigned char>(name.begin(), name.end())
+                                         << std::vector<unsigned char>(value3.begin(), value3.end()) << OP_2DROP << OP_DROP << OP_TRUE;
+    tx2.vout[1].nValue = 2;
+
+    fixture.CommitTx(tx2);
+    fixture.IncrementBlocks(1);
+
+    auto tx3 = fixture.MakeClaim(fixture.GetCoinbase(), name, value4, 4);
+    fixture.IncrementBlocks(1);
+
+    int height = chainActive.Height();
+
+    auto claimId1 = ClaimIdHash(tx1.GetHash(), 0);
+    auto claimId2 = ClaimIdHash(tx2.GetHash(), 0);
+    auto claimId3 = ClaimIdHash(tx2.GetHash(), 1);
+    auto claimId4 = ClaimIdHash(tx3.GetHash(), 0);
+
+    int claim1bid = 3, claim1seq = 0;
+    int claim2bid = 1, claim2seq = 1;
+    int claim3bid = 2, claim3seq = 2;
+    int claim4bid = 0, claim4seq = 3;
+
+    auto getclaimsforname = tableRPC["getclaimsforname"]->actor;
+
+    JSONRPCRequest req;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+
+    auto result = getclaimsforname(req);
+    auto claims = result[T_CLAIMS];
+    BOOST_CHECK_EQUAL(claims.size(), 4U);
+    BOOST_CHECK_EQUAL(result[T_LASTTAKEOVERHEIGHT].get_int(), height);
+    BOOST_CHECK_EQUAL(claims[0][T_EFFECTIVEAMOUNT].get_int(), 4);
+    BOOST_CHECK_EQUAL(claims[0][T_BID].get_int(), claim4bid);
+    BOOST_CHECK_EQUAL(claims[0][T_SEQUENCE].get_int(), claim4seq);
+    BOOST_CHECK_EQUAL(claims[0][T_CLAIMID].get_str(), claimId4.GetHex());
+    BOOST_CHECK_EQUAL(claims[1][T_EFFECTIVEAMOUNT].get_int(), 3);
+    BOOST_CHECK_EQUAL(claims[1][T_BID].get_int(), claim2bid);
+    BOOST_CHECK_EQUAL(claims[1][T_SEQUENCE].get_int(), claim2seq);
+    BOOST_CHECK_EQUAL(claims[1][T_CLAIMID].get_str(), claimId2.GetHex());
+    BOOST_CHECK_EQUAL(claims[2][T_EFFECTIVEAMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(claims[2][T_BID].get_int(), claim3bid);
+    BOOST_CHECK_EQUAL(claims[2][T_SEQUENCE].get_int(), claim3seq);
+    BOOST_CHECK_EQUAL(claims[2][T_CLAIMID].get_str(), claimId3.GetHex());
+    BOOST_CHECK_EQUAL(claims[3][T_EFFECTIVEAMOUNT].get_int(), 1);
+    BOOST_CHECK_EQUAL(claims[3][T_BID].get_int(), claim1bid);
+    BOOST_CHECK_EQUAL(claims[3][T_SEQUENCE].get_int(), claim1seq);
+    BOOST_CHECK_EQUAL(claims[3][T_CLAIMID].get_str(), claimId1.GetHex());
+
+    auto getclaimbybid = tableRPC["getclaimbybid"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+    req.params.push_back(UniValue(claim3bid));
+
+    result = getclaimbybid(req);
+    BOOST_CHECK_EQUAL(result[T_LASTTAKEOVERHEIGHT].get_int(), height);
+    BOOST_CHECK_EQUAL(result[T_EFFECTIVEAMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(result[T_BID].get_int(), claim3bid);
+    BOOST_CHECK_EQUAL(result[T_SEQUENCE].get_int(), claim3seq);
+    BOOST_CHECK_EQUAL(result[T_CLAIMID].get_str(), claimId3.GetHex());
+
+    auto getclaimbyseq = tableRPC["getclaimbyseq"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+    req.params.push_back(UniValue(claim2seq));
+
+    result = getclaimbyseq(req);
+    BOOST_CHECK_EQUAL(result[T_LASTTAKEOVERHEIGHT].get_int(), height);
+    BOOST_CHECK_EQUAL(result[T_EFFECTIVEAMOUNT].get_int(), 3);
+    BOOST_CHECK_EQUAL(result[T_BID].get_int(), claim2bid);
+    BOOST_CHECK_EQUAL(result[T_SEQUENCE].get_int(), claim2seq);
+    BOOST_CHECK_EQUAL(result[T_CLAIMID].get_str(), claimId2.GetHex());
+
+    auto getclaimbyid = tableRPC["getclaimbyid"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(claimId1.GetHex()));
+
+    result = getclaimbyid(req);
+    BOOST_CHECK_EQUAL(result[T_LASTTAKEOVERHEIGHT].get_int(), height);
+    BOOST_CHECK_EQUAL(result[T_EFFECTIVEAMOUNT].get_int(), 1);
+    BOOST_CHECK_EQUAL(result[T_BID].get_int(), claim1bid);
+    BOOST_CHECK_EQUAL(result[T_SEQUENCE].get_int(), claim1seq);
+    BOOST_CHECK_EQUAL(result[T_CLAIMID].get_str(), claimId1.GetHex());
+
+    // check by partial id (at least 3 chars)
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(claimId3.GetHex().substr(0, 3)));
+
+    result = getclaimbyid(req);
+    BOOST_CHECK_EQUAL(result[T_LASTTAKEOVERHEIGHT].get_int(), height);
+    BOOST_CHECK_EQUAL(result[T_EFFECTIVEAMOUNT].get_int(), 2);
+    BOOST_CHECK_EQUAL(result[T_BID].get_int(), claim3bid);
+    BOOST_CHECK_EQUAL(result[T_SEQUENCE].get_int(), claim3seq);
+    BOOST_CHECK_EQUAL(result[T_CLAIMID].get_str(), claimId3.GetHex());
+
+    auto blockhash = chainActive.Tip()->GetBlockHash();
+
+    auto getnameproof = tableRPC["getnameproof"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+    req.params.push_back(UniValue(blockhash.GetHex()));
+    req.params.push_back(UniValue(claimId3.GetHex()));
+
+    result = getnameproof(req);
+    auto claimHash = getValueHash(COutPoint(tx2.GetHash(), 1), result[T_LASTTAKEOVERHEIGHT].get_int());
+    ValidatePairs(fixture, jsonToPairs(result[T_PAIRS]), claimHash);
+
+    // check by partial id (can be even 1 char)
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+    req.params.push_back(UniValue(blockhash.GetHex()));
+    req.params.push_back(UniValue(claimId2.GetHex().substr(0, 2)));
+
+    result = getnameproof(req);
+    claimHash = getValueHash(COutPoint(tx2.GetHash(), 0), result[T_LASTTAKEOVERHEIGHT].get_int());
+    ValidatePairs(fixture, jsonToPairs(result[T_PAIRS]), claimHash);
+
+    auto getclaimproofbybid = tableRPC["getclaimproofbybid"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+    req.params.push_back(UniValue(claim1bid));
+
+    result = getclaimproofbybid(req);
+    claimHash = getValueHash(COutPoint(tx1.GetHash(), 0), result[T_LASTTAKEOVERHEIGHT].get_int());
+    ValidatePairs(fixture, jsonToPairs(result[T_PAIRS]), claimHash);
+
+    auto getclaimproofbyseq = tableRPC["getclaimproofbyseq"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(name));
+    req.params.push_back(UniValue(claim4seq));
+
+    result = getclaimproofbyseq(req);
+    claimHash = getValueHash(COutPoint(tx3.GetHash(), 0), result[T_LASTTAKEOVERHEIGHT].get_int());
+    ValidatePairs(fixture, jsonToPairs(result[T_PAIRS]), claimHash);
+
+    auto getchangesinblock = tableRPC["getchangesinblock"]->actor;
+    req.params = UniValue(UniValue::VARR);
+    req.params.push_back(UniValue(blockhash.GetHex()));
+
+    result = getchangesinblock(req);
+    BOOST_CHECK_EQUAL(result[T_CLAIMSADDEDORUPDATED].size(), 3);
+    BOOST_CHECK_EQUAL(result[T_CLAIMSADDEDORUPDATED][0].get_str(), claimId2.GetHex());
+    BOOST_CHECK_EQUAL(result[T_CLAIMSADDEDORUPDATED][1].get_str(), claimId3.GetHex());
+    BOOST_CHECK_EQUAL(result[T_CLAIMSADDEDORUPDATED][2].get_str(), claimId4.GetHex());
+    BOOST_CHECK_EQUAL(result[T_CLAIMSREMOVED].size(), 0);
+    BOOST_CHECK_EQUAL(result[T_SUPPORTSADDEDORUPDATED].size(), 0);
+    BOOST_CHECK_EQUAL(result[T_SUPPORTSREMOVED].size(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/claimtriecache_tests.cpp
+++ b/src/test/claimtriecache_tests.cpp
@@ -210,13 +210,13 @@ BOOST_AUTO_TEST_CASE(basic_insertion_info_test)
     CClaimValue claimVal(claimOutPoint, claimId, amount, height, validHeight);
     ctc.insertClaimIntoTrie("test", claimVal, true);
 
-    // try getClaimsForName, getEffectiveAmountForClaim, getInfoForName
+    // try getClaimsForName, effectiveAmount, getInfoForName
     auto res = ctc.getClaimsForName("test");
-    BOOST_CHECK_EQUAL(res.claims.size(), 1);
-    BOOST_CHECK_EQUAL(res.claims[0], claimVal);
-    BOOST_CHECK_EQUAL(res.supports.size(), 0);
+    BOOST_CHECK_EQUAL(res.claimsNsupports.size(), 1);
+    BOOST_CHECK_EQUAL(res.claimsNsupports[0].claim, claimVal);
+    BOOST_CHECK_EQUAL(res.claimsNsupports[0].supports.size(), 0);
 
-    BOOST_CHECK_EQUAL(10, ctc.getEffectiveAmountForClaim("test", claimId));
+    BOOST_CHECK_EQUAL(10, res.claimsNsupports[0].effectiveAmount);
 
     CClaimValue claim;
     BOOST_CHECK(ctc.getInfoForName("test", claim));
@@ -231,12 +231,12 @@ BOOST_AUTO_TEST_CASE(basic_insertion_info_test)
     CSupportValue support(supportOutPoint, claimId, supportAmount, height, validHeight);
     ctc.insertSupportIntoMap("test", support, false);
 
-    res = ctc.getClaimsForName("test");
-    BOOST_CHECK_EQUAL(res.claims.size(), 1);
-    BOOST_CHECK_EQUAL(res.supports.size(), 1);
+    auto res1 = ctc.getClaimsForName("test");
+    BOOST_CHECK_EQUAL(res1.claimsNsupports.size(), 1);
+    BOOST_CHECK_EQUAL(res1.claimsNsupports[0].supports.size(), 1);
 
     // try getEffectiveAmount
-    BOOST_CHECK_EQUAL(20, ctc.getEffectiveAmountForClaim("test", claimId));
+    BOOST_CHECK_EQUAL(20, res1.claimsNsupports[0].effectiveAmount);
 }
 
 BOOST_AUTO_TEST_CASE(recursive_prune_test)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -880,7 +880,7 @@ UniValue supportclaim(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 3 || request.params.size() > 5)
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 5)
         throw std::runtime_error(
             "supportclaim \"name\" \"claimid\" \"amount\" \"value\"\n"
             "Increase the value of a claim. Whichever claim has the greatest value, including all support values, will be the authoritative claim, according to the rest of the rules. The name is the name which is claimed by the claim that will be supported, the txid is the txid\
@@ -889,31 +889,49 @@ UniValue supportclaim(const JSONRPCRequest& request)
             + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
             "1. \"name\"         (string, required) The name claimed by the claim to support.\n"
-            "2. \"claimid\"      (string, required) The claimid of the claim to support.\n"
-            "3. \"amount\"       (numeric, required) The amount in LBC to use to support the claim.\n"
+            "2. \"claimid\"      (string, optional) The claimid, partialid or best claim to support.\n"
+            "3. \"amount\"       (numeric, optional) The amount in LBC to use to support the claim.\n"
             "4. \"value\"        (string, optional) The metadata of the support encoded in hexadecimal.\n"
-            "\nResult:\n"
-            "\"transactionid\"  (string) The transaction id of the support.\n");
+            "\nResult: [\n"
+                "\"txId\"        (string) The transaction id of the support.\n"
+                "\"address\"     (string) The destination address of the claim.\n"
+            "\n]");
 
     auto sName = request.params[0].get_str();
-    auto sClaimId = request.params[1].get_str();
+    std::string sClaimId;
+    if (request.params.size() > 1)
+        sClaimId = request.params[1].get_str();
 
     const size_t claimLength = 40;
 
-    if (!IsHex(sClaimId))
+    if (!IsHexNumber(sClaimId))
         throw JSONRPCError(RPC_INVALID_PARAMETER, "claimid must be a 20-character hexadecimal string (not '" + sClaimId + "')");
-    if (sClaimId.length() != claimLength)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("claimid must be of length %d", claimLength));
 
-    uint160 claimId;
-    claimId.SetHex(sClaimId);
-    std::vector<unsigned char> vchName (sName.begin(), sName.end());
-    std::vector<unsigned char> vchClaimId (claimId.begin(), claimId.end());
-    CAmount nAmount = AmountFromValue(request.params[2]);
+    if (sClaimId.length() > claimLength)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("claimid must be maximum of length %d", claimLength));
 
     pwallet->BlockUntilSyncedToCurrentChain();
     LOCK2(cs_main, pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
+
+    uint160 claimId;
+    if (sClaimId.length() != claimLength) {
+        CClaimTrieCache trieCache(pclaimTrie);
+        auto csToName = trieCache.getClaimsForName(sName);
+        if (csToName.claimsNsupports.empty())
+            return NullUniValue;
+        auto& claimNsupports = !sClaimId.empty() ? csToName.find(sClaimId) : csToName.claimsNsupports[0];
+        if (claimNsupports.IsNull())
+            return NullUniValue;
+        claimId = claimNsupports.claim.claimId;
+    } else {
+        claimId.SetHex(sClaimId);
+    }
+
+    std::vector<unsigned char> vchName (sName.begin(), sName.end());
+    std::vector<unsigned char> vchClaimId (claimId.begin(), claimId.end());
+    CAmount nAmount = AmountFromValue(request.params.size() > 2 ? request.params[2] : "0.00000001");
+
     CScript supportScript = CScript() << OP_SUPPORT_CLAIM << vchName << vchClaimId;
     auto lastOp = OP_DROP;
     if (request.params.size() > 3) {
@@ -941,7 +959,11 @@ UniValue supportclaim(const JSONRPCRequest& request)
     CCoinControl cc;
     cc.m_change_type = pwallet->m_default_change_type;
     auto tx = SendMoney(pwallet, dest, nAmount, false, cc, {}, {}, supportScript);
-    return tx->GetHash().GetHex();
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("txId", tx->GetHash().GetHex());
+    result.pushKV("address", EncodeDestination(dest));
+    return result;
 }
 
 UniValue abandonsupport(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -889,9 +889,10 @@ UniValue supportclaim(const JSONRPCRequest& request)
             + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
             "1. \"name\"         (string, required) The name claimed by the claim to support.\n"
-            "2. \"claimid\"      (string, optional) The claimid, partialid or best claim to support.\n"
+            "2. \"claimid\"      (string, optional) The claimid or partialid of the claim to support.\n"
             "3. \"amount\"       (numeric, optional) The amount in LBC to use to support the claim.\n"
             "4. \"value\"        (string, optional) The metadata of the support encoded in hexadecimal.\n"
+            "5. \"isTip\"        (boolean, optional, defaults to false) spendable by owning claim's address when true.\n"
             "\nResult: [\n"
                 "\"txId\"        (string) The transaction id of the support.\n"
                 "\"address\"     (string) The destination address of the claim.\n"
@@ -914,19 +915,14 @@ UniValue supportclaim(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
 
-    uint160 claimId;
-    if (sClaimId.length() != claimLength) {
-        CClaimTrieCache trieCache(pclaimTrie);
-        auto csToName = trieCache.getClaimsForName(sName);
-        if (csToName.claimsNsupports.empty())
-            return NullUniValue;
-        auto& claimNsupports = !sClaimId.empty() ? csToName.find(sClaimId) : csToName.claimsNsupports[0];
-        if (claimNsupports.IsNull())
-            return NullUniValue;
-        claimId = claimNsupports.claim.claimId;
-    } else {
-        claimId.SetHex(sClaimId);
-    }
+    CClaimTrieCache trieCache(pclaimTrie);
+    auto csToName = trieCache.getClaimsForName(sName);
+    if (csToName.claimsNsupports.empty())
+        return NullUniValue;
+    auto& claimNsupports = !sClaimId.empty() ? csToName.find(sClaimId) : csToName.claimsNsupports[0];
+    if (claimNsupports.IsNull())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Unable to find a claimid that starts with %s", sClaimId));
+    auto& claimId = claimNsupports.claim.claimId;
 
     std::vector<unsigned char> vchName (sName.begin(), sName.end());
     std::vector<unsigned char> vchClaimId (claimId.begin(), claimId.end());
@@ -948,13 +944,28 @@ UniValue supportclaim(const JSONRPCRequest& request)
 
     supportScript = supportScript << OP_2DROP << lastOp;
 
-    CPubKey newKey;
-    if (!pwallet->GetKeyFromPool(newKey))
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+    auto isTip = false;
+    if (request.params.size() > 4)
+        isTip = request.params[4].get_bool();
 
-    OutputType output_type = pwallet->m_default_address_type;
-    pwallet->LearnRelatedScripts(newKey, output_type);
-    CTxDestination dest = GetDestinationForKey(newKey, output_type);
+    CTxDestination dest;
+    if (isTip) {
+        CTransactionRef ref;
+        uint256 block;
+        if (!GetTransaction(claimNsupports.claim.outPoint.hash, ref, Params().GetConsensus(), block, true))
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Unable to locate the TX with the claim's output.");
+        if (!ExtractDestination(ref->vout[claimNsupports.claim.outPoint.n].scriptPubKey, dest))
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Unable to extract the destination from the chosen claim.");
+    }
+    else {
+        CPubKey newKey;
+        if (!pwallet->GetKeyFromPool(newKey))
+            throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+
+        OutputType output_type = pwallet->m_default_address_type;
+        pwallet->LearnRelatedScripts(newKey, output_type);
+        dest = GetDestinationForKey(newKey, output_type);
+    }
 
     CCoinControl cc;
     cc.m_change_type = pwallet->m_default_change_type;

--- a/src/wallet/test/claim_rpc_tests.cpp
+++ b/src/wallet/test/claim_rpc_tests.cpp
@@ -78,7 +78,7 @@ uint256 SupportAName(const std::string& name, const std::string& claimId, const 
     req.params.push_back(price);
 
     UniValue results = rpc_method(req);
-    auto txid = results.get_str();
+    auto txid = results["txId"].get_str();
     uint256 ret;
     ret.SetHex(txid);
     return ret;


### PR DESCRIPTION
A bunch of updated rpc keys can lead to breaking changes in users, note it uses camelCase name notation, it can be changed as well. Notable changes:
nomalized_name -> normalizedName
txid -> txId
nHeight -> height
nValidAtHeight (valid at height) -> validAtHeight
nAmount -> amount
nEffectiveAmount (effective amount) -> effectiveAmount
total names -> totalNames
total claims -> totalClaims
total value -> totalValue
Most values in getclaimsfortx