### PR TITLE
initial commit of metadata on supports

### DIFF
--- a/src/claimscriptop.cpp
+++ b/src/claimscriptop.cpp
@@ -149,7 +149,7 @@ bool ProcessClaim(CClaimScriptOp& claimOp, CClaimTrieCache& trieCache, const CSc
 {
     int op;
     std::vector<std::vector<unsigned char> > vvchParams;
-    if (!DecodeClaimScript(scriptPubKey, op, vvchParams))
+    if (!DecodeClaimScript(scriptPubKey, op, vvchParams, trieCache.allowSupportMetadata()))
         return false;
 
     switch (op) {

--- a/src/claimtrie.h
+++ b/src/claimtrie.h
@@ -778,6 +778,8 @@ public:
     void initializeIncrement() override;
     bool finalizeDecrement(std::vector<std::pair<std::string, int>>& takeoverHeightUndo) override;
 
+    bool allowSupportMetadata() const;
+
 protected:
     uint256 recursiveComputeMerkleHash(CClaimPrefixTrie::iterator& it) override;
 

--- a/src/claimtrieforks.cpp
+++ b/src/claimtrieforks.cpp
@@ -499,3 +499,7 @@ bool CClaimTrieCacheHashFork::finalizeDecrement(std::vector<std::pair<std::strin
         copyAllBaseToCache();
     return ret;
 }
+
+bool CClaimTrieCacheHashFork::allowSupportMetadata() const {
+    return nNextHeight >= Params().GetConsensus().nAllClaimsInMerkleForkHeight;
+}

--- a/src/nameclaim.h
+++ b/src/nameclaim.h
@@ -26,10 +26,10 @@
 #define MAX_CLAIM_NAME_SIZE 255
 
 CScript ClaimNameScript(std::string name, std::string value, bool fakeSuffix=true);
-CScript SupportClaimScript(std::string name, uint160 claimId, bool fakeSuffix=true);
+CScript SupportClaimScript(std::string name, uint160 claimId, std::string value="", bool fakeSuffix=true);
 CScript UpdateClaimScript(std::string name, uint160 claimId, std::string value);
-bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams);
-bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams, CScript::const_iterator& pc);
+bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams, bool allowSupportMetadata=true);
+bool DecodeClaimScript(const CScript& scriptIn, int& op, std::vector<std::vector<unsigned char> >& vvchParams, CScript::const_iterator& pc, bool allowSupportMetadata=true);
 CScript StripClaimScriptPrefix(const CScript& scriptIn);
 CScript StripClaimScriptPrefix(const CScript& scriptIn, int& op);
 uint160 ClaimIdHash(const uint256& txhash, uint32_t nOut);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -179,6 +179,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getclaimproofbybid", 1, "bid"},
     { "getclaimproofbyseq", 1, "sequence"},
     { "supportclaim", 4, "isTip"},
+    { "gettotalvalueofclaims", 0, "controlling_only"},
 };
 
 class CRPCConvertTable

--- a/src/test/nameclaim_tests.cpp
+++ b/src/test/nameclaim_tests.cpp
@@ -8,7 +8,6 @@ BOOST_FIXTURE_TEST_SUITE(nameclaim_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(calc_min_claimtrie_fee)
 {
-
     CMutableTransaction tx;
     tx.vout.resize(1);
     tx.vout[0].scriptPubKey = ClaimNameScript("A","test");
@@ -31,7 +30,18 @@ BOOST_AUTO_TEST_CASE(calc_min_claimtrie_fee)
     CMutableTransaction tx4;
     tx4.vout.resize(1);
     BOOST_CHECK_EQUAL(CalcMinClaimTrieFee(tx4,MIN_FEE_PER_NAMECLAIM_CHAR), 0);
+}
 
+BOOST_AUTO_TEST_CASE(support_handles_value)
+{
+    auto script = SupportClaimScript("s1", uint160(), "me value");
+    int op = 0;
+    std::vector<std::vector<unsigned char>> params;
+    BOOST_CHECK(!DecodeClaimScript(script, op, params, false));
+    params.clear();
+    BOOST_CHECK(DecodeClaimScript(script, op, params));
+    BOOST_CHECK(params[0][0] == 's');
+    BOOST_CHECK(std::string(params[2].begin(), params[2].end()) == "me value");
 }
 
 BOOST_AUTO_TEST_CASE(scriptToAsmStr_output)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -935,7 +935,7 @@ UniValue supportclaim(const JSONRPCRequest& request)
         if (!hex.empty()) {
             if (!IsHex(hex))
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "value/metadata must be of hexadecimal data");
-            if (!IsWitnessEnabled(chainActive.Tip(), Params().GetConsensus()))
+            if (!trieCache.allowSupportMetadata())
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "value/metadata on supports is not enabled yet");
             supportScript = supportScript << ParseHex(hex);
             lastOp = OP_2DROP;


### PR DESCRIPTION
The nonstandard transactions themselves should be okay in the current code; we just don't want a different hash or trie computation until the fork height.

Fixes #272 