### PR TITLE
Drastically reduce repetitive disk writes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -164,11 +164,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1548288000; // Jan 24, 2019
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000607ca7e806c4c1e9"); //400000
+        consensus.nMinimumChainWork = uint256S("00000000000000000000000000000000000000000000024108e3204a44a57a5a"); //621000
 
         // By default assume that the signatures in ancestors of this block are valid.
-        //consensus.defaultAssumeValid = uint256S("0xf0e56e70782af63ccb49c76e852540688755869ba59ec68cac9c04a6b4d9f5ca"); //400000
-        consensus.defaultAssumeValid = uint256S("0xa6bbb48f5343eb9b0287c22f3ea8b29f36cf10794a37f8a925a894d6f4519913"); //4000
+        consensus.defaultAssumeValid = uint256S("7899464514d0d8854919e87eb234fd5f0c35d06418bd5fd3c1a8f7092b2a9317"); //620000
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -148,8 +148,8 @@ struct CClaimTrieData
     int nHeightOfLastTakeover = 0;
 
     // non-serialized data:
-    uint256 hash;
     uint32_t flags = 0;
+    uint256 hash;
 
     CClaimTrieData() = default;
     CClaimTrieData(CClaimTrieData&&) = default;

--- a/src/claimtrieforks.cpp
+++ b/src/claimtrieforks.cpp
@@ -164,7 +164,7 @@ bool CClaimTrieCacheNormalizationFork::normalizeAllNamesInTrieIfNecessary(insert
     boost::scoped_ptr<CDBIterator> pcursor(base->db->NewIterator());
     for (pcursor->SeekToFirst(); pcursor->Valid(); pcursor->Next()) {
         std::pair<uint8_t, std::string> key;
-        if (!pcursor->GetKey(key) || key.first != TRIE_NODE_BY_NAME)
+        if (!pcursor->GetKey(key) || key.first != TRIE_NODE_CHILDREN)
             continue;
 
         const auto& name = key.second;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -80,14 +80,14 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
     // implementation that does not use extra file descriptors (the fds are
     // closed after being mmaped).
     //
-    // Increasing the value beyond the default is dangerous because LevelDB will
-    // fall back to a non-mmap implementation when the file count is too large.
+    // Increasing the value beyond the nmap count is dangerous because LevelDB will
+    // fall back to a non-mmap implementation when the file count is too large (thus contending select()).
     // On 32-bit Unix host we should decrease the value because the handles use
     // up real fds, and we want to avoid fd exhaustion issues.
     //
     // See PR #12495 for further discussion.
 
-    int default_open_files = options->max_open_files;
+    int default_open_files = 400;
 #ifndef WIN32
     if (sizeof(void*) < 8) {
         options->max_open_files = 64;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -100,10 +100,10 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
 static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
-    auto write_cache = std::min(nCacheSize / 4, size_t(16) << 20U); // cap write_cache at 16MB (4x default)
+    auto write_cache = std::min(nCacheSize / 4, size_t(32 * 1024 * 1024)); // cap write_cache
     options.block_cache = leveldb::NewLRUCache(nCacheSize - write_cache * 2);
     options.write_buffer_size = write_cache; // up to two write buffers may be held in memory simultaneously
-    options.filter_policy = leveldb::NewBloomFilterPolicy(10);
+    options.filter_policy = leveldb::NewBloomFilterPolicy(12);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
@@ -116,7 +116,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
 }
 
 CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
-    : m_name(fs::basename(path))
+        : m_name(fs::basename(path)), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION)
 {
     penv = nullptr;
     readoptions.verify_checksums = true;
@@ -179,6 +179,11 @@ CDBWrapper::~CDBWrapper()
     options.block_cache = nullptr;
     delete penv;
     options.env = nullptr;
+}
+
+bool CDBWrapper::Sync() {
+    CDBBatch batch(*this);
+    return WriteBatch(batch, true);
 }
 
 bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1461,7 +1461,7 @@ bool AppInitMain()
                 pblocktree.reset();
                 pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
                 delete pclaimTrie;
-                pclaimTrie = new CClaimTrie(false, fReindex);
+                pclaimTrie = new CClaimTrie(false, fReindex || fReindexChainState);
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);

--- a/src/leveldb/include/leveldb/env.h
+++ b/src/leveldb/include/leveldb/env.h
@@ -221,6 +221,9 @@ class RandomAccessFile {
   // Get a name for the file, only for error reporting
   virtual std::string GetName() const = 0;
 
+  virtual char* AllocateScratch(std::size_t size) const { return new char[size]; };
+  virtual void DeallocateScratch(char* pointer) const { delete[] pointer; };
+
  private:
   // No copying allowed
   RandomAccessFile(const RandomAccessFile&);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -207,7 +207,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     CValidationState state;
     if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false)) {
-        if (!trieCache.empty() && trieCache.checkConsistency())
+        if (!trieCache.empty())
             trieCache.dumpToLog(trieCache.begin());
         throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
     }

--- a/src/prefixtrie.cpp
+++ b/src/prefixtrie.cpp
@@ -174,21 +174,6 @@ std::vector<typename CPrefixTrie<TKey, TData>::template Iterator<IsConst>> CPref
     return ret;
 }
 
-template <typename TKey>
-static std::size_t match(const TKey& a, const TKey& b)
-{
-    std::size_t count = 0;
-    auto ait = a.cbegin(), aend = a.cend();
-    auto bit = b.cbegin(), bend = b.cend();
-    while (ait != aend && bit != bend) {
-        if (*ait != *bit) break;
-        ++count;
-        ++ait;
-        ++bit;
-    }
-    return count;
-}
-
 template <typename TKey, typename TData>
 template <typename TIterator, typename TNode>
 TIterator CPrefixTrie<TKey, TData>::find(const TKey& key, TNode node, TIterator end)

--- a/src/prefixtrie.h
+++ b/src/prefixtrie.h
@@ -29,7 +29,7 @@ class CPrefixTrie
         Node(Node&& o) noexcept = default;
         Node& operator=(Node&& o) noexcept = default;
         Node& operator=(const Node&) = delete;
-        std::shared_ptr<TData> data;
+        TData data;
     };
 
     using TChildren = decltype(Node::children);

--- a/src/prefixtrie.h
+++ b/src/prefixtrie.h
@@ -9,6 +9,10 @@
 #include <type_traits>
 #include <vector>
 
+#include <boost/container/flat_map.hpp>
+
+namespace bc = boost::container;
+
 template <typename TKey, typename TData>
 class CPrefixTrie
 {
@@ -17,7 +21,7 @@ class CPrefixTrie
         template <bool>
         friend class Iterator;
         friend class CPrefixTrie<TKey, TData>;
-        std::map<TKey, std::shared_ptr<Node>> children;
+        bc::flat_map<TKey, std::shared_ptr<Node>> children;
 
     public:
         Node() = default;

--- a/src/prefixtrie.h
+++ b/src/prefixtrie.h
@@ -193,4 +193,19 @@ inline bool operator!=(const std::reference_wrapper<std::unique_ptr<T>>& ref, co
     return !(ref == obj);
 }
 
+template <typename TKey>
+static std::size_t match(const TKey& a, const TKey& b)
+{
+    std::size_t count = 0;
+    auto ait = a.cbegin(), aend = a.cend();
+    auto bit = b.cbegin(), bend = b.cend();
+    while (ait != aend && bit != bend) {
+        if (*ait != *bit) break;
+        ++count;
+        ++ait;
+        ++bit;
+    }
+    return count;
+}
+
 #endif // BITCOIN_PREFIXTRIE_H

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -559,8 +559,8 @@ template<typename Stream, typename K, typename T> void Unserialize(Stream& is, s
 /**
  * map
  */
-template<typename Stream, typename K, typename T, typename Pred, typename A> void Serialize(Stream& os, const std::map<K, T, Pred, A>& m);
-template<typename Stream, typename K, typename T, typename Pred, typename A> void Unserialize(Stream& is, std::map<K, T, Pred, A>& m);
+template<typename Stream, typename K, typename T, typename ... Z> void Serialize(Stream& os, const std::map<K, T, Z...>& m);
+template<typename Stream, typename K, typename T, typename ... Z> void Unserialize(Stream& is, std::map<K, T, Z...>& m);
 
 /**
  * set
@@ -781,20 +781,20 @@ void Unserialize(Stream& is, std::pair<K, T>& item)
 /**
  * map
  */
-template<typename Stream, typename K, typename T, typename Pred, typename A>
-void Serialize(Stream& os, const std::map<K, T, Pred, A>& m)
+template<typename Stream, typename K, typename T, typename ... Z>
+void Serialize(Stream& os, const std::map<K, T, Z...>& m)
 {
     WriteCompactSize(os, m.size());
     for (const auto& entry : m)
         Serialize(os, entry);
 }
 
-template<typename Stream, typename K, typename T, typename Pred, typename A>
-void Unserialize(Stream& is, std::map<K, T, Pred, A>& m)
+template<typename Stream, typename K, typename T, typename ... Z>
+void Unserialize(Stream& is, std::map<K, T, Z...>& m)
 {
     m.clear();
     unsigned int nSize = ReadCompactSize(is);
-    typename std::map<K, T, Pred, A>::iterator mi = m.begin();
+    typename std::map<K, T, Z...>::iterator mi = m.begin();
     for (unsigned int i = 0; i < nSize; i++)
     {
         std::pair<K, T> item;

--- a/src/streams.h
+++ b/src/streams.h
@@ -227,6 +227,10 @@ public:
         return (std::string(begin(), end()));
     }
 
+    std::size_t capacity() const
+    {
+        return vch.capacity();
+    }
 
     //
     // Vector subset

--- a/src/test/claimtriecache_tests.cpp
+++ b/src/test/claimtriecache_tests.cpp
@@ -200,7 +200,6 @@ BOOST_AUTO_TEST_CASE(basic_insertion_info_test)
     CClaimTrieCacheTest ctc(pclaimTrie);
 
     // create and insert claim
-    CClaimValue unused;
     uint256 hash0(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
     CMutableTransaction tx1 = BuildTransaction(hash0);
     uint160 claimId = ClaimIdHash(tx1.GetHash(), 0);
@@ -304,7 +303,9 @@ BOOST_AUTO_TEST_CASE(iteratetrie_test)
     BOOST_CHECK_EQUAL(node.children.size(), 1U);
     BOOST_CHECK(pclaimTrie->find("test", node));
     BOOST_CHECK_EQUAL(node.children.size(), 0U);
-    BOOST_CHECK_EQUAL(node.data.claims.size(), 1);
+    CClaimTrieData data;
+    BOOST_CHECK(pclaimTrie->find("test", data));
+    BOOST_CHECK_EQUAL(data.claims.size(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(trie_stays_consistent_test)

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -20,6 +20,8 @@
 #include <script/sigcache.h>
 
 #include "claimtrie.h"
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_parameters.hpp>
 
 void CConnmanTest::AddNode(CNode& node)
 {
@@ -39,7 +41,6 @@ void CConnmanTest::ClearNodes()
 uint256 insecure_rand_seed = GetRandHash();
 FastRandomContext insecure_rand_ctx(insecure_rand_seed);
 
-extern bool fPrintToConsole;
 extern void noui_connect();
 
 std::ostream& operator<<(std::ostream& os, const uint256& num)
@@ -90,6 +91,14 @@ std::ostream& operator<<(std::ostream& os, const CSupportValue& support)
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     : m_path_root(fs::temp_directory_path() / "test_bitcoin" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
 {
+    // for debugging:
+    if (boost::unit_test::runtime_config::get<boost::unit_test::log_level>(boost::unit_test::runtime_config::btrt_log_level)
+            <= boost::unit_test::log_level::log_messages) {
+        g_logger->m_print_to_console = true;
+        g_logger->m_log_time_micros = true;
+        g_logger->EnableCategory(BCLog::ALL);
+    }
+
     SHA256AutoDetect();
     RandomInit();
     ECC_Start();

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -44,7 +44,7 @@ struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
 
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
-    ~BasicTestingSetup();
+    virtual ~BasicTestingSetup();
 
     fs::path SetDataDir(const std::string& name);
 
@@ -70,7 +70,7 @@ struct TestingSetup: public BasicTestingSetup {
     std::unique_ptr<PeerLogicValidation> peerLogic;
 
     explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
-    ~TestingSetup();
+    ~TestingSetup() override;
 };
 
 class CBlock;
@@ -89,7 +89,7 @@ struct TestChain100Setup : public TestingSetup {
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
                                  const CScript& scriptPubKey);
 
-    ~TestChain100Setup();
+    ~TestChain100Setup() override;
 
     std::vector<CTransactionRef> m_coinbase_txns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions
@@ -97,7 +97,7 @@ struct TestChain100Setup : public TestingSetup {
 
 struct RegTestingSetup: public TestingSetup {
     RegTestingSetup();
-    ~RegTestingSetup();
+    ~RegTestingSetup() override;
 };
 
 class CTxMemPoolEntry;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1562,13 +1562,11 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     assert(trieCache.finalizeDecrement(blockUndo.takeoverHeightUndo));
     auto merkleHash = trieCache.getMerkleHash();
     if (merkleHash != pindex->pprev->hashClaimTrie) {
-        if (trieCache.checkConsistency()) {
-            for (auto cit = trieCache.begin(); cit != trieCache.end(); ++cit) {
-                if (cit->claims.size() && cit->nHeightOfLastTakeover <= 0)
-                    LogPrintf("Invalid takeover height discovered in cache for %s\n", cit.key());
-                if (cit->hash.IsNull())
-                    LogPrintf("Invalid hash discovered in cache for %s\n", cit.key());
-            }
+        for (auto cit = trieCache.begin(); cit != trieCache.end(); ++cit) {
+            if (cit->claims.size() && cit->nHeightOfLastTakeover <= 0)
+                LogPrintf("Invalid takeover height discovered in cache for %s\n", cit.key());
+            if (cit->hash.IsNull())
+                LogPrintf("Invalid hash discovered in cache for %s\n", cit.key());
         }
         LogPrintf("Hash comparison failure at block %d\n", pindex->nHeight);
         assert(merkleHash == pindex->pprev->hashClaimTrie);
@@ -2048,7 +2046,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     if (trieCache.getMerkleHash() != block.hashClaimTrie)
     {
-        if (!trieCache.empty() && trieCache.checkConsistency())
+        if (!trieCache.empty()) // we could run checkConsistency here, but it would take a while
             trieCache.dumpToLog(trieCache.begin());
         return state.DoS(100, error("ConnectBlock() : the merkle root of the claim trie does not match "
                                "(actual=%s vs block=%s on height=%d)", trieCache.getMerkleHash().GetHex(),
@@ -2296,13 +2294,13 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
     auto oldBlock = pindexNew->nTime + MAX_FUTURE_BLOCK_TIME < currentTime;
     if (!warningMessages.empty() || !oldBlock || lastBlockPrintTime < currentTime - 15 || LogAcceptCategory(BCLog::CLAIMS)) {
         lastBlockPrintTime = currentTime;
-        LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g txb=%lu tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo) trie nodes=%zu%s",
+        LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g txb=%lu tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s",
                 __func__, pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
                 log(pindexNew->nChainWork.getdouble()) / log(2.0), (unsigned long) pindexNew->nTx,
                 (unsigned long) pindexNew->nChainTx, FormatISO8601DateTime(pindexNew->GetBlockTime()),
                 GuessVerificationProgress(chainParams.TxData(), pindexNew),
                 pcoinsTip->DynamicMemoryUsage() * (1.0 / (1U << 20U)), pcoinsTip->GetCacheSize(),
-                pclaimTrie->height(), oldBlock ? " (synchronizing)" : "");
+                oldBlock ? " (synchronizing)" : "");
         if (!warningMessages.empty())
             LogPrintf(" warning='%s'", warningMessages); /* Continued */
         LogPrintf("\n");

--- a/src/wallet/test/claim_rpc_tests.cpp
+++ b/src/wallet/test/claim_rpc_tests.cpp
@@ -28,11 +28,11 @@ struct CatchWalletTestSetup: public TestingSetup {
         UniValue results = rpc_method(req);
         BOOST_CHECK_EQUAL(results["name"].get_str(), "tester_wallet");
     }
-    ~CatchWalletTestSetup() {
+    ~CatchWalletTestSetup() override {
         rpcfn_type rpc_method = tableRPC["unloadwallet"]->actor;
         JSONRPCRequest req;
+        req.URI = "/wallet/tester_wallet";
         req.params = UniValue(UniValue::VARR);
-        req.params.push_back("tester_wallet");
         rpc_method(req);
     }
 };
@@ -42,6 +42,7 @@ BOOST_FIXTURE_TEST_SUITE(claim_rpc_tests, CatchWalletTestSetup)
 double AvailableBalance() {
     rpcfn_type rpc_method = tableRPC["getbalance"]->actor;
     JSONRPCRequest req;
+    req.URI = "/wallet/tester_wallet";
     req.params = UniValue(UniValue::VARR);
     UniValue results = rpc_method(req);
     return results.get_real();
@@ -51,6 +52,7 @@ uint256 ClaimAName(const std::string& name, const std::string& data, const std::
     // pass a txid as name for update
     rpcfn_type rpc_method = tableRPC[isUpdate ? "updateclaim" : "claimname"]->actor;
     JSONRPCRequest req;
+    req.URI = "/wallet/tester_wallet";
     req.params = UniValue(UniValue::VARR);
     req.params.push_back(name);
     req.params.push_back(data);
@@ -67,6 +69,7 @@ uint256 SupportAName(const std::string& name, const std::string& claimId, const 
     // pass a txid as name for update
     rpcfn_type rpc_method = tableRPC["supportclaim"]->actor;
     JSONRPCRequest req;
+    req.URI = "/wallet/tester_wallet";
     req.params = UniValue(UniValue::VARR);
     req.params.push_back(name);
     req.params.push_back(claimId);
@@ -82,6 +85,7 @@ uint256 SupportAName(const std::string& name, const std::string& claimId, const 
 UniValue LookupAllNames() {
     rpcfn_type rpc_method = tableRPC["listnameclaims"]->actor;
     JSONRPCRequest req;
+    req.URI = "/wallet/tester_wallet";
     req.params = UniValue(UniValue::VARR);
     return rpc_method(req);
 }
@@ -89,6 +93,7 @@ UniValue LookupAllNames() {
 std::vector<uint256> generateBlock(int blocks = 1) {
     rpcfn_type rpc_method = tableRPC["generate"]->actor;
     JSONRPCRequest req;
+    req.URI = "/wallet/tester_wallet";
     req.params = UniValue(UniValue::VARR);
     req.params.push_back(blocks);
     UniValue results = rpc_method(req);
@@ -107,6 +112,7 @@ void rollbackBlock(const std::vector<uint256>& ids) {
     rpcfn_type rpc_method = tableRPC["invalidateblock"]->actor;
     for (auto it = ids.rbegin(); it != ids.rend(); ++it) {
         JSONRPCRequest req;
+        req.URI = "/wallet/tester_wallet";
         req.params = UniValue(UniValue::VARR);
         req.params.push_back(it->GetHex());
         rpc_method(req);
@@ -119,6 +125,7 @@ void rollbackBlock(const std::vector<uint256>& ids) {
 uint256 AbandonAClaim(const uint256& txid, bool isSupport = false) {
     rpcfn_type pre_rpc_method = tableRPC["getrawchangeaddress"]->actor;
     JSONRPCRequest pre_req;
+    pre_req.URI = "/wallet/tester_wallet";
     pre_req.params = UniValue(UniValue::VARR);
     pre_req.params.push_back("legacy");
     UniValue adr_hash = pre_rpc_method(pre_req);
@@ -126,6 +133,7 @@ uint256 AbandonAClaim(const uint256& txid, bool isSupport = false) {
     // pass a txid as name for update
     rpcfn_type rpc_method = tableRPC[isSupport ? "abandonsupport" : "abandonclaim"]->actor;
     JSONRPCRequest req;
+    req.URI = "/wallet/tester_wallet";
     req.params = UniValue(UniValue::VARR);
     req.params.push_back(txid.GetHex());
     req.params.push_back(adr_hash.get_str());


### PR DESCRIPTION
This change separates out the cliams from the nodes and puts each in separate storage in order to reduce disk writes. 