### PR TITLE
Fix 'Use $(...) notation instead of legacy backticked `...`.' issue

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,7 +7,7 @@ export LC_ALL=C
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"
-if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
+if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="$(which glibtoolize 2>/dev/null)"; then
   LIBTOOLIZE="${GLIBTOOLIZE}"
   export LIBTOOLIZE
 fi

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -36,13 +36,13 @@ if [ -z "${CODESIGN_ALLOCATE}" ]; then
 fi
 
 find ${TEMPDIR} -name "*.sign" | while read i; do
-  SIZE=`stat -c %s "${i}"`
-  TARGET_FILE="`echo "${i}" | sed 's/\.sign$//'`"
+  SIZE=$(stat -c %s "${i}")
+  TARGET_FILE="$(echo "${i}" | sed 's/\.sign$//')"
 
   echo "Allocating space for the signature of size ${SIZE} in ${TARGET_FILE}"
   ${CODESIGN_ALLOCATE} -i "${TARGET_FILE}" -a ${ARCH} ${SIZE} -o "${i}.tmp"
 
-  OFFSET=`${PAGESTUFF} "${i}.tmp" -p | tail -2 | grep offset | sed 's/[^0-9]*//g'`
+  OFFSET=$(${PAGESTUFF} "${i}.tmp" -p | tail -2 | grep offset | sed 's/[^0-9]*//g')
   if [ -z ${QUIET} ]; then
     echo "Attaching signature at offset ${OFFSET}"
   fi

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -27,19 +27,19 @@ ${CODESIGN} -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
 
 grep -v CodeResources < "${TEMPLIST}" | while read i; do
   TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"
-  SIZE=`pagestuff "$i" -p | tail -2 | grep size | sed 's/[^0-9]*//g'`
-  OFFSET=`pagestuff "$i" -p | tail -2 | grep offset | sed 's/[^0-9]*//g'`
+  SIZE=$(pagestuff "$i" -p | tail -2 | grep size | sed 's/[^0-9]*//g')
+  OFFSET=$(pagestuff "$i" -p | tail -2 | grep offset | sed 's/[^0-9]*//g')
   SIGNFILE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}.sign"
-  DIRNAME="`dirname "${SIGNFILE}"`"
+  DIRNAME="$(dirname "${SIGNFILE}")"
   mkdir -p "${DIRNAME}"
   echo "Adding detached signature for: ${TARGETFILE}. Size: ${SIZE}. Offset: ${OFFSET}"
   dd if="$i" of="${SIGNFILE}" bs=1 skip=${OFFSET} count=${SIZE} 2>/dev/null
 done
 
 grep CodeResources < "${TEMPLIST}" | while read i; do
-  TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"
+  TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"
   RESOURCE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}"
-  DIRNAME="`dirname "${RESOURCE}"`"
+  DIRNAME="$(dirname "${RESOURCE}")"
   mkdir -p "${DIRNAME}"
   echo "Adding resource for: \"${TARGETFILE}\""
   cp "${i}" "${RESOURCE}"

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -23,7 +23,7 @@ TIMESERVER=http://timestamp.comodoca.com
 CERTFILE="win-codesign.cert"
 
 mkdir -p "${OUTSUBDIR}"
-basename -a `ls -1 "${SRCDIR}"/*-unsigned.exe` | while read UNSIGNED; do
+basename -a $(ls -1 "${SRCDIR}"/*-unsigned.exe) | while read UNSIGNED; do
   echo Signing "${UNSIGNED}"
   "${OSSLSIGNCODE}" sign -certs "${CERTFILE}" -t "${TIMESERVER}" -in "${SRCDIR}/${UNSIGNED}" -out "${WORKDIR}/${UNSIGNED}" "$@"
   "${OSSLSIGNCODE}" extract-signature -pem -in "${WORKDIR}/${UNSIGNED}" -out "${OUTSUBDIR}/${UNSIGNED}.pem" && rm "${WORKDIR}/${UNSIGNED}"

--- a/packaging/build_darwin_64bit.sh
+++ b/packaging/build_darwin_64bit.sh
@@ -30,13 +30,13 @@ if which ccache >/dev/null; then
 fi
 
 pushd depends
-make -j`getconf _NPROCESSORS_ONLN` HOST=x86_64-apple-darwin14 NO_QT=1 V=1
+make -j$(getconf _NPROCESSORS_ONLN) HOST=x86_64-apple-darwin14 NO_QT=1 V=1
 popd
 
 ./autogen.sh
-DEPS_DIR=`pwd`/depends/x86_64-apple-darwin14
+DEPS_DIR=$(pwd)/depends/x86_64-apple-darwin14
 CONFIG_SITE=${DEPS_DIR}/share/config.site ./configure --enable-reduce-exports --without-gui --with-icu="${DEPS_DIR}" --enable-static --disable-shared
-make -j`getconf _NPROCESSORS_ONLN`
+make -j$(getconf _NPROCESSORS_ONLN)
 ${DEPS_DIR}/native/bin/x86_64-apple-darwin14-strip src/lbrycrdd src/lbrycrd-cli src/lbrycrd-tx
 
 if which ccache >/dev/null; then

--- a/packaging/build_linux_64bit.sh
+++ b/packaging/build_linux_64bit.sh
@@ -20,13 +20,13 @@ export CXXFLAGS="${CXXFLAGS:--frecord-gcc-switches}"
 echo "CXXFLAGS set to $CXXFLAGS"
 
 cd depends
-make -j`getconf _NPROCESSORS_ONLN` HOST=x86_64-pc-linux-gnu NO_QT=1 V=1
+make -j$(getconf _NPROCESSORS_ONLN) HOST=x86_64-pc-linux-gnu NO_QT=1 V=1
 cd ..
 
 ./autogen.sh
-DEPS_DIR=`pwd`/depends/x86_64-pc-linux-gnu
+DEPS_DIR=$(pwd)/depends/x86_64-pc-linux-gnu
 CONFIG_SITE=${DEPS_DIR}/share/config.site ./configure --enable-static --disable-shared --with-pic --without-gui
-make -j`getconf _NPROCESSORS_ONLN`
+make -j$(getconf _NPROCESSORS_ONLN)
 strip src/lbrycrdd src/lbrycrd-cli src/lbrycrd-tx
 
 if which ccache >/dev/null; then

--- a/packaging/build_windows_32bit.sh
+++ b/packaging/build_windows_32bit.sh
@@ -21,13 +21,13 @@ if which ccache >/dev/null; then
 fi
 
 pushd depends
-make -j`getconf _NPROCESSORS_ONLN` HOST=i686-w64-mingw32 NO_QT=1 V=1
+make -j$(getconf _NPROCESSORS_ONLN) HOST=i686-w64-mingw32 NO_QT=1 V=1
 popd
 
 ./autogen.sh
-DEPS_DIR=`pwd`/depends/i686-w64-mingw32
+DEPS_DIR=$(pwd)/depends/i686-w64-mingw32
 CONFIG_SITE=${DEPS_DIR}/share/config.site ./configure --prefix=/ --without-gui --with-icu="$DEPS_DIR" --enable-static --disable-shared
-make -j`getconf _NPROCESSORS_ONLN`
+make -j$(getconf _NPROCESSORS_ONLN)
 i686-w64-mingw32-strip src/lbrycrdd.exe src/lbrycrd-cli.exe src/lbrycrd-tx.exe
 
 if which ccache >/dev/null; then

--- a/packaging/build_windows_64bit.sh
+++ b/packaging/build_windows_64bit.sh
@@ -20,13 +20,13 @@ if which ccache >/dev/null; then
 fi
 
 pushd depends
-make -j`getconf _NPROCESSORS_ONLN` HOST=x86_64-w64-mingw32 NO_QT=1 V=1
+make -j$(getconf _NPROCESSORS_ONLN) HOST=x86_64-w64-mingw32 NO_QT=1 V=1
 popd
 
 ./autogen.sh
-DEPS_DIR=`pwd`/depends/x86_64-w64-mingw32
+DEPS_DIR=$(pwd)/depends/x86_64-w64-mingw32
 CONFIG_SITE=${DEPS_DIR}/share/config.site ./configure --prefix=/ --without-gui --with-icu="$DEPS_DIR" --enable-static --disable-shared
-make -j`getconf _NPROCESSORS_ONLN`
+make -j$(getconf _NPROCESSORS_ONLN)
 x86_64-w64-mingw32-strip src/lbrycrdd.exe src/lbrycrd-cli.exe src/lbrycrd-tx.exe
 
 if which ccache >/dev/null; then

--- a/src/univalue/autogen.sh
+++ b/src/univalue/autogen.sh
@@ -2,7 +2,7 @@
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"
-if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
+if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="$(which glibtoolize 2>/dev/null)"; then
   LIBTOOLIZE="${GLIBTOOLIZE}"
   export LIBTOOLIZE
 fi

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -18,12 +18,12 @@ if test "x$1" = "x"; then
 fi
 
 RET=0
-PREV_BRANCH=`git name-rev --name-only HEAD`
-PREV_HEAD=`git rev-parse HEAD`
-for i in `git rev-list --reverse $1`; do
+PREV_BRANCH=$(git name-rev --name-only HEAD)
+PREV_HEAD=$(git rev-parse HEAD)
+for i in $(git rev-list --reverse $1); do
     if git rev-list -n 1 --pretty="%s" $i | grep -q "^scripted-diff:"; then
         git checkout --quiet $i^ || exit
-        SCRIPT="`git rev-list --format=%b -n1 $i | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
+        SCRIPT="$(git rev-list --format=%b -n1 $i | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
         if test "x$SCRIPT" = "x"; then
             echo "Error: missing script for: $i"
             echo "Failed"


### PR DESCRIPTION
Hello,

Backticks are discouraged for any new scripts, since they complicate nesting, quoting, and escaping, besides being graphically less explicit. 

Thanks.

Ref:
http://mywiki.wooledge.org/BashFAQ/082. 
https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_06_03