### PR TITLE
Implement basic log rotation (closes #211)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -486,7 +486,6 @@ void SetupServerArgs()
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)), false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-printpriority", strprintf("Log transaction fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY), true, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set -nodebuglogfile)", false, OptionsCategory::DEBUG_TEST);
-    gArgs.AddArg("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)", false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-uacomment=<cmt>", "Append comment to the user agent string", false, OptionsCategory::DEBUG_TEST);
 
     SetupChainParamsBaseOptions();
@@ -1236,11 +1235,6 @@ bool AppInitMain()
     CreatePidFile(GetPidFile(), getpid());
 #endif
     if (g_logger->m_print_to_file) {
-        if (gArgs.GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile())) {
-            // Do this first since it both loads a bunch of debug.log into memory,
-            // and because this needs to happen before any other debug.log printing
-            g_logger->ShrinkDebugFile();
-        }
         if (!g_logger->OpenDebugLog()) {
             return InitError(strprintf("Could not open debug log file %s",
                                        g_logger->m_file_path.string()));

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -37,6 +37,12 @@ bool BCLog::Logger::OpenDebugLog()
     assert(m_fileout == nullptr);
     assert(!m_file_path.empty());
 
+    if (fs::exists(m_file_path)) {
+        fs::path old_file_path(m_file_path);
+        old_file_path.append(".old");
+        fs::rename(m_file_path, old_file_path);
+    }
+
     m_fileout = fsbridge::fopen(m_file_path, "a");
     if (!m_fileout) {
         return false;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -83,11 +83,6 @@ bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
     return (m_categories.load(std::memory_order_relaxed) & category) != 0;
 }
 
-bool BCLog::Logger::DefaultShrinkDebugFile() const
-{
-    return m_categories == BCLog::NONE;
-}
-
 struct CLogCategoryDesc
 {
     BCLog::LogFlags flag;
@@ -230,45 +225,4 @@ void BCLog::Logger::LogPrintStr(const std::string &str)
             FileWriteStr(strTimestamped, m_fileout);
         }
     }
-}
-
-void BCLog::Logger::ShrinkDebugFile()
-{
-    // Amount of debug.log to save at end when shrinking (must fit in memory)
-    constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 10 * 1000000;
-
-    assert(!m_file_path.empty());
-
-    // Scroll debug.log if it's getting too big
-    FILE* file = fsbridge::fopen(m_file_path, "r");
-
-    // Special files (e.g. device nodes) may not have a size.
-    size_t log_size = 0;
-    try {
-        log_size = fs::file_size(m_file_path);
-    } catch (boost::filesystem::filesystem_error &) {}
-
-    // If debug.log file is more than 10% bigger the RECENT_DEBUG_HISTORY_SIZE
-    // trim it down by saving only the last RECENT_DEBUG_HISTORY_SIZE bytes
-    if (file && log_size > 11 * (RECENT_DEBUG_HISTORY_SIZE / 10))
-    {
-        // Restart the file with some of the end
-        std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
-        if (fseek(file, -((long)vch.size()), SEEK_END)) {
-            LogPrintf("Failed to shrink debug log file: fseek(...) failed\n");
-            fclose(file);
-            return;
-        }
-        int nBytes = fread(vch.data(), 1, vch.size(), file);
-        fclose(file);
-
-        file = fsbridge::fopen(m_file_path, "w");
-        if (file)
-        {
-            fwrite(vch.data(), 1, nBytes, file);
-            fclose(file);
-        }
-    }
-    else if (file != nullptr)
-        fclose(file);
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -93,7 +93,6 @@ namespace BCLog {
         bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
         bool OpenDebugLog();
-        void ShrinkDebugFile();
 
         uint32_t GetCategoryMask() const { return m_categories.load(); }
 
@@ -103,8 +102,6 @@ namespace BCLog {
         bool DisableCategory(const std::string& str);
 
         bool WillLogCategory(LogFlags category) const;
-
-        bool DefaultShrinkDebugFile() const;
     };
 
 } // namespace BCLog


### PR DESCRIPTION
As discussed in #211, this PR introduces the automatic moving of and existing log file to an `.old` file. This means logs are preserved for the last 2 executions, and also implies the -shrinkdebugfile is no longer useful, and thus removed.

Please tell me if there are any improvements to be made.