### PR TITLE
reverted base-trie-on-disk

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1465,7 +1465,7 @@ bool AppInitMain()
                 int64_t trieCacheMB = gArgs.GetArg("-claimtriecache", nDefaultDbCache);
                 trieCacheMB = std::min(trieCacheMB, nMaxDbCache);
                 trieCacheMB = std::max(trieCacheMB, nMinDbCache);
-                pclaimTrie = new CClaimTrieHashFork(false, fReindex || fReindexChainState, 32, trieCacheMB);
+                pclaimTrie = new CClaimTrie(false, fReindex || fReindexChainState, 32, trieCacheMB);
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);

--- a/src/prefixtrie.cpp
+++ b/src/prefixtrie.cpp
@@ -319,7 +319,7 @@ typename CPrefixTrie<TKey, TData>::iterator CPrefixTrie<TKey, TData>::copy(CPref
     auto& key = it.key();
     auto& node = key.empty() ? root : insert(key, root);
     node->data = it.node.lock()->data;
-    return key.empty() ? begin() : iterator{key, node};
+    return iterator{key, node};
 }
 
 template <typename TKey, typename TData>

--- a/src/test/claimtriebranching_tests.cpp
+++ b/src/test/claimtriebranching_tests.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(claim_replace_test) {
     fixture.Spend(tx1);
     CMutableTransaction tx2 = fixture.MakeClaim(fixture.GetCoinbase(), "bassfisher", "one", 1);
     fixture.IncrementBlocks(1);
-    BOOST_CHECK(pclaimTrie->checkConsistency(fixture.getMerkleHash()));
+    BOOST_CHECK(fixture.checkConsistency(fixture.getMerkleHash()));
     BOOST_CHECK(!fixture.is_best_claim("bass", tx1));
     BOOST_CHECK(fixture.is_best_claim("bassfisher", tx2));
 }
@@ -1852,17 +1852,18 @@ BOOST_AUTO_TEST_CASE(update_on_support2_test)
     CMutableTransaction s2 = fixture.MakeSupport(fixture.GetCoinbase(), tx1, name, 1);
     fixture.IncrementBlocks(1);
 
-    CClaimTrieData node;
-    BOOST_CHECK(pclaimTrie->find(name, node));
-    BOOST_CHECK_EQUAL(node.nHeightOfLastTakeover, height + 1);
+    auto bit = pclaimTrie->find(name);
+    BOOST_CHECK(bit);
+    BOOST_CHECK_EQUAL(bit->nHeightOfLastTakeover, height + 1);
 
     fixture.Spend(s1);
     fixture.Spend(s2);
     CMutableTransaction u1 = fixture.MakeUpdate(tx1, name, value, ClaimIdHash(tx1.GetHash(), 0), 3);
     fixture.IncrementBlocks(1);
 
-    BOOST_CHECK(pclaimTrie->find(name, node));
-    BOOST_CHECK_EQUAL(node.nHeightOfLastTakeover, height + 1);
+    bit = pclaimTrie->find(name);
+    BOOST_CHECK(bit);
+    BOOST_CHECK_EQUAL(bit->nHeightOfLastTakeover, height + 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/claimtriecache_tests.cpp
+++ b/src/test/claimtriecache_tests.cpp
@@ -37,9 +37,13 @@ public:
         return nodesToAddOrUpdate.height();
     }
 
-    CClaimPrefixTrie::iterator getCache(const std::string& key)
+    CClaimTrie::iterator getCache(const std::string& key)
     {
         return nodesToAddOrUpdate.find(key);
+    }
+
+    bool checkConsistency(const uint256& hash) {
+        return CClaimTrieCacheBase::checkConsistency(hash);
     }
 };
 
@@ -108,7 +112,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
 
     BOOST_CHECK(!pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState.getMerkleHash(), hash2);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash2));
+    BOOST_CHECK(ntState.checkConsistency(hash2));
 
     CClaimTrieCacheTest ntState1(pclaimTrie);
     ntState1.removeClaimFromTrie(std::string("test"), tx1OutPoint, unused, true);
@@ -128,7 +132,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
 
     BOOST_CHECK(!pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState2.getMerkleHash(), hash3);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash3));
+    BOOST_CHECK(ntState2.checkConsistency(hash3));
 
     CClaimTrieCacheTest ntState3(pclaimTrie);
     ntState3.insertClaimIntoTrie(std::string("test"), CClaimValue(tx1OutPoint, hash160, 50, 100, 200), true);
@@ -136,7 +140,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
     ntState3.flush();
     BOOST_CHECK(!pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState3.getMerkleHash(), hash4);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash4));
+    BOOST_CHECK(ntState3.checkConsistency(hash4));
 
     CClaimTrieCacheTest ntState4(pclaimTrie);
     ntState4.removeClaimFromTrie(std::string("abab"), tx6OutPoint, unused, true);
@@ -144,7 +148,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
     ntState4.flush();
     BOOST_CHECK(!pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState4.getMerkleHash(), hash2);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash2));
+    BOOST_CHECK(ntState4.checkConsistency(hash2));
 
     CClaimTrieCacheTest ntState5(pclaimTrie);
     ntState5.removeClaimFromTrie(std::string("test"), tx3OutPoint, unused, true);
@@ -153,7 +157,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
     ntState5.flush();
     BOOST_CHECK(!pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState5.getMerkleHash(), hash2);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash2));
+    BOOST_CHECK(ntState5.checkConsistency(hash2));
 
     CClaimTrieCacheTest ntState6(pclaimTrie);
     ntState6.insertClaimIntoTrie(std::string("test"), CClaimValue(tx3OutPoint, hash160, 50, 101, 201), true);
@@ -162,7 +166,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
     ntState6.flush();
     BOOST_CHECK(!pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState6.getMerkleHash(), hash2);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash2));
+    BOOST_CHECK(ntState6.checkConsistency(hash2));
 
     CClaimTrieCacheTest ntState7(pclaimTrie);
     ntState7.removeClaimFromTrie(std::string("test"), tx3OutPoint, unused, true);
@@ -174,7 +178,7 @@ BOOST_AUTO_TEST_CASE(merkle_hash_multiple_test)
     ntState7.flush();
     BOOST_CHECK(pclaimTrie->empty());
     BOOST_CHECK_EQUAL(ntState7.getMerkleHash(), hash0);
-    BOOST_CHECK(pclaimTrie->checkConsistency(hash0));
+    BOOST_CHECK(ntState7.checkConsistency(hash0));
 }
 
 BOOST_AUTO_TEST_CASE(basic_insertion_info_test)
@@ -281,14 +285,12 @@ BOOST_AUTO_TEST_CASE(iteratetrie_test)
     ctc.insertClaimIntoTrie("test", claimVal, true);
     BOOST_CHECK(ctc.flush());
 
-    CClaimTrieDataNode node;
-    BOOST_CHECK(pclaimTrie->find("", node));
-    BOOST_CHECK_EQUAL(node.children.size(), 1U);
-    BOOST_CHECK(pclaimTrie->find("test", node));
-    BOOST_CHECK_EQUAL(node.children.size(), 0U);
-    CClaimTrieData data;
-    BOOST_CHECK(pclaimTrie->find("test", data));
-    BOOST_CHECK_EQUAL(data.claims.size(), 1);
+    auto hit = pclaimTrie->find("");
+    BOOST_CHECK(hit);
+    BOOST_CHECK_EQUAL(hit.children().size(), 1U);
+    BOOST_CHECK(hit = pclaimTrie->find("test"));
+    BOOST_CHECK_EQUAL(hit.children().size(), 0U);
+    BOOST_CHECK_EQUAL(hit.data().claims.size(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(trie_stays_consistent_test)
@@ -305,13 +307,13 @@ BOOST_AUTO_TEST_CASE(trie_stays_consistent_test)
         BOOST_CHECK(cache.insertClaimIntoTrie(name, value, false));
 
     cache.flush();
-    BOOST_CHECK(trie.checkConsistency(cache.getMerkleHash()));
+    BOOST_CHECK(cache.checkConsistency(cache.getMerkleHash()));
 
     for (auto& name: names) {
         CClaimValue temp;
         BOOST_CHECK(cache.removeClaimFromTrie(name, COutPoint(), temp, false));
         cache.flush();
-        BOOST_CHECK(trie.checkConsistency(cache.getMerkleHash()));
+        BOOST_CHECK(cache.checkConsistency(cache.getMerkleHash()));
     }
     BOOST_CHECK(trie.empty());
 }
@@ -384,7 +386,7 @@ BOOST_AUTO_TEST_CASE(verify_basic_serialization)
     ssData >> cv2;
 
     BOOST_CHECK_EQUAL(cv, cv2);
-    BOOST_CHECK_EQUAL(cv.nEffectiveAmount, cv2.nEffectiveAmount);
+    // BOOST_CHECK_EQUAL(cv.nEffectiveAmount, cv2.nEffectiveAmount); // TODO: bring this back
 }
 
 BOOST_AUTO_TEST_CASE(claimtrienode_serialize_unserialize)

--- a/src/test/claimtrienormalization_tests.cpp
+++ b/src/test/claimtrienormalization_tests.cpp
@@ -93,8 +93,7 @@ BOOST_AUTO_TEST_CASE(claimtriebranching_normalization)
     BOOST_CHECK(fixture.is_best_claim("normalizetest", tx1));
     BOOST_CHECK(fixture.best_claim_effective_amount_equals("normalizetest", 3));
 
-    CClaimTrieData data;
-    BOOST_CHECK(!pclaimTrie->find("normalizeTest", data));
+    BOOST_CHECK(!pclaimTrie->find("normalizeTest"));
 
     // Check equivalence of normalized claim names
     BOOST_CHECK(fixture.is_best_claim("normalizetest", tx1)); // collapsed tx2
@@ -223,8 +222,7 @@ BOOST_AUTO_TEST_CASE(claimtriecache_normalization)
     BOOST_CHECK(!trieCache.spendClaim(name_normd, COutPoint(tx2.GetHash(), 0), currentHeight, amelieValidHeight));
     BOOST_CHECK(trieCache.spendClaim(name_upper, COutPoint(tx2.GetHash(), 0), currentHeight, amelieValidHeight));
 
-    CClaimTrieData data;
-    BOOST_CHECK(!pclaimTrie->find(name, data));
+    BOOST_CHECK(!pclaimTrie->find(name));
     BOOST_CHECK(trieCache.getInfoForName(name, nval1));
     BOOST_CHECK(trieCache.addClaim(name, COutPoint(tx1.GetHash(), 0), ClaimIdHash(tx1.GetHash(), 0), CAmount(2), currentHeight + 1));
     BOOST_CHECK(trieCache.getInfoForName(name, nval1));
@@ -236,8 +234,10 @@ BOOST_AUTO_TEST_CASE(claimtriecache_normalization)
     BOOST_CHECK(trieCache.incrementBlock(insertUndo, expireUndo, insertSupportUndo, expireSupportUndo, takeoverHeightUndo));
     BOOST_CHECK(trieCache.shouldNormalize());
 
-    CClaimTrieDataNode node;
-    BOOST_CHECK(!pclaimTrie->find(name, node));
+    // we cannot use getXXXForName cause they will normalized name
+    for (auto it = pclaimTrie->begin(); it != pclaimTrie->end(); ++it) {
+        BOOST_CHECK(it.key() != name);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(undo_normalization_does_not_kill_claim_order)

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -144,7 +144,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         pblocktree.reset(new CBlockTreeDB(1 << 20, true));
         pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
         pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
-        pclaimTrie = new CClaimTrieHashFork(true, false, 1);
+        pclaimTrie = new CClaimTrie(true, false, 1);
         if (!LoadGenesisBlock(chainparams)) {
             throw std::runtime_error("LoadGenesisBlock failed.");
         }


### PR DESCRIPTION
It wasn't substantially better so I yanked it. It was theoretically better, but it didn't look better by the numbers. It's going to take a substantial number of claims to make the capped leveldb approach better, and before that happens we'll have done the sqlite backing.