### PR TITLE
Changing download path artifactory URL for Boost

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_69_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.69.0/source/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 $(package)_dependencies=icu


### PR DESCRIPTION
This change is to resolve the issue with building the source both with Docker and directly on specific platforms such as Mac OS, Windows and Linux distributions. Currently it's not possible to build it with the current URL. 

Issue: [https://github.com/lbryio/lbrycrd/issues/407](https://github.com/lbryio/lbrycrd/issues/407)